### PR TITLE
fix: resolve CI integration test permission errors

### DIFF
--- a/agent_forge/sandbox/docker.py
+++ b/agent_forge/sandbox/docker.py
@@ -88,10 +88,22 @@ class DockerSandbox(Sandbox):
         if not cfg.network_enabled:
             run_kwargs["network_mode"] = "none"
 
+        # Start as root so we can fix bind-mount permissions, then exec as 'agent'
+        run_kwargs["user"] = "root"
+
         try:
             self._container = await asyncio.to_thread(
                 lambda: self._client.containers.run(**run_kwargs)
             )
+
+            # Fix ownership of bind-mounted workspace (host UID may differ
+            # from container's 'agent' user).
+            await asyncio.to_thread(
+                self._container.exec_run,  # type: ignore[union-attr]
+                "chown -R agent:agent /workspace",
+                user="root",
+            )
+
             self._state = SandboxState.RUNNING
             logger.info(
                 "Sandbox started: container=%s, image=%s",
@@ -153,6 +165,7 @@ class DockerSandbox(Sandbox):
                     self._container.exec_run,
                     ["bash", "-c", command],
                     demux=True,
+                    user="agent",
                 ),
                 timeout=timeout_seconds,
             )

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -63,6 +63,7 @@ class TestSandboxLifecycle:
             assert call_kwargs["pids_limit"] == 256
             assert "/tmp" in call_kwargs["tmpfs"]
             assert call_kwargs["network_mode"] == "none"
+            assert call_kwargs["user"] == "root"  # starts as root for chown
 
     @pytest.mark.asyncio
     async def test_start_with_custom_config(self, mock_docker_client: MagicMock) -> None:
@@ -145,7 +146,11 @@ class TestSandboxExec:
             assert result.exit_code == 0
             assert result.stdout == "hello"
             container = mock_docker_client.containers.run.return_value
-            container.exec_run.assert_called_once_with(["bash", "-c", "echo hello"], demux=True)
+            # First exec_run call is chown during start(); second is our command
+            assert container.exec_run.call_count == 2
+            container.exec_run.assert_called_with(
+                ["bash", "-c", "echo hello"], demux=True, user="agent",
+            )
 
     @pytest.mark.asyncio
     async def test_exec_with_stderr(self, mock_docker_client: MagicMock) -> None:
@@ -216,7 +221,8 @@ class TestSandboxFileOps:
 
             await sandbox.write_file("/workspace/new.py", "print('hi')")
             # Should have called exec at least twice (mkdir -p + write)
-            assert container.exec_run.call_count >= 2
+            # 1 chown during start + 1 mkdir + 1 write = at least 3
+            assert container.exec_run.call_count >= 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix integration test permission errors in CI. Docker container's bind-mounted `/workspace` was inaccessible to the `agent` user due to UID mismatch with the GitHub Actions runner.

### Changes

- **`docker.py`**: Start container as `root`, `chown -R agent:agent /workspace` after start, exec commands with `user="agent"`
- **`test_sandbox.py`**: Updated assertions for new permission model (chown during start, user param in exec)
- **`Makefile`**: Exclude `@pytest.mark.integration` from `make test` (integration tests have `make test-integration`)

### Root Cause

GitHub Actions runner creates temp dirs owned by `runner` (UID 1001). Dockerfile creates `agent` (UID 1000). Bind mount overrides Dockerfile `chown`, so `agent` can't access `/workspace`.