### PR TITLE
feat(#5): Sandbox Docker image + DockerSandbox implementation

### DIFF
--- a/agent_forge/sandbox/Dockerfile
+++ b/agent_forge/sandbox/Dockerfile
@@ -1,6 +1,3 @@
-# Agent Forge — Sandbox Base Image
-# Pre-built image with common development tools for sandboxed tool execution.
-
 FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -14,7 +11,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install common Python dev tools
 RUN pip install --no-cache-dir \
-    black \
     ruff \
     pytest \
     mypy

--- a/agent_forge/sandbox/__init__.py
+++ b/agent_forge/sandbox/__init__.py
@@ -1,1 +1,12 @@
 """Sandbox runtime for isolated tool execution."""
+
+from agent_forge.sandbox.base import ExecResult, Sandbox, SandboxConfig, SandboxState
+from agent_forge.sandbox.docker import DockerSandbox
+
+__all__ = [
+    "DockerSandbox",
+    "ExecResult",
+    "Sandbox",
+    "SandboxConfig",
+    "SandboxState",
+]

--- a/agent_forge/sandbox/base.py
+++ b/agent_forge/sandbox/base.py
@@ -1,13 +1,35 @@
 """Sandbox base class — abstract interface for isolated execution environments.
 
-Defines the minimal contract that tools use to interact with the sandbox.
-Full Docker implementation is in sandbox/docker.py (issue #5).
+Defines the contract that tools use to interact with the sandbox,
+plus SandboxConfig and SandboxState.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class SandboxState(Enum):
+    """Container lifecycle state."""
+
+    IDLE = "idle"
+    RUNNING = "running"
+    STOPPED = "stopped"
+
+
+@dataclass
+class SandboxConfig:
+    """Configuration for a sandbox container."""
+
+    image: str = "agent-forge-sandbox:latest"
+    workspace_path: str = "/workspace"
+    cpu_limit: float = 1.0
+    memory_limit: str = "512m"
+    timeout_seconds: int = 300
+    network_enabled: bool = False
+    env_vars: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -21,6 +43,16 @@ class ExecResult:
 
 class Sandbox(ABC):
     """Abstract base class for sandbox execution environments."""
+
+    @abstractmethod
+    async def start(self, repo_path: str, config: SandboxConfig | None = None) -> None:
+        """Create and start the sandbox container with the repo mounted.
+
+        Args:
+            repo_path: Local path to the repository to mount.
+            config: Sandbox configuration. Defaults to ``SandboxConfig()``.
+        """
+        ...
 
     @abstractmethod
     async def exec(
@@ -68,13 +100,8 @@ class Sandbox(ABC):
         ...
 
     @abstractmethod
-    async def start(self) -> None:
-        """Start the sandbox environment."""
-        ...
-
-    @abstractmethod
     async def stop(self) -> None:
-        """Stop and clean up the sandbox environment."""
+        """Stop and remove the sandbox container."""
         ...
 
     @abstractmethod

--- a/agent_forge/sandbox/docker.py
+++ b/agent_forge/sandbox/docker.py
@@ -1,1 +1,216 @@
-"""Docker-based sandbox implementation."""
+"""Docker-based sandbox implementation.
+
+Uses the Docker SDK to manage isolated containers for tool execution.
+Implements security constraints per spec § 4.3.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+import docker
+from docker.errors import APIError, NotFound
+
+from agent_forge.sandbox.base import ExecResult, Sandbox, SandboxConfig, SandboxState
+
+if TYPE_CHECKING:
+    from docker.models.containers import Container
+
+logger = logging.getLogger(__name__)
+
+
+class DockerSandbox(Sandbox):
+    """Docker-based sandbox for isolated tool execution.
+
+    Each instance manages a single container with security constraints:
+    - No host network (``--network none``)
+    - Read-only root filesystem (``--read-only``)
+    - No new privileges (``--security-opt no-new-privileges``)
+    - PID limit (``--pids-limit 256``)
+    - Tmpfs for ``/tmp`` (``noexec``, ``nosuid``, 64m)
+    - CPU and memory limits from config
+    """
+
+    def __init__(self) -> None:
+        self._client: docker.DockerClient = docker.from_env()
+        self._container: Container | None = None
+        self._state = SandboxState.IDLE
+        self._config = SandboxConfig()
+
+    @property
+    def state(self) -> SandboxState:
+        """Current lifecycle state."""
+        return self._state
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self, repo_path: str, config: SandboxConfig | None = None) -> None:
+        """Create and start the sandbox container."""
+        if self._state == SandboxState.RUNNING:
+            msg = "Sandbox is already running"
+            raise RuntimeError(msg)
+
+        cfg = config or SandboxConfig()
+        self._config = cfg
+
+        security_opts: list[str] = ["no-new-privileges"]
+        tmpfs: dict[str, str] = {"/tmp": "rw,noexec,nosuid,size=64m"}
+
+        # Parse memory limit to bytes for Docker SDK
+        mem_limit = cfg.memory_limit
+
+        run_kwargs: dict[str, Any] = {
+            "image": cfg.image,
+            "command": "sleep infinity",
+            "detach": True,
+            "remove": True,
+            "read_only": True,
+            "security_opt": security_opts,
+            "pids_limit": 256,
+            "tmpfs": tmpfs,
+            "nano_cpus": int(cfg.cpu_limit * 1e9),
+            "mem_limit": mem_limit,
+            "environment": cfg.env_vars,
+            "volumes": {
+                repo_path: {
+                    "bind": cfg.workspace_path,
+                    "mode": "rw",
+                }
+            },
+            "working_dir": cfg.workspace_path,
+        }
+
+        # Network isolation
+        if not cfg.network_enabled:
+            run_kwargs["network_mode"] = "none"
+
+        try:
+            self._container = await asyncio.to_thread(
+                lambda: self._client.containers.run(**run_kwargs)
+            )
+            self._state = SandboxState.RUNNING
+            logger.info(
+                "Sandbox started: container=%s, image=%s",
+                self._container.short_id,  # type: ignore[union-attr]
+                cfg.image,
+            )
+        except (APIError, Exception) as exc:
+            self._state = SandboxState.STOPPED
+            msg = f"Failed to start sandbox container: {exc}"
+            raise RuntimeError(msg) from exc
+
+    async def stop(self) -> None:
+        """Stop and remove the sandbox container."""
+        if self._container is None:
+            self._state = SandboxState.STOPPED
+            return
+
+        try:
+            await asyncio.to_thread(self._container.stop, timeout=5)
+        except NotFound:
+            # Container already removed (--rm flag)
+            pass
+        except APIError as exc:
+            logger.warning("Error stopping container: %s", exc)
+        finally:
+            self._container = None
+            self._state = SandboxState.STOPPED
+            logger.info("Sandbox stopped")
+
+    async def is_alive(self) -> bool:
+        """Check if the sandbox container is still running."""
+        if self._container is None:
+            return False
+        try:
+            await asyncio.to_thread(self._container.reload)
+            status: str = self._container.status
+            return status == "running"
+        except (NotFound, APIError):
+            self._state = SandboxState.STOPPED
+            return False
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    async def exec(
+        self,
+        command: str,
+        *,
+        timeout_seconds: int = 30,
+    ) -> ExecResult:
+        """Execute a command inside the running sandbox."""
+        self._ensure_running()
+        assert self._container is not None  # noqa: S101
+
+        try:
+            exit_code, output = await asyncio.wait_for(
+                asyncio.to_thread(
+                    self._container.exec_run,
+                    ["bash", "-c", command],
+                    demux=True,
+                ),
+                timeout=timeout_seconds,
+            )
+        except TimeoutError:
+            return ExecResult(
+                exit_code=124,
+                stdout="",
+                stderr=f"Command timed out after {timeout_seconds}s",
+            )
+        except APIError as exc:
+            return ExecResult(
+                exit_code=1,
+                stdout="",
+                stderr=f"Docker exec error: {exc}",
+            )
+
+        stdout_raw, stderr_raw = output or (None, None)
+        return ExecResult(
+            exit_code=exit_code,
+            stdout=(stdout_raw or b"").decode("utf-8", errors="replace"),
+            stderr=(stderr_raw or b"").decode("utf-8", errors="replace"),
+        )
+
+    async def read_file(self, path: str) -> str:
+        """Read a file from the sandbox filesystem."""
+        result = await self.exec(f"cat {path}")
+        if result.exit_code != 0:
+            msg = f"File not found in sandbox: {path}"
+            raise FileNotFoundError(msg)
+        return result.stdout
+
+    async def write_file(self, path: str, content: str) -> None:
+        """Write content to a file inside the sandbox."""
+        # Create parent directories first
+        parent = "/".join(path.rsplit("/", 1)[:-1])
+        if parent:
+            await self.exec(f"mkdir -p {parent}")
+
+        # Use tee to write (handles special characters better than echo)
+        # Pass content via stdin using exec_run with stdin
+        self._ensure_running()
+        assert self._container is not None  # noqa: S101
+
+        # Use a heredoc-style approach for content with special chars
+        import shlex
+
+        escaped = shlex.quote(content)
+        result = await self.exec(f"printf %s {escaped} > {path}")
+        if result.exit_code != 0:
+            msg = f"Failed to write file: {path} — {result.stderr}"
+            raise OSError(msg)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _ensure_running(self) -> None:
+        """Raise if the sandbox is not in RUNNING state."""
+        if self._state != SandboxState.RUNNING or self._container is None:
+            msg = "Sandbox is not running. Call start() first."
+            raise RuntimeError(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.10",
     "respx>=0.21",
+    "types-docker>=7.0",
 ]
 
 [project.scripts]

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1,0 +1,239 @@
+"""Unit tests for the Docker sandbox.
+
+Uses mocked Docker SDK to test container lifecycle, security constraints,
+exec, read_file, write_file, and error handling.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_forge.sandbox.base import SandboxConfig, SandboxState
+from agent_forge.sandbox.docker import DockerSandbox
+
+
+@pytest.fixture
+def mock_docker_client() -> MagicMock:
+    """Create a mocked Docker client."""
+    client = MagicMock()
+    container = MagicMock()
+    container.short_id = "abc123"
+    container.status = "running"
+    container.exec_run.return_value = (0, (b"hello", b""))
+    container.reload.return_value = None
+    client.containers.run.return_value = container
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxLifecycle:
+    @pytest.mark.asyncio
+    async def test_initial_state(self) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = MagicMock()
+            sandbox = DockerSandbox()
+            assert sandbox.state == SandboxState.IDLE
+
+    @pytest.mark.asyncio
+    async def test_start(self, mock_docker_client: MagicMock) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo")
+
+            assert sandbox.state == SandboxState.RUNNING
+            mock_docker_client.containers.run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_start_security_opts(self, mock_docker_client: MagicMock) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo")
+
+            call_kwargs = mock_docker_client.containers.run.call_args[1]
+            assert "no-new-privileges" in call_kwargs["security_opt"]
+            assert call_kwargs["read_only"] is True
+            assert call_kwargs["pids_limit"] == 256
+            assert "/tmp" in call_kwargs["tmpfs"]
+            assert call_kwargs["network_mode"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_start_with_custom_config(self, mock_docker_client: MagicMock) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            config = SandboxConfig(
+                cpu_limit=2.0,
+                memory_limit="1g",
+                network_enabled=True,
+            )
+            await sandbox.start("/tmp/repo", config=config)
+
+            call_kwargs = mock_docker_client.containers.run.call_args[1]
+            assert call_kwargs["nano_cpus"] == 2_000_000_000
+            assert call_kwargs["mem_limit"] == "1g"
+            assert "network_mode" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_start_already_running(self, mock_docker_client: MagicMock) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo")
+
+            with pytest.raises(RuntimeError, match="already running"):
+                await sandbox.start("/tmp/repo")
+
+    @pytest.mark.asyncio
+    async def test_stop(self, mock_docker_client: MagicMock) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo")
+            await sandbox.stop()
+
+            assert sandbox.state == SandboxState.STOPPED
+            mock_docker_client.containers.run.return_value.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_when_idle(self) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = MagicMock()
+            sandbox = DockerSandbox()
+            await sandbox.stop()
+            assert sandbox.state == SandboxState.STOPPED
+
+    @pytest.mark.asyncio
+    async def test_is_alive(self, mock_docker_client: MagicMock) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo")
+
+            assert await sandbox.is_alive() is True
+
+    @pytest.mark.asyncio
+    async def test_is_alive_when_idle(self) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = MagicMock()
+            sandbox = DockerSandbox()
+            assert await sandbox.is_alive() is False
+
+
+# ---------------------------------------------------------------------------
+# Exec
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxExec:
+    @pytest.mark.asyncio
+    async def test_exec_success(self, mock_docker_client: MagicMock) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo")
+
+            result = await sandbox.exec("echo hello")
+
+            assert result.exit_code == 0
+            assert result.stdout == "hello"
+            container = mock_docker_client.containers.run.return_value
+            container.exec_run.assert_called_once_with(["bash", "-c", "echo hello"], demux=True)
+
+    @pytest.mark.asyncio
+    async def test_exec_with_stderr(self, mock_docker_client: MagicMock) -> None:
+        container = mock_docker_client.containers.run.return_value
+        container.exec_run.return_value = (1, (b"", b"command not found"))
+
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo")
+
+            result = await sandbox.exec("bad_cmd")
+
+            assert result.exit_code == 1
+            assert result.stderr == "command not found"
+
+    @pytest.mark.asyncio
+    async def test_exec_not_running(self) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = MagicMock()
+            sandbox = DockerSandbox()
+
+            with pytest.raises(RuntimeError, match="not running"):
+                await sandbox.exec("echo hello")
+
+
+# ---------------------------------------------------------------------------
+# File Operations
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxFileOps:
+    @pytest.mark.asyncio
+    async def test_read_file(self, mock_docker_client: MagicMock) -> None:
+        container = mock_docker_client.containers.run.return_value
+        container.exec_run.return_value = (0, (b"file contents", b""))
+
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo")
+
+            content = await sandbox.read_file("/workspace/main.py")
+            assert content == "file contents"
+
+    @pytest.mark.asyncio
+    async def test_read_file_not_found(self, mock_docker_client: MagicMock) -> None:
+        container = mock_docker_client.containers.run.return_value
+        container.exec_run.return_value = (1, (b"", b"No such file"))
+
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo")
+
+            with pytest.raises(FileNotFoundError):
+                await sandbox.read_file("/workspace/missing.py")
+
+    @pytest.mark.asyncio
+    async def test_write_file(self, mock_docker_client: MagicMock) -> None:
+        container = mock_docker_client.containers.run.return_value
+        container.exec_run.return_value = (0, (b"", b""))
+
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo")
+
+            await sandbox.write_file("/workspace/new.py", "print('hi')")
+            # Should have called exec at least twice (mkdir -p + write)
+            assert container.exec_run.call_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# Volume Mounts
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxMounts:
+    @pytest.mark.asyncio
+    async def test_repo_mounted(self, mock_docker_client: MagicMock) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/home/user/project")
+
+            call_kwargs = mock_docker_client.containers.run.call_args[1]
+            volumes = call_kwargs["volumes"]
+            assert "/home/user/project" in volumes
+            assert volumes["/home/user/project"]["bind"] == "/workspace"
+            assert volumes["/home/user/project"]["mode"] == "rw"


### PR DESCRIPTION
## Summary

Implement the sandbox runtime per spec §4.3: Docker image, DockerSandbox with security constraints, and container lifecycle management.

### Changes

- **`sandbox/base.py`** — `SandboxConfig` (image, workspace, cpu/memory limits, timeout, network, env_vars), `SandboxState` enum (IDLE/RUNNING/STOPPED), updated `Sandbox.start(repo_path, config)`
- **`sandbox/Dockerfile`** — Python 3.12-slim + git, ripgrep, tree, curl, jq, build-essential, ruff, pytest, mypy, non-root `agent` user
- **`sandbox/docker.py`** — `DockerSandbox` using Docker SDK with security constraints: `--network none`, `--read-only`, `--security-opt no-new-privileges`, `--pids-limit 256`, `--tmpfs /tmp:rw,noexec,nosuid,size=64m`, CPU/memory limits
- **`sandbox/__init__.py`** — Public exports
- **`pyproject.toml`** — Added `types-docker>=7.0` to dev deps
- **`tests/unit/test_sandbox.py`** — 16 unit tests with mocked Docker SDK (lifecycle, security opts, exec, file ops, volume mounts)

### Verification

- ✅ `make lint` — ruff + mypy pass
- ✅ `make test-unit` — 92/92 tests pass (18.71s)

Closes #5