### PR TITLE
feat(#4): tool system base classes + read_file, write_file, list_directory

### DIFF
--- a/agent_forge/sandbox/base.py
+++ b/agent_forge/sandbox/base.py
@@ -1,1 +1,83 @@
-"""Sandbox base class — abstract interface for isolated execution environments."""
+"""Sandbox base class — abstract interface for isolated execution environments.
+
+Defines the minimal contract that tools use to interact with the sandbox.
+Full Docker implementation is in sandbox/docker.py (issue #5).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class ExecResult:
+    """Result of executing a command inside the sandbox."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class Sandbox(ABC):
+    """Abstract base class for sandbox execution environments."""
+
+    @abstractmethod
+    async def exec(
+        self,
+        command: str,
+        *,
+        timeout_seconds: int = 30,
+    ) -> ExecResult:
+        """Execute a shell command inside the sandbox.
+
+        Args:
+            command: Shell command to execute.
+            timeout_seconds: Max time to wait for the command.
+
+        Returns:
+            ExecResult with exit_code, stdout, and stderr.
+        """
+        ...
+
+    @abstractmethod
+    async def read_file(self, path: str) -> str:
+        """Read the contents of a file inside the sandbox.
+
+        Args:
+            path: Absolute path inside the sandbox.
+
+        Returns:
+            File contents as a string.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+        """
+        ...
+
+    @abstractmethod
+    async def write_file(self, path: str, content: str) -> None:
+        """Write content to a file inside the sandbox.
+
+        Creates parent directories if needed.
+
+        Args:
+            path: Absolute path inside the sandbox.
+            content: File content to write.
+        """
+        ...
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Start the sandbox environment."""
+        ...
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop and clean up the sandbox environment."""
+        ...
+
+    @abstractmethod
+    async def is_alive(self) -> bool:
+        """Check if the sandbox is still running."""
+        ...

--- a/agent_forge/tools/__init__.py
+++ b/agent_forge/tools/__init__.py
@@ -1,1 +1,26 @@
-"""Built-in tools for Agent Forge."""
+"""Tool system — base classes and built-in tools."""
+
+from agent_forge.tools.base import Tool, ToolRegistry, ToolResult, validate_path
+from agent_forge.tools.list_directory import ListDirectoryTool
+from agent_forge.tools.read_file import ReadFileTool
+from agent_forge.tools.write_file import WriteFileTool
+
+__all__ = [
+    "ListDirectoryTool",
+    "ReadFileTool",
+    "Tool",
+    "ToolRegistry",
+    "ToolResult",
+    "WriteFileTool",
+    "create_default_registry",
+    "validate_path",
+]
+
+
+def create_default_registry() -> ToolRegistry:
+    """Create a ToolRegistry with all built-in tools registered."""
+    registry = ToolRegistry()
+    registry.register(ReadFileTool())
+    registry.register(WriteFileTool())
+    registry.register(ListDirectoryTool())
+    return registry

--- a/agent_forge/tools/base.py
+++ b/agent_forge/tools/base.py
@@ -1,1 +1,144 @@
-"""Tool base classes: Tool ABC, ToolResult, and ToolRegistry."""
+"""Tool base classes: Tool ABC, ToolResult, and ToolRegistry.
+
+Defines the pluggable tool interface per spec § 4.2.
+"""
+
+from __future__ import annotations
+
+import posixpath
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from agent_forge.llm.base import ToolDefinition
+
+if TYPE_CHECKING:
+    from agent_forge.sandbox.base import Sandbox
+
+# ---------------------------------------------------------------------------
+# Data Classes
+# ---------------------------------------------------------------------------
+
+WORKSPACE_ROOT = "/workspace"
+
+
+@dataclass
+class ToolResult:
+    """Result of a tool execution."""
+
+    output: str
+    error: str | None = None
+    exit_code: int = 0
+    execution_time_ms: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Path Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_path(path: str) -> str:
+    """Validate and normalize a workspace-relative path.
+
+    Rejects path traversal (``..``) and ensures the resolved path is
+    under ``/workspace``.
+
+    Args:
+        path: Relative or absolute path within the workspace.
+
+    Returns:
+        Normalized absolute path under ``/workspace``.
+
+    Raises:
+        ValueError: If the path escapes the workspace root.
+    """
+    # Reject obvious traversal
+    if ".." in path.split("/"):
+        msg = f"Path traversal detected: '{path}'"
+        raise ValueError(msg)
+
+    # Make absolute if relative
+    resolved = posixpath.join(WORKSPACE_ROOT, path) if not posixpath.isabs(path) else path
+
+    # Normalize (collapse //, resolve . etc.)
+    resolved = posixpath.normpath(resolved)
+
+    # Must be under workspace
+    if not resolved.startswith(WORKSPACE_ROOT):
+        msg = f"Path must be within {WORKSPACE_ROOT}: '{path}'"
+        raise ValueError(msg)
+
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Tool ABC
+# ---------------------------------------------------------------------------
+
+
+class Tool(ABC):
+    """Base class for all agent tools."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Unique tool name, e.g. ``'read_file'``."""
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Human-readable description for the LLM."""
+        ...
+
+    @property
+    @abstractmethod
+    def parameters(self) -> dict[str, Any]:
+        """JSON Schema describing accepted arguments."""
+        ...
+
+    @abstractmethod
+    async def execute(self, arguments: dict[str, Any], sandbox: Sandbox) -> ToolResult:
+        """Execute the tool inside the given sandbox."""
+        ...
+
+    def to_definition(self) -> ToolDefinition:
+        """Convert this tool to an LLM-facing ToolDefinition."""
+        return ToolDefinition(
+            name=self.name,
+            description=self.description,
+            parameters=self.parameters,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool Registry
+# ---------------------------------------------------------------------------
+
+
+class ToolRegistry:
+    """Manages available tools and dispatches executions."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, Tool] = {}
+
+    def register(self, tool: Tool) -> None:
+        """Register a tool. Raises ValueError if name is already taken."""
+        if tool.name in self._tools:
+            msg = f"Tool '{tool.name}' already registered"
+            raise ValueError(msg)
+        self._tools[tool.name] = tool
+
+    def get(self, name: str) -> Tool:
+        """Get a tool by name. Raises KeyError if not found."""
+        if name not in self._tools:
+            msg = f"Unknown tool: '{name}'"
+            raise KeyError(msg)
+        return self._tools[name]
+
+    def list_definitions(self) -> list[ToolDefinition]:
+        """Return LLM-facing definitions for all registered tools."""
+        return [t.to_definition() for t in self._tools.values()]
+
+    def __len__(self) -> int:
+        return len(self._tools)

--- a/agent_forge/tools/list_directory.py
+++ b/agent_forge/tools/list_directory.py
@@ -1,1 +1,81 @@
-"""List directory tool — lists files and directories in the sandbox workspace."""
+"""list_directory tool — lists files and directories in the sandbox."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from agent_forge.tools.base import Tool, ToolResult, validate_path
+
+if TYPE_CHECKING:
+    from agent_forge.sandbox.base import Sandbox
+
+
+class ListDirectoryTool(Tool):
+    """List files and directories at the given path."""
+
+    @property
+    def name(self) -> str:
+        return "list_directory"
+
+    @property
+    def description(self) -> str:
+        return "List files and directories at the given path"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to list (default: /workspace)",
+                    "default": "/workspace",
+                },
+                "recursive": {
+                    "type": "boolean",
+                    "description": "List recursively (default: false)",
+                    "default": False,
+                },
+                "max_depth": {
+                    "type": "integer",
+                    "description": "Maximum depth for recursive listing (default: 3)",
+                    "default": 3,
+                },
+            },
+        }
+
+    async def execute(self, arguments: dict[str, Any], sandbox: Sandbox) -> ToolResult:
+        """List directory contents using find."""
+        path = arguments.get("path", "/workspace")
+        recursive = arguments.get("recursive", False)
+        max_depth = arguments.get("max_depth", 3)
+
+        try:
+            resolved = validate_path(path)
+        except ValueError as exc:
+            return ToolResult(output="", error=str(exc), exit_code=1)
+
+        start = time.monotonic()
+
+        if recursive:
+            cmd = f"find {resolved} -maxdepth {max_depth} -type f -o -type d | sort"
+        else:
+            cmd = f"find {resolved} -maxdepth 1 -type f -o -type d | sort"
+
+        result = await sandbox.exec(cmd)
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+
+        if result.exit_code != 0:
+            return ToolResult(
+                output="",
+                error=result.stderr or f"Failed to list directory: {resolved}",
+                exit_code=result.exit_code,
+                execution_time_ms=elapsed_ms,
+            )
+
+        return ToolResult(
+            output=result.stdout,
+            exit_code=0,
+            execution_time_ms=elapsed_ms,
+        )

--- a/agent_forge/tools/read_file.py
+++ b/agent_forge/tools/read_file.py
@@ -1,1 +1,75 @@
-"""Read file tool — reads contents of a file in the sandbox workspace."""
+"""read_file tool — reads file contents from the sandbox."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from agent_forge.tools.base import Tool, ToolResult, validate_path
+
+if TYPE_CHECKING:
+    from agent_forge.sandbox.base import Sandbox
+
+_MAX_SIZE_BYTES = 100 * 1024  # 100 KB
+
+
+class ReadFileTool(Tool):
+    """Read the contents of a file at the given path."""
+
+    @property
+    def name(self) -> str:
+        return "read_file"
+
+    @property
+    def description(self) -> str:
+        return "Read the contents of a file at the given path"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Relative path within the workspace",
+                },
+            },
+            "required": ["path"],
+        }
+
+    async def execute(self, arguments: dict[str, Any], sandbox: Sandbox) -> ToolResult:
+        """Read a file, truncating at 100KB."""
+        path = arguments.get("path", "")
+        if not path:
+            return ToolResult(output="", error="Missing required argument: path", exit_code=1)
+
+        try:
+            resolved = validate_path(path)
+        except ValueError as exc:
+            return ToolResult(output="", error=str(exc), exit_code=1)
+
+        start = time.monotonic()
+
+        result = await sandbox.exec(f"cat {resolved}")
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+
+        if result.exit_code != 0:
+            return ToolResult(
+                output="",
+                error=result.stderr or f"Failed to read file: {resolved}",
+                exit_code=result.exit_code,
+                execution_time_ms=elapsed_ms,
+            )
+
+        content = result.stdout
+        if len(content.encode("utf-8", errors="replace")) > _MAX_SIZE_BYTES:
+            truncated = content[:_MAX_SIZE_BYTES].rsplit("\n", 1)[0]
+            content = (
+                f"{truncated}\n\n[WARNING: File truncated at 100KB. Total size exceeds limit.]"
+            )
+
+        return ToolResult(
+            output=content,
+            exit_code=0,
+            execution_time_ms=elapsed_ms,
+        )

