### PR TITLE
feat(#51): set up GitHub Actions CI (lint + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run linters
+        run: make lint
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run unit tests
+        run: make test-unit

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > A sandboxed AI coding agent runtime that autonomously modifies codebases through LLM-driven reasoning and isolated tool execution.
 
+[![CI](https://github.com/akoita/agent-forge/actions/workflows/ci.yml/badge.svg)](https://github.com/akoita/agent-forge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
@@ -144,15 +145,15 @@ agent_forge/
 
 ## Roadmap
 
-| Phase | Focus | Status |
-|-------|-------|--------|
-| **1** | Core Agent MVP — ReAct loop + Docker sandbox + CLI | 🚧 In Progress |
-| **2** | Production Hardening — Observability, multi-provider, Redis queue | ⬜ Planned |
-| **3** | Git-Aware Agent & Plugin System | ⬜ Planned |
-| **4** | Web Dashboard & REST API | ⬜ Planned |
-| **5** | Multi-Agent Collaboration | ⬜ Planned |
-| **6** | Advanced Isolation & Scaling (microVMs, K8s) | ⬜ Planned |
-| **7** | Platform & Ecosystem (MCP, marketplace, IDE plugins) | ⬜ Planned |
+| Phase | Focus                                                             | Status         |
+| ----- | ----------------------------------------------------------------- | -------------- |
+| **1** | Core Agent MVP — ReAct loop + Docker sandbox + CLI                | 🚧 In Progress |
+| **2** | Production Hardening — Observability, multi-provider, Redis queue | ⬜ Planned     |
+| **3** | Git-Aware Agent & Plugin System                                   | ⬜ Planned     |
+| **4** | Web Dashboard & REST API                                          | ⬜ Planned     |
+| **5** | Multi-Agent Collaboration                                         | ⬜ Planned     |
+| **6** | Advanced Isolation & Scaling (microVMs, K8s)                      | ⬜ Planned     |
+| **7** | Platform & Ecosystem (MCP, marketplace, IDE plugins)              | ⬜ Planned     |
 
 See [spec.md § Roadmap](spec.md#12-roadmap) for detailed milestones.
 


### PR DESCRIPTION
## Summary

Set up GitHub Actions CI pipeline for automated lint and test on every push/PR.

### Changes

- **`.github/workflows/ci.yml`** — CI workflow with:
  - **Lint job**: ruff check + mypy (Python 3.13)
  - **Test job**: pytest unit tests across Python 3.11, 3.12, 3.13 matrix
  - Triggers on push to `main` and PRs targeting `main`
- **`README.md`** — CI status badge added to header

Closes #51