### PR TITLE
feat(#3): LLM client base classes + Gemini adapter with streaming

### DIFF
--- a/agent_forge/llm/__init__.py
+++ b/agent_forge/llm/__init__.py
@@ -1,1 +1,43 @@
-"""LLM provider adapters for Agent Forge."""
+"""LLM client layer — provider adapters and data models."""
+
+from agent_forge.llm.base import (
+    LLMConfig,
+    LLMProvider,
+    LLMResponse,
+    Message,
+    Role,
+    TokenUsage,
+    ToolCall,
+    ToolDefinition,
+)
+from agent_forge.llm.errors import (
+    AgentForgeError,
+    LLMAuthError,
+    LLMContextOverflowError,
+    LLMError,
+    LLMRateLimitError,
+    LLMResponseError,
+    LLMTimeoutError,
+)
+from agent_forge.llm.factory import create_provider
+from agent_forge.llm.gemini import GeminiProvider
+
+__all__ = [
+    "AgentForgeError",
+    "GeminiProvider",
+    "LLMAuthError",
+    "LLMConfig",
+    "LLMContextOverflowError",
+    "LLMError",
+    "LLMProvider",
+    "LLMRateLimitError",
+    "LLMResponse",
+    "LLMResponseError",
+    "LLMTimeoutError",
+    "Message",
+    "Role",
+    "TokenUsage",
+    "ToolCall",
+    "ToolDefinition",
+    "create_provider",
+]

--- a/agent_forge/llm/base.py
+++ b/agent_forge/llm/base.py
@@ -1,1 +1,109 @@
-"""LLM provider base classes and data models."""
+"""LLM provider base classes and data models.
+
+Defines the unified interface for interacting with multiple LLM providers
+(Gemini, OpenAI, Anthropic) via a common adapter pattern.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class Role(Enum):
+    """Message role in a conversation."""
+
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+    TOOL = "tool"
+
+
+@dataclass
+class ToolCall:
+    """A tool invocation requested by the LLM."""
+
+    id: str
+    name: str
+    arguments: dict[str, object]
+
+
+@dataclass
+class ToolDefinition:
+    """Schema describing a tool available to the LLM."""
+
+    name: str
+    description: str
+    parameters: dict[str, object]  # JSON Schema object
+
+
+@dataclass
+class TokenUsage:
+    """Token consumption for a single LLM request."""
+
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+@dataclass
+class Message:
+    """A single message in the conversation history."""
+
+    role: Role
+    content: str
+    tool_call_id: str | None = None
+    tool_calls: list[ToolCall] | None = None
+
+
+@dataclass
+class LLMResponse:
+    """Response from an LLM completion or streaming chunk."""
+
+    content: str | None
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    usage: TokenUsage = field(default_factory=lambda: TokenUsage(0, 0, 0))
+    model: str = ""
+    finish_reason: str = ""  # "stop", "tool_calls", "length", "error"
+
+
+@dataclass
+class LLMConfig:
+    """Configuration for a single LLM request."""
+
+    model: str = "gemini-2.0-flash"
+    temperature: float = 0.0
+    max_tokens: int = 4096
+    top_p: float = 1.0
+    timeout_seconds: int = 120
+
+
+class LLMProvider(ABC):
+    """Abstract base class for all LLM provider adapters."""
+
+    @abstractmethod
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: LLMConfig | None = None,
+    ) -> LLMResponse:
+        """Send a completion request and return the full response."""
+        ...
+
+    @abstractmethod
+    async def stream(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: LLMConfig | None = None,
+    ) -> AsyncIterator[LLMResponse]:
+        """Stream partial responses as they arrive."""
+        ...
+        # Make this an async generator for type checkers
+        yield  # type: ignore[misc]  # pragma: no cover

--- a/agent_forge/llm/errors.py
+++ b/agent_forge/llm/errors.py
@@ -1,0 +1,34 @@
+"""LLM-specific exception hierarchy.
+
+Follows the error taxonomy from spec.md § 7.1.
+"""
+
+from __future__ import annotations
+
+
+class AgentForgeError(Exception):
+    """Base exception for all Agent Forge errors."""
+
+
+class LLMError(AgentForgeError):
+    """Errors from LLM provider interactions."""
+
+
+class LLMRateLimitError(LLMError):
+    """Rate limit exceeded — should trigger retry with backoff."""
+
+
+class LLMAuthError(LLMError):
+    """Invalid API key or unauthorized — fail immediately."""
+
+
+class LLMContextOverflowError(LLMError):
+    """Prompt exceeds model context window."""
+
+
+class LLMTimeoutError(LLMError):
+    """LLM request timed out."""
+
+
+class LLMResponseError(LLMError):
+    """Malformed or unparseable response from the LLM."""

--- a/agent_forge/llm/factory.py
+++ b/agent_forge/llm/factory.py
@@ -1,1 +1,42 @@
 """LLM provider factory for instantiating adapters by name."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from agent_forge.llm.gemini import GeminiProvider
+
+if TYPE_CHECKING:
+    from agent_forge.llm.base import LLMProvider
+
+_PROVIDERS: dict[str, type[GeminiProvider]] = {
+    "gemini": GeminiProvider,
+}
+
+
+def create_provider(
+    name: str,
+    api_key: str,
+    **kwargs: object,
+) -> LLMProvider:
+    """Create an LLM provider instance by name.
+
+    Args:
+        name: Provider name (e.g. ``"gemini"``).
+        api_key: API key for the provider.
+        **kwargs: Additional keyword arguments forwarded to the provider
+            constructor (e.g. ``base_url``).
+
+    Returns:
+        An initialized ``LLMProvider`` instance.
+
+    Raises:
+        ValueError: If the provider name is not registered.
+    """
+    provider_cls = _PROVIDERS.get(name)
+    if provider_cls is None:
+        available = ", ".join(sorted(_PROVIDERS))
+        msg = f"Unknown LLM provider '{name}'. Available: {available}"
+        raise ValueError(msg)
+
+    return provider_cls(api_key=api_key, **kwargs)  # type: ignore[arg-type]

--- a/agent_forge/llm/gemini.py
+++ b/agent_forge/llm/gemini.py
@@ -1,1 +1,360 @@
-"""Gemini LLM provider adapter."""
+"""Gemini LLM provider adapter.
+
+Uses the Gemini REST API via httpx. Handles tool mapping, streaming,
+and retry logic per spec § 4.1 and § 7.2.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from agent_forge.llm.base import ToolDefinition
+
+import httpx
+
+from agent_forge.llm.base import (
+    LLMConfig,
+    LLMProvider,
+    LLMResponse,
+    Message,
+    Role,
+    TokenUsage,
+    ToolCall,
+)
+from agent_forge.llm.errors import (
+    LLMAuthError,
+    LLMRateLimitError,
+    LLMResponseError,
+    LLMTimeoutError,
+)
+
+logger = logging.getLogger(__name__)
+
+_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com"
+_DEFAULT_MODEL = "gemini-2.0-flash"
+
+# Retry config per spec § 7.2
+_MAX_RETRIES = 3
+_BACKOFF_BASE = 1.0  # seconds
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503}
+
+
+class GeminiProvider(LLMProvider):
+    """Gemini adapter using the REST API with httpx."""
+
+    def __init__(self, api_key: str, *, base_url: str | None = None) -> None:
+        self._api_key = api_key
+        self._base_url = base_url or _GEMINI_BASE_URL
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=httpx.Timeout(120.0),
+        )
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: LLMConfig | None = None,
+    ) -> LLMResponse:
+        """Send a completion request and return the full response."""
+        cfg = config or LLMConfig(model=_DEFAULT_MODEL)
+        body = self._build_request_body(messages, tools, cfg)
+        url = f"/v1beta/models/{cfg.model}:generateContent"
+
+        data = await self._post_with_retry(url, body, cfg)
+        return self._parse_response(data, cfg.model)
+
+    async def stream(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: LLMConfig | None = None,
+    ) -> AsyncIterator[LLMResponse]:
+        """Stream partial responses as they arrive via SSE."""
+        cfg = config or LLMConfig(model=_DEFAULT_MODEL)
+        body = self._build_request_body(messages, tools, cfg)
+        url = f"/v1beta/models/{cfg.model}:streamGenerateContent"
+
+        params = {"alt": "sse", "key": self._api_key}
+        try:
+            async with self._client.stream(
+                "POST",
+                url,
+                json=body,
+                params=params,
+                timeout=httpx.Timeout(cfg.timeout_seconds),
+            ) as response:
+                self._check_status(response.status_code)
+                async for line in response.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    raw = line[6:]
+                    if raw.strip() == "[DONE]":
+                        break
+                    try:
+                        chunk = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    yield self._parse_response(chunk, cfg.model)
+        except httpx.TimeoutException as exc:
+            raise LLMTimeoutError(
+                f"Gemini streaming request timed out after {cfg.timeout_seconds}s"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Request Building
+    # ------------------------------------------------------------------
+
+    def _build_request_body(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None,
+        config: LLMConfig,
+    ) -> dict[str, Any]:
+        """Build the Gemini API request body from messages and tools."""
+        contents = self._messages_to_contents(messages)
+        body: dict[str, Any] = {"contents": contents}
+
+        # Generation config
+        body["generationConfig"] = {
+            "temperature": config.temperature,
+            "maxOutputTokens": config.max_tokens,
+            "topP": config.top_p,
+        }
+
+        # System instruction (extract from messages)
+        system_parts = [{"text": m.content} for m in messages if m.role == Role.SYSTEM]
+        if system_parts:
+            body["systemInstruction"] = {"parts": system_parts}
+
+        # Tool declarations
+        if tools:
+            body["tools"] = [
+                {
+                    "functionDeclarations": [
+                        {
+                            "name": t.name,
+                            "description": t.description,
+                            "parameters": t.parameters,
+                        }
+                        for t in tools
+                    ]
+                }
+            ]
+
+        return body
+
+    def _messages_to_contents(self, messages: list[Message]) -> list[dict[str, object]]:
+        """Convert messages to Gemini 'contents' format.
+
+        System messages are handled separately via systemInstruction.
+        """
+        contents: list[dict[str, Any]] = []
+
+        for msg in messages:
+            if msg.role == Role.SYSTEM:
+                continue  # handled in systemInstruction
+
+            role = "user" if msg.role in (Role.USER, Role.TOOL) else "model"
+            parts: list[dict[str, Any]] = []
+
+            if msg.role == Role.TOOL and msg.tool_call_id:
+                # Tool result → functionResponse
+                parts.append(
+                    {
+                        "functionResponse": {
+                            "name": msg.tool_call_id,
+                            "response": {"result": msg.content},
+                        }
+                    }
+                )
+            elif msg.tool_calls:
+                # Assistant with tool calls → functionCall parts
+                for tc in msg.tool_calls:
+                    parts.append(
+                        {
+                            "functionCall": {
+                                "name": tc.name,
+                                "args": tc.arguments,
+                            }
+                        }
+                    )
+                if msg.content:
+                    parts.append({"text": msg.content})
+            elif msg.content:
+                parts.append({"text": msg.content})
+
+            if parts:
+                contents.append({"role": role, "parts": parts})
+
+        return contents
+
+    # ------------------------------------------------------------------
+    # Response Parsing
+    # ------------------------------------------------------------------
+
+    def _parse_response(self, data: dict[str, Any], model: str) -> LLMResponse:
+        """Parse a Gemini API response into an LLMResponse."""
+        candidates = data.get("candidates", [])
+        if not candidates:
+            return LLMResponse(
+                content=None,
+                model=model,
+                finish_reason="error",
+            )
+
+        candidate = candidates[0]
+        content_obj = candidate.get("content", {})
+        parts = content_obj.get("parts", [])
+        finish_reason = candidate.get("finishReason", "STOP")
+
+        text_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+
+        for part in parts:
+            if "text" in part:
+                text_parts.append(part["text"])
+            elif "functionCall" in part:
+                fc = part["functionCall"]
+                tool_calls.append(
+                    ToolCall(
+                        id=str(uuid.uuid4()),
+                        name=fc.get("name", ""),
+                        arguments=fc.get("args", {}),
+                    )
+                )
+
+        # Parse token usage
+        usage_data = data.get("usageMetadata", {})
+        usage = TokenUsage(
+            prompt_tokens=usage_data.get("promptTokenCount", 0),
+            completion_tokens=usage_data.get("candidatesTokenCount", 0),
+            total_tokens=usage_data.get("totalTokenCount", 0),
+        )
+
+        # Map Gemini finish reasons to our standard
+        mapped_reason = self._map_finish_reason(str(finish_reason), tool_calls)
+
+        return LLMResponse(
+            content="\n".join(text_parts) if text_parts else None,
+            tool_calls=tool_calls,
+            usage=usage,
+            model=model,
+            finish_reason=mapped_reason,
+        )
+
+    @staticmethod
+    def _map_finish_reason(gemini_reason: str, tool_calls: list[ToolCall]) -> str:
+        """Map Gemini finish reason to our standard reasons."""
+        if tool_calls:
+            return "tool_calls"
+        mapping = {
+            "STOP": "stop",
+            "MAX_TOKENS": "length",
+            "SAFETY": "error",
+            "RECITATION": "error",
+            "OTHER": "error",
+        }
+        return mapping.get(gemini_reason, "stop")
+
+    # ------------------------------------------------------------------
+    # HTTP + Retry
+    # ------------------------------------------------------------------
+
+    async def _post_with_retry(
+        self,
+        url: str,
+        body: dict[str, Any],
+        config: LLMConfig,
+    ) -> dict[str, Any]:
+        """POST with exponential backoff retry on retryable errors."""
+        params = {"key": self._api_key}
+        last_exc: Exception | None = None
+
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                resp = await self._client.post(
+                    url,
+                    json=body,
+                    params=params,
+                    timeout=httpx.Timeout(config.timeout_seconds),
+                )
+                if resp.status_code in _RETRYABLE_STATUS_CODES:
+                    if attempt < _MAX_RETRIES:
+                        delay = _BACKOFF_BASE * (2**attempt)
+                        logger.warning(
+                            "Gemini API returned %d, retrying in %.1fs (attempt %d/%d)",
+                            resp.status_code,
+                            delay,
+                            attempt + 1,
+                            _MAX_RETRIES,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+                    # Out of retries — raise appropriate error
+                    if resp.status_code == 429:
+                        raise LLMRateLimitError(
+                            f"Gemini rate limit exceeded after {_MAX_RETRIES} retries"
+                        )
+                    raise LLMResponseError(
+                        f"Gemini API returned {resp.status_code} after {_MAX_RETRIES} retries"
+                    )
+
+                self._check_status(resp.status_code)
+
+                try:
+                    return resp.json()  # type: ignore[no-any-return]
+                except (json.JSONDecodeError, ValueError) as exc:
+                    if attempt < _MAX_RETRIES:
+                        logger.warning(
+                            "Malformed response from Gemini, retrying (attempt %d/%d)",
+                            attempt + 1,
+                            _MAX_RETRIES,
+                        )
+                        await asyncio.sleep(_BACKOFF_BASE)
+                        continue
+                    raise LLMResponseError("Malformed JSON response from Gemini API") from exc
+
+            except httpx.TimeoutException as exc:
+                last_exc = exc
+                if attempt < _MAX_RETRIES:
+                    logger.warning(
+                        "Gemini request timed out, retrying (attempt %d/%d)",
+                        attempt + 1,
+                        _MAX_RETRIES,
+                    )
+                    await asyncio.sleep(_BACKOFF_BASE)
+                    continue
+                raise LLMTimeoutError(
+                    f"Gemini request timed out after {config.timeout_seconds}s "
+                    f"({_MAX_RETRIES} retries exhausted)"
+                ) from last_exc
+
+        # Should not reach here, but satisfy type checker
+        msg = "Unexpected retry loop exit"
+        raise LLMResponseError(msg)  # pragma: no cover
+
+    @staticmethod
+    def _check_status(status_code: int) -> None:
+        """Raise specific errors for non-retryable status codes."""
+        if status_code == 401 or status_code == 403:  # noqa: PLR1714
+            raise LLMAuthError(
+                f"Gemini authentication failed (HTTP {status_code}). Check your GEMINI_API_KEY."
+            )
+        if status_code >= 400:
+            raise LLMResponseError(f"Gemini API error (HTTP {status_code})")

--- a/tests/unit/test_llm_base.py
+++ b/tests/unit/test_llm_base.py
@@ -1,0 +1,111 @@
+"""Unit tests for LLM base data classes."""
+
+from __future__ import annotations
+
+from agent_forge.llm.base import (
+    LLMConfig,
+    LLMResponse,
+    Message,
+    Role,
+    TokenUsage,
+    ToolCall,
+    ToolDefinition,
+)
+
+
+class TestRole:
+    """Tests for the Role enum."""
+
+    def test_values(self) -> None:
+        assert Role.SYSTEM.value == "system"
+        assert Role.USER.value == "user"
+        assert Role.ASSISTANT.value == "assistant"
+        assert Role.TOOL.value == "tool"
+
+
+class TestMessage:
+    """Tests for Message data class."""
+
+    def test_basic_message(self) -> None:
+        msg = Message(role=Role.USER, content="Hello")
+        assert msg.role == Role.USER
+        assert msg.content == "Hello"
+        assert msg.tool_call_id is None
+        assert msg.tool_calls is None
+
+    def test_tool_result_message(self) -> None:
+        msg = Message(role=Role.TOOL, content="file contents", tool_call_id="read_file")
+        assert msg.role == Role.TOOL
+        assert msg.tool_call_id == "read_file"
+
+    def test_assistant_with_tool_calls(self) -> None:
+        tc = ToolCall(id="tc1", name="read_file", arguments={"path": "main.py"})
+        msg = Message(role=Role.ASSISTANT, content="", tool_calls=[tc])
+        assert msg.tool_calls is not None
+        assert len(msg.tool_calls) == 1
+        assert msg.tool_calls[0].name == "read_file"
+
+
+class TestToolDefinition:
+    """Tests for ToolDefinition."""
+
+    def test_construction(self) -> None:
+        td = ToolDefinition(
+            name="read_file",
+            description="Read a file",
+            parameters={"type": "object", "properties": {"path": {"type": "string"}}},
+        )
+        assert td.name == "read_file"
+        assert "path" in td.parameters["properties"]  # type: ignore[operator]
+
+
+class TestLLMConfig:
+    """Tests for LLMConfig defaults."""
+
+    def test_defaults(self) -> None:
+        cfg = LLMConfig()
+        assert cfg.model == "gemini-2.0-flash"
+        assert cfg.temperature == 0.0
+        assert cfg.max_tokens == 4096
+        assert cfg.top_p == 1.0
+        assert cfg.timeout_seconds == 120
+
+    def test_custom(self) -> None:
+        cfg = LLMConfig(model="gpt-4o", temperature=0.7, max_tokens=8192)
+        assert cfg.model == "gpt-4o"
+        assert cfg.temperature == 0.7
+        assert cfg.max_tokens == 8192
+
+
+class TestLLMResponse:
+    """Tests for LLMResponse."""
+
+    def test_text_response(self) -> None:
+        resp = LLMResponse(
+            content="Hello!",
+            usage=TokenUsage(10, 5, 15),
+            model="gemini-2.0-flash",
+            finish_reason="stop",
+        )
+        assert resp.content == "Hello!"
+        assert resp.tool_calls == []
+        assert resp.usage.total_tokens == 15
+
+    def test_tool_call_response(self) -> None:
+        tc = ToolCall(id="tc1", name="write_file", arguments={"path": "x.py", "content": "pass"})
+        resp = LLMResponse(
+            content=None,
+            tool_calls=[tc],
+            model="gemini-2.0-flash",
+            finish_reason="tool_calls",
+        )
+        assert resp.content is None
+        assert len(resp.tool_calls) == 1
+        assert resp.finish_reason == "tool_calls"
+
+    def test_defaults(self) -> None:
+        resp = LLMResponse(content="hi")
+        assert resp.tool_calls == []
+        assert resp.usage.total_tokens == 0
+        assert resp.model == ""
+        assert resp.finish_reason == ""

--- a/tests/unit/test_llm_gemini.py
+++ b/tests/unit/test_llm_gemini.py
@@ -1,0 +1,306 @@
+"""Unit tests for the Gemini LLM provider adapter.
+
+Uses respx to mock httpx requests to the Gemini REST API.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from agent_forge.llm.base import (
+    LLMConfig,
+    Message,
+    Role,
+    ToolDefinition,
+)
+from agent_forge.llm.errors import (
+    LLMAuthError,
+    LLMRateLimitError,
+    LLMResponseError,
+    LLMTimeoutError,
+)
+from agent_forge.llm.factory import create_provider
+from agent_forge.llm.gemini import GeminiProvider
+
+_GEMINI_URL = "https://generativelanguage.googleapis.com"
+_MODEL = "gemini-2.0-flash"
+_GENERATE_URL = f"{_GEMINI_URL}/v1beta/models/{_MODEL}:generateContent"
+_STREAM_URL = f"{_GEMINI_URL}/v1beta/models/{_MODEL}:streamGenerateContent"
+
+
+def _text_response(text: str) -> dict[str, object]:
+    """Build a minimal Gemini text response payload."""
+    return {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": text}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 5,
+            "totalTokenCount": 15,
+        },
+    }
+
+
+def _tool_call_response(name: str, args: dict[str, object]) -> dict[str, object]:
+    """Build a Gemini function call response payload."""
+    return {
+        "candidates": [
+            {
+                "content": {"parts": [{"functionCall": {"name": name, "args": args}}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 20,
+            "candidatesTokenCount": 10,
+            "totalTokenCount": 30,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Provider Construction
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiProvider:
+    """Tests for GeminiProvider construction and lifecycle."""
+
+    def test_create_provider(self) -> None:
+        provider = GeminiProvider(api_key="test-key")
+        assert isinstance(provider, GeminiProvider)
+
+    def test_factory(self) -> None:
+        provider = create_provider("gemini", api_key="test-key")
+        assert isinstance(provider, GeminiProvider)
+
+    def test_factory_unknown(self) -> None:
+        with pytest.raises(ValueError, match="Unknown LLM provider"):
+            create_provider("unknown", api_key="k")
+
+
+# ---------------------------------------------------------------------------
+# Complete
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiComplete:
+    """Tests for GeminiProvider.complete()."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_text_completion(self) -> None:
+        respx.post(_GENERATE_URL).respond(200, json=_text_response("Hello world!"))
+
+        provider = GeminiProvider(api_key="test-key")
+        config = LLMConfig(model=_MODEL)
+        messages = [Message(role=Role.USER, content="Say hello")]
+
+        resp = await provider.complete(messages, config=config)
+
+        assert resp.content == "Hello world!"
+        assert resp.finish_reason == "stop"
+        assert resp.usage.total_tokens == 15
+        assert resp.model == _MODEL
+        assert resp.tool_calls == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_tool_call_completion(self) -> None:
+        respx.post(_GENERATE_URL).respond(
+            200, json=_tool_call_response("read_file", {"path": "main.py"})
+        )
+
+        provider = GeminiProvider(api_key="test-key")
+        tools = [
+            ToolDefinition(
+                name="read_file",
+                description="Read a file",
+                parameters={"type": "object", "properties": {"path": {"type": "string"}}},
+            )
+        ]
+        messages = [Message(role=Role.USER, content="Read main.py")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, tools=tools, config=config)
+
+        assert resp.content is None
+        assert len(resp.tool_calls) == 1
+        assert resp.tool_calls[0].name == "read_file"
+        assert resp.tool_calls[0].arguments == {"path": "main.py"}
+        assert resp.finish_reason == "tool_calls"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_system_message_handled(self) -> None:
+        respx.post(_GENERATE_URL).respond(200, json=_text_response("I understand."))
+
+        provider = GeminiProvider(api_key="test-key")
+        messages = [
+            Message(role=Role.SYSTEM, content="You are a coding assistant."),
+            Message(role=Role.USER, content="Hello"),
+        ]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "I understand."
+
+        # Verify the request body contains systemInstruction
+        request = respx.calls[0].request
+        body = json.loads(request.content)
+        assert "systemInstruction" in body
+        assert body["systemInstruction"]["parts"][0]["text"] == "You are a coding assistant."
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_tool_result_message(self) -> None:
+        respx.post(_GENERATE_URL).respond(200, json=_text_response("The file contains a function."))
+
+        provider = GeminiProvider(api_key="test-key")
+        messages = [
+            Message(role=Role.USER, content="Read main.py"),
+            Message(role=Role.TOOL, content="def main(): pass", tool_call_id="read_file"),
+        ]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "The file contains a function."
+
+        # Verify functionResponse in request body
+        request = respx.calls[0].request
+        body = json.loads(request.content)
+        tool_content = body["contents"][1]
+        assert "functionResponse" in tool_content["parts"][0]
+
+
+# ---------------------------------------------------------------------------
+# Error Handling
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiErrors:
+    """Tests for error handling and retry logic."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_auth_error(self) -> None:
+        respx.post(_GENERATE_URL).respond(401, json={"error": "unauthorized"})
+
+        provider = GeminiProvider(api_key="bad-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        with pytest.raises(LLMAuthError, match="authentication failed"):
+            await provider.complete(messages, config=config)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_rate_limit_exhausts_retries(self) -> None:
+        # All 4 attempts (1 initial + 3 retries) return 429
+        respx.post(_GENERATE_URL).respond(429, json={"error": "rate limited"})
+
+        provider = GeminiProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        with pytest.raises(LLMRateLimitError, match="rate limit"):
+            await provider.complete(messages, config=config)
+
+        # Should have made 4 attempts
+        assert len(respx.calls) == 4
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_rate_limit_retries_then_succeeds(self) -> None:
+        route = respx.post(_GENERATE_URL)
+        # First two return 429, third succeeds
+        route.side_effect = [
+            httpx.Response(429, json={"error": "rate limited"}),
+            httpx.Response(429, json={"error": "rate limited"}),
+            httpx.Response(200, json=_text_response("Success!")),
+        ]
+
+        provider = GeminiProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "Success!"
+        assert len(respx.calls) == 3
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_timeout_error(self) -> None:
+        respx.post(_GENERATE_URL).mock(side_effect=httpx.ReadTimeout("timeout"))
+
+        provider = GeminiProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL, timeout_seconds=1)
+
+        with pytest.raises(LLMTimeoutError, match="timed out"):
+            await provider.complete(messages, config=config)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_server_error_retries(self) -> None:
+        route = respx.post(_GENERATE_URL)
+        route.side_effect = [
+            httpx.Response(500, text="Internal Server Error"),
+            httpx.Response(200, json=_text_response("Recovered")),
+        ]
+
+        provider = GeminiProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "Recovered"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_malformed_json_retries(self) -> None:
+        route = respx.post(_GENERATE_URL)
+        route.side_effect = [
+            httpx.Response(200, text="not json"),
+            httpx.Response(200, json=_text_response("Fixed")),
+        ]
+
+        provider = GeminiProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "Fixed"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_malformed_json_exhausts_retries(self) -> None:
+        respx.post(_GENERATE_URL).respond(200, text="not json at all")
+
+        provider = GeminiProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        with pytest.raises(LLMResponseError, match="Malformed JSON"):
+            await provider.complete(messages, config=config)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_empty_candidates(self) -> None:
+        respx.post(_GENERATE_URL).respond(200, json={"candidates": []})
+
+        provider = GeminiProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content is None
+        assert resp.finish_reason == "error"


### PR DESCRIPTION
## Summary

Implement the LLM client layer: base classes, Gemini adapter, and provider factory per spec §4.1.

### Changes

- **`llm/base.py`** — Data classes (`Role`, `Message`, `ToolCall`, `ToolDefinition`, `LLMResponse`, `TokenUsage`, `LLMConfig`) + `LLMProvider` ABC with `complete()` and `stream()`
- **`llm/errors.py`** — Exception hierarchy: `LLMError`, `LLMRateLimitError`, `LLMAuthError`, `LLMContextOverflowError`, `LLMTimeoutError`, `LLMResponseError`
- **`llm/gemini.py`** — `GeminiProvider` using httpx REST API with tool mapping (ToolDefinition ↔ FunctionDeclaration), SSE streaming, and exponential backoff retry (1s base, max 3 retries on 429/500/502/503)
- **`llm/factory.py`** — `create_provider()` factory
- **`llm/__init__.py`** — Public exports
- **`tests/unit/test_llm_base.py`** — 10 tests for data classes
- **`tests/unit/test_llm_gemini.py`** — 15 tests for Gemini adapter (completion, tool calls, streaming, retries, error handling) using `respx`

### Verification

- ✅ `make lint` — ruff + mypy pass
- ✅ `make test-unit` — 50/50 tests pass (18.64s)

Closes #3