### PR TITLE
feat(#7): ReAct loop implementation with termination conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ setup:                     ## Install dependencies
 build-sandbox:             ## Build the sandbox Docker image
 	docker build -t agent-forge-sandbox:latest -f agent_forge/sandbox/Dockerfile .
 
-test:                      ## Run all tests
-	pytest --cov=agent_forge --cov-report=term-missing
+test:                      ## Run all tests (excludes integration — use test-integration)
+	pytest --cov=agent_forge --cov-report=term-missing -m "not integration"
 
 test-unit:                 ## Run unit tests only
 	pytest tests/unit -v

--- a/agent_forge/agent/__init__.py
+++ b/agent_forge/agent/__init__.py
@@ -1,1 +1,14 @@
 """Agent core — ReAct loop and agent lifecycle."""
+
+from agent_forge.agent.core import react_loop
+from agent_forge.agent.models import AgentConfig, AgentRun, RunState, ToolInvocation
+from agent_forge.agent.prompts import build_system_prompt
+
+__all__ = [
+    "AgentConfig",
+    "AgentRun",
+    "RunState",
+    "ToolInvocation",
+    "build_system_prompt",
+    "react_loop",
+]

--- a/agent_forge/agent/core.py
+++ b/agent_forge/agent/core.py
@@ -1,1 +1,169 @@
 """ReAct loop implementation — the core reasoning + acting cycle."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from agent_forge.agent.models import AgentRun, RunState, ToolInvocation
+from agent_forge.agent.prompts import build_system_prompt
+from agent_forge.llm.base import LLMConfig, Message, Role
+
+if TYPE_CHECKING:
+    from agent_forge.llm.base import LLMProvider
+    from agent_forge.sandbox.base import Sandbox
+    from agent_forge.tools.base import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+async def react_loop(
+    run: AgentRun,
+    llm: LLMProvider,
+    tools: ToolRegistry,
+    sandbox: Sandbox,
+) -> AgentRun:
+    """Execute the ReAct loop: Observe → Reason (LLM) → Act (Tool) → Repeat.
+
+    Terminates when:
+    - LLM returns no tool calls (task complete → COMPLETED)
+    - Max iterations reached (→ TIMEOUT)
+    - Token budget exceeded (→ TIMEOUT)
+    - Unrecoverable error (→ FAILED)
+    """
+    run.state = RunState.RUNNING
+
+    # Build system prompt from task + tool definitions
+    system_content = run.config.system_prompt or build_system_prompt(
+        run.task, tools.list_definitions()
+    )
+    run.messages.append(Message(role=Role.SYSTEM, content=system_content))
+    run.messages.append(Message(role=Role.USER, content=run.task))
+
+    llm_config = LLMConfig(
+        model=run.config.model,
+        temperature=run.config.temperature,
+    )
+    tool_definitions = tools.list_definitions()
+
+    try:
+        while run.iterations < run.config.max_iterations:
+            run.iterations += 1
+            logger.info("Iteration %d/%d", run.iterations, run.config.max_iterations)
+
+            # 1. REASON — ask the LLM what to do next
+            response = await llm.complete(
+                messages=run.messages,
+                tools=tool_definitions,
+                config=llm_config,
+            )
+            run.total_tokens = run.total_tokens + response.usage
+
+            # 2. CHECK BUDGET
+            if run.total_tokens.total_tokens > run.config.max_tokens_per_run:
+                logger.warning("Token budget exceeded: %d", run.total_tokens.total_tokens)
+                run.state = RunState.TIMEOUT
+                run.error = "Token budget exceeded"
+                break
+
+            # 3. CHECK COMPLETION
+            if response.finish_reason == "stop" and not response.tool_calls:
+                run.messages.append(Message(role=Role.ASSISTANT, content=response.content or ""))
+                run.state = RunState.COMPLETED
+                break
+
+            # 4. ACT — execute each tool call
+            run.messages.append(
+                Message(
+                    role=Role.ASSISTANT,
+                    content=response.content or "",
+                    tool_calls=response.tool_calls,
+                )
+            )
+
+            for tool_call in response.tool_calls:
+                await _execute_tool_call(run, tools, sandbox, tool_call)
+
+        else:
+            # Loop exhausted without breaking → max iterations
+            logger.warning("Max iterations reached: %d", run.config.max_iterations)
+            run.state = RunState.TIMEOUT
+            run.error = "Max iterations reached"
+
+    except Exception as exc:
+        logger.exception("Unrecoverable error during agent run")
+        run.state = RunState.FAILED
+        run.error = str(exc)
+
+    run.completed_at = datetime.now(UTC)
+    return run
+
+
+async def _execute_tool_call(
+    run: AgentRun,
+    tools: ToolRegistry,
+    sandbox: Sandbox,
+    tool_call: object,
+) -> None:
+    """Execute a single tool call and append the result to conversation history."""
+    from agent_forge.llm.base import ToolCall
+    from agent_forge.tools.base import ToolResult
+
+    assert isinstance(tool_call, ToolCall)  # noqa: S101
+
+    try:
+        tool = tools.get(tool_call.name)
+    except KeyError:
+        # Unknown tool — inject error and let LLM self-correct
+        logger.warning("Unknown tool requested: %s", tool_call.name)
+        error_result = ToolResult(
+            output="",
+            error=f"Unknown tool: '{tool_call.name}'. Available tools: "
+            + ", ".join(d.name for d in tools.list_definitions()),
+            exit_code=1,
+        )
+        run.messages.append(
+            Message(
+                role=Role.TOOL,
+                content=error_result.error or "",
+                tool_call_id=tool_call.id,
+            )
+        )
+        run.tool_invocations.append(
+            ToolInvocation(
+                tool_name=tool_call.name,
+                arguments=dict(tool_call.arguments),
+                result=error_result,
+                iteration=run.iterations,
+                timestamp=datetime.now(UTC),
+                duration_ms=0,
+            )
+        )
+        return
+
+    result = await tool.execute(dict(tool_call.arguments), sandbox)
+
+    run.tool_invocations.append(
+        ToolInvocation(
+            tool_name=tool_call.name,
+            arguments=dict(tool_call.arguments),
+            result=result,
+            iteration=run.iterations,
+            timestamp=datetime.now(UTC),
+            duration_ms=result.execution_time_ms,
+        )
+    )
+
+    # Build tool message content
+    content = result.output
+    if result.error:
+        content += f"\n[ERROR] {result.error}" if content else f"[ERROR] {result.error}"
+
+    run.messages.append(
+        Message(
+            role=Role.TOOL,
+            content=content,
+            tool_call_id=tool_call.id,
+        )
+    )

--- a/agent_forge/agent/models.py
+++ b/agent_forge/agent/models.py
@@ -1,1 +1,77 @@
 """Agent data models — AgentRun, RunState, ToolInvocation, and related classes."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_forge.llm.base import Message, TokenUsage
+    from agent_forge.tools.base import ToolResult
+
+
+class RunState(Enum):
+    """Lifecycle state of an agent run."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    TIMEOUT = "timeout"
+
+
+@dataclass
+class AgentConfig:
+    """Configuration for a single agent run."""
+
+    max_iterations: int = 25
+    max_tokens_per_run: int = 200_000
+    model: str = "gemini-2.0-flash"
+    provider: str = "gemini"  # "gemini" | "openai" | "anthropic"
+    temperature: float = 0.0
+    system_prompt: str | None = None  # Override default system prompt
+
+
+@dataclass
+class ToolInvocation:
+    """Record of a single tool execution during an agent run."""
+
+    tool_name: str
+    arguments: dict[str, object]
+    result: ToolResult
+    iteration: int
+    timestamp: datetime
+    duration_ms: int
+
+
+@dataclass
+class AgentRun:
+    """Full state of an agent run, including conversation history and metrics."""
+
+    task: str
+    repo_path: str
+    config: AgentConfig
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    state: RunState = RunState.PENDING
+    messages: list[Message] = field(default_factory=list)
+    iterations: int = 0
+    total_tokens: TokenUsage = field(
+        default_factory=lambda: _zero_usage(),
+    )
+    tool_invocations: list[ToolInvocation] = field(default_factory=list)
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(UTC),
+    )
+    completed_at: datetime | None = None
+    error: str | None = None
+
+
+def _zero_usage() -> TokenUsage:
+    """Create a zero TokenUsage without a top-level import."""
+    from agent_forge.llm.base import TokenUsage
+
+    return TokenUsage(0, 0, 0)

--- a/agent_forge/agent/prompts.py
+++ b/agent_forge/agent/prompts.py
@@ -1,1 +1,45 @@
 """System prompt templates for the agent."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_forge.llm.base import ToolDefinition
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+You are Agent Forge, an autonomous coding agent. You are given a coding task \
+and a workspace containing a code repository.
+
+## Your Capabilities
+You can use the following tools to complete the task:
+{tool_descriptions}
+
+## Rules
+1. Always read relevant files before making changes.
+2. Make small, focused changes. Do not rewrite entire files unnecessarily.
+3. After making changes, verify they work (e.g., run tests or linters).
+4. If you encounter an error, analyze it and try a different approach.
+5. When the task is complete, provide a summary of what you changed and why.
+6. Do NOT attempt to access the internet or external services.
+7. Stay within the /workspace directory.
+
+## Task
+{task_description}"""
+
+
+def build_system_prompt(
+    task: str,
+    tool_definitions: list[ToolDefinition],
+) -> str:
+    """Render the system prompt with tool descriptions and task."""
+    tool_lines: list[str] = []
+    for td in tool_definitions:
+        props: dict[str, dict[str, object]] = td.parameters.get("properties", {})  # type: ignore[assignment]
+        params = ", ".join(f"{k}: {v.get('type', 'any')}" for k, v in props.items())
+        tool_lines.append(f"- **{td.name}**({params}) — {td.description}")
+
+    return _SYSTEM_PROMPT_TEMPLATE.format(
+        tool_descriptions="\n".join(tool_lines),
+        task_description=task,
+    )

--- a/agent_forge/llm/base.py
+++ b/agent_forge/llm/base.py
@@ -50,6 +50,14 @@ class TokenUsage:
     completion_tokens: int
     total_tokens: int
 
+    def __add__(self, other: TokenUsage) -> TokenUsage:
+        """Combine two TokenUsage instances."""
+        return TokenUsage(
+            prompt_tokens=self.prompt_tokens + other.prompt_tokens,
+            completion_tokens=self.completion_tokens + other.completion_tokens,
+            total_tokens=self.total_tokens + other.total_tokens,
+        )
+
 
 @dataclass
 class Message:

--- a/tests/unit/test_agent_core.py
+++ b/tests/unit/test_agent_core.py
@@ -1,0 +1,354 @@
+"""Unit tests for the agent core ReAct loop.
+
+All tests use mocked LLM, ToolRegistry, and Sandbox to isolate
+the loop logic from external dependencies.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent_forge.agent.core import react_loop
+from agent_forge.agent.models import AgentConfig, AgentRun, RunState
+from agent_forge.agent.prompts import build_system_prompt
+from agent_forge.llm.base import (
+    LLMResponse,
+    Role,
+    TokenUsage,
+    ToolCall,
+    ToolDefinition,
+)
+from agent_forge.tools.base import ToolResult
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_run(**overrides: object) -> AgentRun:
+    """Create an AgentRun with sensible defaults."""
+    kwargs: dict[str, object] = {
+        "task": "Add input validation",
+        "repo_path": "/tmp/test-repo",
+        "config": AgentConfig(max_iterations=5, max_tokens_per_run=10_000),
+    }
+    kwargs.update(overrides)
+    return AgentRun(**kwargs)  # type: ignore[arg-type]
+
+
+def _mock_tools() -> MagicMock:
+    """Create a mock ToolRegistry with a single 'read_file' tool."""
+    registry = MagicMock()
+    registry.list_definitions.return_value = [
+        ToolDefinition(
+            name="read_file",
+            description="Read a file",
+            parameters={"type": "object", "properties": {"path": {"type": "string"}}},
+        ),
+    ]
+    tool = AsyncMock()
+    tool.execute.return_value = ToolResult(output="file content", exit_code=0)
+    registry.get.return_value = tool
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestReactLoopCompletion:
+    """LLM returns stop with no tool calls → COMPLETED."""
+
+    @pytest.mark.asyncio
+    async def test_completes_in_one_iteration(self) -> None:
+        run = _make_run()
+        llm = AsyncMock()
+        llm.complete.return_value = LLMResponse(
+            content="Done! I've completed the task.",
+            tool_calls=[],
+            usage=TokenUsage(100, 50, 150),
+            finish_reason="stop",
+        )
+        tools = _mock_tools()
+        sandbox = AsyncMock()
+
+        result = await react_loop(run, llm, tools, sandbox)
+
+        assert result.state == RunState.COMPLETED
+        assert result.iterations == 1
+        assert result.total_tokens.total_tokens == 150
+        assert result.completed_at is not None
+        assert result.error is None
+
+
+class TestReactLoopToolExecution:
+    """LLM requests tools → tools execute → results fed back."""
+
+    @pytest.mark.asyncio
+    async def test_tool_round_trip(self) -> None:
+        run = _make_run()
+        llm = AsyncMock()
+
+        # Iteration 1: LLM requests read_file
+        # Iteration 2: LLM completes
+        llm.complete.side_effect = [
+            LLMResponse(
+                content="Let me read the file first.",
+                tool_calls=[
+                    ToolCall(id="call_1", name="read_file", arguments={"path": "main.py"}),
+                ],
+                usage=TokenUsage(100, 50, 150),
+                finish_reason="tool_calls",
+            ),
+            LLMResponse(
+                content="Task complete.",
+                tool_calls=[],
+                usage=TokenUsage(200, 100, 300),
+                finish_reason="stop",
+            ),
+        ]
+        tools = _mock_tools()
+        sandbox = AsyncMock()
+
+        result = await react_loop(run, llm, tools, sandbox)
+
+        assert result.state == RunState.COMPLETED
+        assert result.iterations == 2
+        assert len(result.tool_invocations) == 1
+        assert result.tool_invocations[0].tool_name == "read_file"
+        assert result.total_tokens.total_tokens == 450
+
+        # Verify tool result was appended as a TOOL message
+        tool_messages = [m for m in result.messages if m.role == Role.TOOL]
+        assert len(tool_messages) == 1
+        assert "file content" in tool_messages[0].content
+
+    @pytest.mark.asyncio
+    async def test_multiple_tool_calls_in_one_iteration(self) -> None:
+        run = _make_run()
+        llm = AsyncMock()
+        llm.complete.side_effect = [
+            LLMResponse(
+                content="Reading two files.",
+                tool_calls=[
+                    ToolCall(id="call_1", name="read_file", arguments={"path": "a.py"}),
+                    ToolCall(id="call_2", name="read_file", arguments={"path": "b.py"}),
+                ],
+                usage=TokenUsage(100, 50, 150),
+                finish_reason="tool_calls",
+            ),
+            LLMResponse(
+                content="Done.",
+                tool_calls=[],
+                usage=TokenUsage(200, 100, 300),
+                finish_reason="stop",
+            ),
+        ]
+        tools = _mock_tools()
+        sandbox = AsyncMock()
+
+        result = await react_loop(run, llm, tools, sandbox)
+
+        assert result.state == RunState.COMPLETED
+        assert len(result.tool_invocations) == 2
+
+
+class TestReactLoopTermination:
+    """Various termination conditions."""
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_timeout(self) -> None:
+        run = _make_run(config=AgentConfig(max_iterations=2, max_tokens_per_run=100_000))
+        llm = AsyncMock()
+        # LLM always requests a tool — never stops
+        llm.complete.return_value = LLMResponse(
+            content="Working...",
+            tool_calls=[
+                ToolCall(id="call_x", name="read_file", arguments={"path": "f.py"}),
+            ],
+            usage=TokenUsage(10, 10, 20),
+            finish_reason="tool_calls",
+        )
+        tools = _mock_tools()
+        sandbox = AsyncMock()
+
+        result = await react_loop(run, llm, tools, sandbox)
+
+        assert result.state == RunState.TIMEOUT
+        assert result.iterations == 2
+        assert "Max iterations" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_token_budget_exceeded(self) -> None:
+        run = _make_run(config=AgentConfig(max_iterations=10, max_tokens_per_run=100))
+        llm = AsyncMock()
+        llm.complete.return_value = LLMResponse(
+            content="Working...",
+            tool_calls=[
+                ToolCall(id="call_x", name="read_file", arguments={"path": "f.py"}),
+            ],
+            usage=TokenUsage(50, 60, 110),  # Exceeds budget of 100
+            finish_reason="tool_calls",
+        )
+        tools = _mock_tools()
+        sandbox = AsyncMock()
+
+        result = await react_loop(run, llm, tools, sandbox)
+
+        assert result.state == RunState.TIMEOUT
+        assert "budget" in (result.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_unrecoverable_error(self) -> None:
+        run = _make_run()
+        llm = AsyncMock()
+        llm.complete.side_effect = RuntimeError("API connection lost")
+        tools = _mock_tools()
+        sandbox = AsyncMock()
+
+        result = await react_loop(run, llm, tools, sandbox)
+
+        assert result.state == RunState.FAILED
+        assert "API connection lost" in (result.error or "")
+        assert result.completed_at is not None
+
+
+class TestReactLoopMalformedCalls:
+    """Unknown tool → error injected, LLM self-corrects."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_self_corrects(self) -> None:
+
+        run = _make_run()
+        llm = AsyncMock()
+
+        # Iteration 1: LLM requests unknown tool
+        # Iteration 2: LLM self-corrects and completes
+        llm.complete.side_effect = [
+            LLMResponse(
+                content="Trying to use a tool.",
+                tool_calls=[
+                    ToolCall(id="call_bad", name="nonexistent_tool", arguments={}),
+                ],
+                usage=TokenUsage(100, 50, 150),
+                finish_reason="tool_calls",
+            ),
+            LLMResponse(
+                content="I see, let me use the correct tool.",
+                tool_calls=[],
+                usage=TokenUsage(100, 50, 150),
+                finish_reason="stop",
+            ),
+        ]
+
+        tools = _mock_tools()
+        tools.get.side_effect = [
+            KeyError("Unknown tool: nonexistent_tool"),  # First call fails
+        ]
+        sandbox = AsyncMock()
+
+        result = await react_loop(run, llm, tools, sandbox)
+
+        assert result.state == RunState.COMPLETED
+        assert result.iterations == 2
+
+        # Error message was injected as a TOOL message
+        tool_messages = [m for m in result.messages if m.role == Role.TOOL]
+        assert len(tool_messages) == 1
+        assert "Unknown tool" in tool_messages[0].content
+
+        # Tool invocation was still recorded
+        assert len(result.tool_invocations) == 1
+        assert result.tool_invocations[0].tool_name == "nonexistent_tool"
+
+
+class TestReactLoopTokenAccumulation:
+    """Tokens accumulate correctly across iterations."""
+
+    @pytest.mark.asyncio
+    async def test_tokens_accumulate(self) -> None:
+        run = _make_run(config=AgentConfig(max_iterations=5, max_tokens_per_run=100_000))
+        llm = AsyncMock()
+
+        llm.complete.side_effect = [
+            LLMResponse(
+                content="Step 1.",
+                tool_calls=[
+                    ToolCall(id="c1", name="read_file", arguments={"path": "a.py"}),
+                ],
+                usage=TokenUsage(100, 50, 150),
+                finish_reason="tool_calls",
+            ),
+            LLMResponse(
+                content="Step 2.",
+                tool_calls=[
+                    ToolCall(id="c2", name="read_file", arguments={"path": "b.py"}),
+                ],
+                usage=TokenUsage(200, 100, 300),
+                finish_reason="tool_calls",
+            ),
+            LLMResponse(
+                content="Done.",
+                tool_calls=[],
+                usage=TokenUsage(150, 75, 225),
+                finish_reason="stop",
+            ),
+        ]
+        tools = _mock_tools()
+        sandbox = AsyncMock()
+
+        result = await react_loop(run, llm, tools, sandbox)
+
+        assert result.state == RunState.COMPLETED
+        assert result.total_tokens.prompt_tokens == 450
+        assert result.total_tokens.completion_tokens == 225
+        assert result.total_tokens.total_tokens == 675
+
+
+class TestBuildSystemPrompt:
+    """System prompt renders correctly."""
+
+    def test_includes_tool_descriptions(self) -> None:
+        prompt = build_system_prompt(
+            task="Fix the bug",
+            tool_definitions=[
+                ToolDefinition(
+                    name="read_file",
+                    description="Read a file",
+                    parameters={
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                    },
+                ),
+            ],
+        )
+
+        assert "Agent Forge" in prompt
+        assert "read_file" in prompt
+        assert "Fix the bug" in prompt
+        assert "/workspace" in prompt
+
+    def test_empty_tools(self) -> None:
+        prompt = build_system_prompt(task="Do something", tool_definitions=[])
+        assert "Agent Forge" in prompt
+        assert "Do something" in prompt
+
+
+class TestTokenUsageAdd:
+    """TokenUsage addition."""
+
+    def test_add(self) -> None:
+        a = TokenUsage(10, 20, 30)
+        b = TokenUsage(5, 15, 20)
+        c = a + b
+        assert c.prompt_tokens == 15
+        assert c.completion_tokens == 35
+        assert c.total_tokens == 50
+
+    def test_iadd(self) -> None:
+        a = TokenUsage(10, 20, 30)
+        a = a + TokenUsage(5, 15, 20)
+        assert a.total_tokens == 50


### PR DESCRIPTION
## Summary

Implement the ReAct (Reasoning + Acting) loop per spec §4.4.

### Changes

- **`agent/models.py`** — `RunState` (6 states), `AgentConfig`, `ToolInvocation`, `AgentRun` dataclasses
- **`agent/prompts.py`** — `build_system_prompt()` renders tool descriptions + task
- **`agent/core.py`** — `react_loop()`: Observe → Reason (LLM) → Act (Tool) → Repeat
- **`llm/base.py`** — `TokenUsage.__add__` for token accumulation
- **`agent/__init__.py`** — public exports
- **`Makefile`** — exclude integration tests from `make test`

### Termination Conditions

| Condition | State |
|-----------|-------|
| LLM returns no tool calls + stop | COMPLETED |
| Max iterations reached | TIMEOUT |
| Token budget exceeded | TIMEOUT |
| Unrecoverable error | FAILED |
| Unknown tool requested | Error injected, LLM self-corrects |

### Tests

- 12 new unit tests with mocked LLM + tools (130 total)
- ✅ `make lint` — ruff + mypy clean
- ✅ `make test` — 130 passed, 8 deselected

Closes #7