### PR TITLE
feat(#57): add CI integration test job with Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,24 @@ jobs:
 
       - name: Run unit tests
         run: make test-unit
+
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Build sandbox Docker image
+        run: make build-sandbox
+
+      - name: Run integration tests
+        run: make test-integration


### PR DESCRIPTION
Add a separate `integration` job to CI that builds the sandbox Docker image and runs integration tests with real containers.

### Changes

- New `integration` job runs after `lint` + `test` both pass (`needs: [lint, test]`)
- Builds sandbox image via `make build-sandbox`
- Runs `make test-integration` against real Docker containers
- Existing unit test matrix (3.11, 3.12, 3.13) unchanged

Closes #57