--- a/agent_forge/tools/write_file.py
+++ b/agent_forge/tools/write_file.py
@@ -1,1 +1,78 @@
-"""Write file tool — creates or overwrites a file in the sandbox workspace."""
+"""write_file tool — writes content to a file in the sandbox."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from agent_forge.tools.base import Tool, ToolResult, validate_path
+
+if TYPE_CHECKING:
+    from agent_forge.sandbox.base import Sandbox
+
+
+class WriteFileTool(Tool):
+    """Create or overwrite a file at the given path with the provided content."""
+
+    @property
+    def name(self) -> str:
+        return "write_file"
+
+    @property
+    def description(self) -> str:
+        return "Create or overwrite a file at the given path with the provided content"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Relative path within the workspace",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "File content to write",
+                },
+            },
+            "required": ["path", "content"],
+        }
+
+    async def execute(self, arguments: dict[str, Any], sandbox: Sandbox) -> ToolResult:
+        """Write content to a file, creating parent directories."""
+        path = arguments.get("path", "")
+        content = arguments.get("content", "")
+
+        if not path:
+            return ToolResult(output="", error="Missing required argument: path", exit_code=1)
+
+        try:
+            resolved = validate_path(path)
+        except ValueError as exc:
+            return ToolResult(output="", error=str(exc), exit_code=1)
+
+        start = time.monotonic()
+
+        # Create parent directories
+        parent = "/".join(resolved.rsplit("/", 1)[:-1])
+        if parent:
+            mkdir_result = await sandbox.exec(f"mkdir -p {parent}")
+            if mkdir_result.exit_code != 0:
+                elapsed_ms = int((time.monotonic() - start) * 1000)
+                return ToolResult(
+                    output="",
+                    error=mkdir_result.stderr or f"Failed to create directory: {parent}",
+                    exit_code=mkdir_result.exit_code,
+                    execution_time_ms=elapsed_ms,
+                )
+
+        # Write the file
+        await sandbox.write_file(resolved, content)
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+
+        return ToolResult(
+            output=f"Successfully wrote {len(content)} bytes to {resolved}",
+            exit_code=0,
+            execution_time_ms=elapsed_ms,
+        )

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,0 +1,262 @@
+"""Unit tests for the tool system.
+
+Tests Tool ABC, ToolResult, ToolRegistry, validate_path, and
+the built-in read_file, write_file, list_directory tools using
+AsyncMock for the Sandbox.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent_forge.sandbox.base import ExecResult
+from agent_forge.tools import (
+    ListDirectoryTool,
+    ReadFileTool,
+    ToolRegistry,
+    ToolResult,
+    WriteFileTool,
+    create_default_registry,
+    validate_path,
+)
+
+# ---------------------------------------------------------------------------
+# ToolResult
+# ---------------------------------------------------------------------------
+
+
+class TestToolResult:
+    def test_defaults(self) -> None:
+        r = ToolResult(output="hello")
+        assert r.output == "hello"
+        assert r.error is None
+        assert r.exit_code == 0
+        assert r.execution_time_ms == 0
+
+    def test_error(self) -> None:
+        r = ToolResult(output="", error="boom", exit_code=1)
+        assert r.exit_code == 1
+        assert r.error == "boom"
+
+
+# ---------------------------------------------------------------------------
+# validate_path
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePath:
+    def test_relative_path(self) -> None:
+        assert validate_path("src/main.py") == "/workspace/src/main.py"
+
+    def test_absolute_workspace_path(self) -> None:
+        assert validate_path("/workspace/src/main.py") == "/workspace/src/main.py"
+
+    def test_rejects_traversal(self) -> None:
+        with pytest.raises(ValueError, match="traversal"):
+            validate_path("../etc/passwd")
+
+    def test_rejects_traversal_absolute(self) -> None:
+        with pytest.raises(ValueError, match="traversal"):
+            validate_path("/workspace/../etc/passwd")
+
+    def test_rejects_outside_workspace(self) -> None:
+        with pytest.raises(ValueError, match="must be within"):
+            validate_path("/etc/passwd")
+
+    def test_normalizes_path(self) -> None:
+        assert validate_path("/workspace/./src//main.py") == "/workspace/src/main.py"
+
+
+# ---------------------------------------------------------------------------
+# ToolRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistry:
+    def test_register_and_get(self) -> None:
+        registry = ToolRegistry()
+        tool = ReadFileTool()
+        registry.register(tool)
+        assert registry.get("read_file") is tool
+
+    def test_register_duplicate(self) -> None:
+        registry = ToolRegistry()
+        registry.register(ReadFileTool())
+        with pytest.raises(ValueError, match="already registered"):
+            registry.register(ReadFileTool())
+
+    def test_get_unknown(self) -> None:
+        registry = ToolRegistry()
+        with pytest.raises(KeyError, match="Unknown tool"):
+            registry.get("nonexistent")
+
+    def test_list_definitions(self) -> None:
+        registry = create_default_registry()
+        defs = registry.list_definitions()
+        names = {d.name for d in defs}
+        assert names == {"read_file", "write_file", "list_directory"}
+        assert len(registry) == 3
+
+    def test_to_definition(self) -> None:
+        tool = ReadFileTool()
+        defn = tool.to_definition()
+        assert defn.name == "read_file"
+        assert "path" in defn.parameters["properties"]
+
+
+# ---------------------------------------------------------------------------
+# ReadFileTool
+# ---------------------------------------------------------------------------
+
+
+class TestReadFile:
+    @pytest.mark.asyncio
+    async def test_read_success(self) -> None:
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = ExecResult(exit_code=0, stdout="hello world", stderr="")
+
+        tool = ReadFileTool()
+        result = await tool.execute({"path": "main.py"}, sandbox)
+
+        assert result.exit_code == 0
+        assert result.output == "hello world"
+        sandbox.exec.assert_called_once_with("cat /workspace/main.py")
+
+    @pytest.mark.asyncio
+    async def test_read_missing_path(self) -> None:
+        sandbox = AsyncMock()
+        tool = ReadFileTool()
+        result = await tool.execute({}, sandbox)
+        assert result.exit_code == 1
+        assert "Missing" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_read_path_traversal(self) -> None:
+        sandbox = AsyncMock()
+        tool = ReadFileTool()
+        result = await tool.execute({"path": "../etc/passwd"}, sandbox)
+        assert result.exit_code == 1
+        assert "traversal" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_read_file_not_found(self) -> None:
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = ExecResult(exit_code=1, stdout="", stderr="cat: no such file")
+
+        tool = ReadFileTool()
+        result = await tool.execute({"path": "nonexistent.py"}, sandbox)
+        assert result.exit_code == 1
+        assert "no such file" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_read_large_file_truncated(self) -> None:
+        sandbox = AsyncMock()
+        # Create content larger than 100KB
+        large_content = "x" * (200 * 1024)
+        sandbox.exec.return_value = ExecResult(exit_code=0, stdout=large_content, stderr="")
+
+        tool = ReadFileTool()
+        result = await tool.execute({"path": "big.bin"}, sandbox)
+
+        assert result.exit_code == 0
+        assert "truncated" in result.output.lower()
+        assert len(result.output) < len(large_content)
+
+
+# ---------------------------------------------------------------------------
+# WriteFileTool
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFile:
+    @pytest.mark.asyncio
+    async def test_write_success(self) -> None:
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = ExecResult(exit_code=0, stdout="", stderr="")
+        sandbox.write_file.return_value = None
+
+        tool = WriteFileTool()
+        result = await tool.execute({"path": "src/new.py", "content": "print('hi')"}, sandbox)
+
+        assert result.exit_code == 0
+        assert "Successfully wrote" in result.output
+        sandbox.exec.assert_called_once_with("mkdir -p /workspace/src")
+        sandbox.write_file.assert_called_once_with("/workspace/src/new.py", "print('hi')")
+
+    @pytest.mark.asyncio
+    async def test_write_missing_path(self) -> None:
+        sandbox = AsyncMock()
+        tool = WriteFileTool()
+        result = await tool.execute({"content": "hello"}, sandbox)
+        assert result.exit_code == 1
+
+    @pytest.mark.asyncio
+    async def test_write_path_traversal(self) -> None:
+        sandbox = AsyncMock()
+        tool = WriteFileTool()
+        result = await tool.execute({"path": "../evil.sh", "content": "rm -rf /"}, sandbox)
+        assert result.exit_code == 1
+        assert "traversal" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_write_outside_workspace(self) -> None:
+        sandbox = AsyncMock()
+        tool = WriteFileTool()
+        result = await tool.execute({"path": "/etc/crontab", "content": "bad"}, sandbox)
+        assert result.exit_code == 1
+        assert "must be within" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# ListDirectoryTool
+# ---------------------------------------------------------------------------
+
+
+class TestListDirectory:
+    @pytest.mark.asyncio
+    async def test_list_default(self) -> None:
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = ExecResult(
+            exit_code=0, stdout="/workspace\n/workspace/main.py\n", stderr=""
+        )
+
+        tool = ListDirectoryTool()
+        result = await tool.execute({}, sandbox)
+
+        assert result.exit_code == 0
+        assert "/workspace/main.py" in result.output
+        sandbox.exec.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_recursive(self) -> None:
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = ExecResult(
+            exit_code=0, stdout="/workspace\n/workspace/src\n/workspace/src/a.py\n", stderr=""
+        )
+
+        tool = ListDirectoryTool()
+        result = await tool.execute({"path": ".", "recursive": True, "max_depth": 2}, sandbox)
+
+        assert result.exit_code == 0
+        # Verify the find command uses maxdepth
+        call_args = sandbox.exec.call_args[0][0]
+        assert "-maxdepth 2" in call_args
+
+    @pytest.mark.asyncio
+    async def test_list_path_traversal(self) -> None:
+        sandbox = AsyncMock()
+        tool = ListDirectoryTool()
+        result = await tool.execute({"path": "../"}, sandbox)
+        assert result.exit_code == 1
+
+    @pytest.mark.asyncio
+    async def test_list_error(self) -> None:
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = ExecResult(exit_code=1, stdout="", stderr="permission denied")
+
+        tool = ListDirectoryTool()
+        result = await tool.execute({"path": "/workspace/secret"}, sandbox)
+        assert result.exit_code == 1
+        assert "permission denied" in (result.error or "")


### PR DESCRIPTION
## Summary

Implement the tool system per spec §4.2: base classes, registry, and three built-in tools.

### Changes

- **`sandbox/base.py`** — `Sandbox` ABC with `exec()`, `read_file()`, `write_file()` + `ExecResult` dataclass
- **`tools/base.py`** — `ToolResult`, `validate_path()` (rejects `..` traversal, enforces `/workspace`), `Tool` ABC, `ToolRegistry`
- **`tools/read_file.py`** — `ReadFileTool` — cat via sandbox, 100KB truncation with warning
- **`tools/write_file.py`** — `WriteFileTool` — mkdir -p + sandbox.write_file(), path validation
- **`tools/list_directory.py`** — `ListDirectoryTool` — find with configurable max_depth
- **`tools/__init__.py`** — Exports + `create_default_registry()`
- **`tests/unit/test_tools.py`** — 26 unit tests with AsyncMock sandbox

### Verification

- ✅ `make lint` — ruff + mypy pass
- ✅ `make test-unit` — 76/76 tests pass (18.60s)

Closes #4