### PR TITLE
feat(#8): state machine for run lifecycle with persistence

### DIFF
--- a/agent_forge/agent/__init__.py
+++ b/agent_forge/agent/__init__.py
@@ -2,13 +2,19 @@
 
 from agent_forge.agent.core import react_loop
 from agent_forge.agent.models import AgentConfig, AgentRun, RunState, ToolInvocation
+from agent_forge.agent.persistence import load_run, save_run
 from agent_forge.agent.prompts import build_system_prompt
+from agent_forge.agent.state import InvalidStateTransitionError, transition
 
 __all__ = [
     "AgentConfig",
     "AgentRun",
+    "InvalidStateTransitionError",
     "RunState",
     "ToolInvocation",
     "build_system_prompt",
+    "load_run",
     "react_loop",
+    "save_run",
+    "transition",
 ]

--- a/agent_forge/agent/core.py
+++ b/agent_forge/agent/core.py
@@ -7,7 +7,9 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from agent_forge.agent.models import AgentRun, RunState, ToolInvocation
+from agent_forge.agent.persistence import save_run
 from agent_forge.agent.prompts import build_system_prompt
+from agent_forge.agent.state import transition
 from agent_forge.llm.base import LLMConfig, Message, Role
 
 if TYPE_CHECKING:
@@ -32,7 +34,7 @@ async def react_loop(
     - Token budget exceeded (→ TIMEOUT)
     - Unrecoverable error (→ FAILED)
     """
-    run.state = RunState.RUNNING
+    transition(run, RunState.RUNNING)
 
     # Build system prompt from task + tool definitions
     system_content = run.config.system_prompt or build_system_prompt(
@@ -63,14 +65,14 @@ async def react_loop(
             # 2. CHECK BUDGET
             if run.total_tokens.total_tokens > run.config.max_tokens_per_run:
                 logger.warning("Token budget exceeded: %d", run.total_tokens.total_tokens)
-                run.state = RunState.TIMEOUT
+                transition(run, RunState.TIMEOUT)
                 run.error = "Token budget exceeded"
                 break
 
             # 3. CHECK COMPLETION
             if response.finish_reason == "stop" and not response.tool_calls:
                 run.messages.append(Message(role=Role.ASSISTANT, content=response.content or ""))
-                run.state = RunState.COMPLETED
+                transition(run, RunState.COMPLETED)
                 break
 
             # 4. ACT — execute each tool call
@@ -88,15 +90,16 @@ async def react_loop(
         else:
             # Loop exhausted without breaking → max iterations
             logger.warning("Max iterations reached: %d", run.config.max_iterations)
-            run.state = RunState.TIMEOUT
+            transition(run, RunState.TIMEOUT)
             run.error = "Max iterations reached"
 
     except Exception as exc:
         logger.exception("Unrecoverable error during agent run")
-        run.state = RunState.FAILED
+        transition(run, RunState.FAILED)
         run.error = str(exc)
 
     run.completed_at = datetime.now(UTC)
+    save_run(run)
     return run
 
 

--- a/agent_forge/agent/persistence.py
+++ b/agent_forge/agent/persistence.py
@@ -1,0 +1,178 @@
+"""Run persistence — save and load AgentRun state to disk.
+
+Persists runs under ~/.agent-forge/runs/<run_id>/:
+  - run.json        — metadata (state, config, timestamps, tokens, error)
+  - messages.jsonl  — conversation history (one JSON line per message)
+  - events.jsonl    — tool invocations (one JSON line per invocation)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from agent_forge.agent.models import AgentConfig, AgentRun, RunState, ToolInvocation
+from agent_forge.config import USER_CONFIG_DIR
+from agent_forge.llm.base import Message, Role, TokenUsage, ToolCall
+
+
+def _default_runs_dir() -> Path:
+    """Return the default runs directory (~/.agent-forge/runs)."""
+    return USER_CONFIG_DIR / "runs"
+
+
+def save_run(run: AgentRun, *, base_dir: Path | None = None) -> Path:
+    """Persist an AgentRun to disk.
+
+    Returns the run directory path.
+    """
+    runs_dir = base_dir or _default_runs_dir()
+    run_dir = runs_dir / run.id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── run.json ──────────────────────────────────────────────────
+    run_meta = {
+        "id": run.id,
+        "task": run.task,
+        "repo_path": run.repo_path,
+        "state": run.state.value,
+        "iterations": run.iterations,
+        "total_tokens": {
+            "prompt_tokens": run.total_tokens.prompt_tokens,
+            "completion_tokens": run.total_tokens.completion_tokens,
+            "total_tokens": run.total_tokens.total_tokens,
+        },
+        "config": asdict(run.config),
+        "created_at": run.created_at.isoformat(),
+        "completed_at": run.completed_at.isoformat() if run.completed_at else None,
+        "error": run.error,
+    }
+    (run_dir / "run.json").write_text(json.dumps(run_meta, indent=2) + "\n")
+
+    # ── messages.jsonl ────────────────────────────────────────────
+    with (run_dir / "messages.jsonl").open("w") as f:
+        for msg in run.messages:
+            line: dict[str, Any] = {
+                "role": msg.role.value,
+                "content": msg.content,
+            }
+            if msg.tool_call_id:
+                line["tool_call_id"] = msg.tool_call_id
+            if msg.tool_calls:
+                line["tool_calls"] = [asdict(tc) for tc in msg.tool_calls]
+            f.write(json.dumps(line) + "\n")
+
+    # ── events.jsonl ──────────────────────────────────────────────
+    with (run_dir / "events.jsonl").open("w") as f:
+        for inv in run.tool_invocations:
+            line_ev: dict[str, Any] = {
+                "tool_name": inv.tool_name,
+                "arguments": inv.arguments,
+                "result": {
+                    "output": inv.result.output,
+                    "error": inv.result.error,
+                    "exit_code": inv.result.exit_code,
+                    "execution_time_ms": inv.result.execution_time_ms,
+                },
+                "iteration": inv.iteration,
+                "timestamp": inv.timestamp.isoformat(),
+                "duration_ms": inv.duration_ms,
+            }
+            f.write(json.dumps(line_ev) + "\n")
+
+    return run_dir
+
+
+def load_run(run_id: str, *, base_dir: Path | None = None) -> AgentRun:
+    """Load an AgentRun from disk.
+
+    Raises FileNotFoundError if the run directory doesn't exist.
+    """
+    from datetime import datetime
+
+    from agent_forge.tools.base import ToolResult
+
+    runs_dir = base_dir or _default_runs_dir()
+    run_dir = runs_dir / run_id
+
+    if not run_dir.exists():
+        msg = f"Run not found: {run_id}"
+        raise FileNotFoundError(msg)
+
+    # ── run.json ──────────────────────────────────────────────────
+    meta = json.loads((run_dir / "run.json").read_text())
+
+    # ── messages.jsonl ────────────────────────────────────────────
+    messages: list[Message] = []
+    messages_path = run_dir / "messages.jsonl"
+    if messages_path.exists():
+        for line in messages_path.read_text().strip().splitlines():
+            data = json.loads(line)
+            tool_calls = None
+            if "tool_calls" in data:
+                tool_calls = [
+                    ToolCall(
+                        id=tc["id"],
+                        name=tc["name"],
+                        arguments=tc["arguments"],
+                    )
+                    for tc in data["tool_calls"]
+                ]
+            messages.append(
+                Message(
+                    role=Role(data["role"]),
+                    content=data["content"],
+                    tool_call_id=data.get("tool_call_id"),
+                    tool_calls=tool_calls,
+                )
+            )
+
+    # ── events.jsonl ──────────────────────────────────────────────
+    invocations: list[ToolInvocation] = []
+    events_path = run_dir / "events.jsonl"
+    if events_path.exists():
+        for line in events_path.read_text().strip().splitlines():
+            data = json.loads(line)
+            invocations.append(
+                ToolInvocation(
+                    tool_name=data["tool_name"],
+                    arguments=data["arguments"],
+                    result=ToolResult(
+                        output=data["result"]["output"],
+                        error=data["result"].get("error"),
+                        exit_code=data["result"]["exit_code"],
+                        execution_time_ms=data["result"].get("execution_time_ms", 0),
+                    ),
+                    iteration=data["iteration"],
+                    timestamp=datetime.fromisoformat(data["timestamp"]),
+                    duration_ms=data["duration_ms"],
+                )
+            )
+
+    tokens = meta["total_tokens"]
+    completed_at = (
+        datetime.fromisoformat(meta["completed_at"]) if meta["completed_at"] else None
+    )
+
+    return AgentRun(
+        task=meta["task"],
+        repo_path=meta["repo_path"],
+        config=AgentConfig(**meta["config"]),
+        id=meta["id"],
+        state=RunState(meta["state"]),
+        messages=messages,
+        iterations=meta["iterations"],
+        total_tokens=TokenUsage(
+            prompt_tokens=tokens["prompt_tokens"],
+            completion_tokens=tokens["completion_tokens"],
+            total_tokens=tokens["total_tokens"],
+        ),
+        tool_invocations=invocations,
+        created_at=datetime.fromisoformat(meta["created_at"]),
+        completed_at=completed_at,
+        error=meta.get("error"),
+    )

--- a/agent_forge/agent/state.py
+++ b/agent_forge/agent/state.py
@@ -1,1 +1,50 @@
 """Run state machine — valid state transitions for AgentRun lifecycle."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from agent_forge.agent.models import RunState
+
+if TYPE_CHECKING:
+    from agent_forge.agent.models import AgentRun
+
+# ── Valid transition map ──────────────────────────────────────────────
+# PENDING  → RUNNING
+# RUNNING  → COMPLETED | FAILED | TIMEOUT | CANCELLED
+
+VALID_TRANSITIONS: dict[RunState, set[RunState]] = {
+    RunState.PENDING: {RunState.RUNNING},
+    RunState.RUNNING: {
+        RunState.COMPLETED,
+        RunState.FAILED,
+        RunState.TIMEOUT,
+        RunState.CANCELLED,
+    },
+    RunState.COMPLETED: set(),
+    RunState.FAILED: set(),
+    RunState.TIMEOUT: set(),
+    RunState.CANCELLED: set(),
+}
+
+
+class InvalidStateTransitionError(Exception):
+    """Raised when an invalid state transition is attempted."""
+
+    def __init__(self, current: RunState, target: RunState) -> None:
+        self.current = current
+        self.target = target
+        super().__init__(
+            f"Invalid state transition: {current.value} → {target.value}"
+        )
+
+
+def transition(run: AgentRun, new_state: RunState) -> None:
+    """Validate and apply a state transition on an AgentRun.
+
+    Raises InvalidStateTransitionError if the transition is not allowed.
+    """
+    allowed = VALID_TRANSITIONS.get(run.state, set())
+    if new_state not in allowed:
+        raise InvalidStateTransitionError(run.state, new_state)
+    run.state = new_state

--- a/agent_forge/config.py
+++ b/agent_forge/config.py
@@ -25,6 +25,7 @@ PROJECT_CONFIG_FILENAME = "agent-forge.toml"
 USER_CONFIG_DIR = Path.home() / ".agent-forge"
 USER_CONFIG_PATH = USER_CONFIG_DIR / "config.toml"
 ENV_PREFIX = "AGENT_FORGE"
+DEFAULT_SANDBOX_IMAGE = "agent-forge-sandbox:latest"
 
 
 class AgentSettings(BaseModel):
@@ -41,7 +42,7 @@ class AgentSettings(BaseModel):
 class SandboxSettings(BaseModel):
     """Settings for the Docker sandbox runtime."""
 
-    image: str = "agent-forge-sandbox:latest"
+    image: str = DEFAULT_SANDBOX_IMAGE
     cpu_limit: float = 1.0
     memory_limit: str = "512m"
     timeout_seconds: int = 300

--- a/tests/unit/test_state_machine.py
+++ b/tests/unit/test_state_machine.py
@@ -1,0 +1,257 @@
+"""Unit tests for the run state machine and persistence."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+
+from agent_forge.agent.models import AgentConfig, AgentRun, RunState, ToolInvocation
+from agent_forge.agent.persistence import load_run, save_run
+from agent_forge.agent.state import (
+    VALID_TRANSITIONS,
+    InvalidStateTransitionError,
+    transition,
+)
+from agent_forge.llm.base import Message, Role, TokenUsage, ToolCall
+from agent_forge.tools.base import ToolResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_run(**overrides: object) -> AgentRun:
+    kwargs: dict[str, object] = {
+        "task": "Fix the login bug",
+        "repo_path": "/tmp/test-repo",
+        "config": AgentConfig(),
+    }
+    kwargs.update(overrides)
+    return AgentRun(**kwargs)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# State Machine
+# ---------------------------------------------------------------------------
+
+
+class TestValidTransitions:
+    """All valid transitions should succeed."""
+
+    def test_pending_to_running(self) -> None:
+        run = _make_run()
+        assert run.state == RunState.PENDING
+        transition(run, RunState.RUNNING)
+        assert run.state == RunState.RUNNING
+
+    def test_running_to_completed(self) -> None:
+        run = _make_run()
+        transition(run, RunState.RUNNING)
+        transition(run, RunState.COMPLETED)
+        assert run.state == RunState.COMPLETED
+
+    def test_running_to_failed(self) -> None:
+        run = _make_run()
+        transition(run, RunState.RUNNING)
+        transition(run, RunState.FAILED)
+        assert run.state == RunState.FAILED
+
+    def test_running_to_timeout(self) -> None:
+        run = _make_run()
+        transition(run, RunState.RUNNING)
+        transition(run, RunState.TIMEOUT)
+        assert run.state == RunState.TIMEOUT
+
+    def test_running_to_cancelled(self) -> None:
+        run = _make_run()
+        transition(run, RunState.RUNNING)
+        transition(run, RunState.CANCELLED)
+        assert run.state == RunState.CANCELLED
+
+
+class TestInvalidTransitions:
+    """Invalid transitions should raise InvalidStateTransitionError."""
+
+    def test_pending_to_completed(self) -> None:
+        run = _make_run()
+        with pytest.raises(InvalidStateTransitionError, match="pending → completed"):
+            transition(run, RunState.COMPLETED)
+
+    def test_pending_to_failed(self) -> None:
+        run = _make_run()
+        with pytest.raises(InvalidStateTransitionError):
+            transition(run, RunState.FAILED)
+
+    def test_completed_to_running(self) -> None:
+        run = _make_run()
+        transition(run, RunState.RUNNING)
+        transition(run, RunState.COMPLETED)
+        with pytest.raises(InvalidStateTransitionError, match="completed → running"):
+            transition(run, RunState.RUNNING)
+
+    def test_failed_to_running(self) -> None:
+        run = _make_run()
+        transition(run, RunState.RUNNING)
+        transition(run, RunState.FAILED)
+        with pytest.raises(InvalidStateTransitionError):
+            transition(run, RunState.RUNNING)
+
+    def test_timeout_to_completed(self) -> None:
+        run = _make_run()
+        transition(run, RunState.RUNNING)
+        transition(run, RunState.TIMEOUT)
+        with pytest.raises(InvalidStateTransitionError):
+            transition(run, RunState.COMPLETED)
+
+    def test_cancelled_is_terminal(self) -> None:
+        run = _make_run()
+        transition(run, RunState.RUNNING)
+        transition(run, RunState.CANCELLED)
+        with pytest.raises(InvalidStateTransitionError):
+            transition(run, RunState.RUNNING)
+
+
+class TestTransitionMap:
+    """The VALID_TRANSITIONS map covers all RunState values."""
+
+    def test_all_states_covered(self) -> None:
+        for state in RunState:
+            assert state in VALID_TRANSITIONS
+
+    def test_terminal_states_have_no_transitions(self) -> None:
+        for state in [RunState.COMPLETED, RunState.FAILED, RunState.TIMEOUT, RunState.CANCELLED]:
+            assert VALID_TRANSITIONS[state] == set()
+
+
+class TestInvalidStateTransitionError:
+    """Error carries current and target state."""
+
+    def test_attributes(self) -> None:
+        err = InvalidStateTransitionError(RunState.COMPLETED, RunState.RUNNING)
+        assert err.current == RunState.COMPLETED
+        assert err.target == RunState.RUNNING
+        assert "completed → running" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+class TestSaveAndLoadRun:
+    """Round-trip: save_run → load_run produces equivalent AgentRun."""
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        run = _make_run()
+        run.state = RunState.COMPLETED  # direct set for test setup
+        run.iterations = 3
+        run.total_tokens = TokenUsage(100, 50, 150)
+        run.completed_at = datetime.now(UTC)
+        run.error = None
+        run.messages = [
+            Message(role=Role.SYSTEM, content="You are an agent."),
+            Message(role=Role.USER, content="Fix the bug"),
+            Message(
+                role=Role.ASSISTANT,
+                content="Reading file.",
+                tool_calls=[ToolCall(id="c1", name="read_file", arguments={"path": "x.py"})],
+            ),
+            Message(role=Role.TOOL, content="file content", tool_call_id="c1"),
+        ]
+        run.tool_invocations = [
+            ToolInvocation(
+                tool_name="read_file",
+                arguments={"path": "x.py"},
+                result=ToolResult(output="file content", exit_code=0),
+                iteration=1,
+                timestamp=datetime.now(UTC),
+                duration_ms=42,
+            ),
+        ]
+
+        run_dir = save_run(run, base_dir=tmp_path)
+        assert (run_dir / "run.json").exists()
+        assert (run_dir / "messages.jsonl").exists()
+        assert (run_dir / "events.jsonl").exists()
+
+        loaded = load_run(run.id, base_dir=tmp_path)
+        assert loaded.id == run.id
+        assert loaded.task == run.task
+        assert loaded.state == RunState.COMPLETED
+        assert loaded.iterations == 3
+        assert loaded.total_tokens.total_tokens == 150
+        assert len(loaded.messages) == 4
+        assert loaded.messages[0].role == Role.SYSTEM
+        assert loaded.messages[2].tool_calls is not None
+        assert loaded.messages[2].tool_calls[0].name == "read_file"
+        assert len(loaded.tool_invocations) == 1
+        assert loaded.tool_invocations[0].tool_name == "read_file"
+        assert loaded.tool_invocations[0].duration_ms == 42
+
+    def test_load_nonexistent_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="Run not found"):
+            load_run("nonexistent-id", base_dir=tmp_path)
+
+
+class TestPersistenceFiles:
+    """File content matches expected format."""
+
+    def test_run_json_structure(self, tmp_path: Path) -> None:
+        run = _make_run()
+        run.state = RunState.COMPLETED
+        save_run(run, base_dir=tmp_path)
+
+        meta = json.loads((tmp_path / run.id / "run.json").read_text())
+        assert meta["id"] == run.id
+        assert meta["state"] == "completed"
+        assert "total_tokens" in meta
+        assert "config" in meta
+
+    def test_messages_jsonl_format(self, tmp_path: Path) -> None:
+        run = _make_run()
+        run.state = RunState.COMPLETED
+        run.messages = [
+            Message(role=Role.USER, content="hello"),
+            Message(role=Role.ASSISTANT, content="hi"),
+        ]
+        save_run(run, base_dir=tmp_path)
+
+        lines = (tmp_path / run.id / "messages.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["role"] == "user"
+        assert json.loads(lines[1])["content"] == "hi"
+
+    def test_events_jsonl_format(self, tmp_path: Path) -> None:
+        run = _make_run()
+        run.state = RunState.COMPLETED
+        run.tool_invocations = [
+            ToolInvocation(
+                tool_name="run_shell",
+                arguments={"command": "ls"},
+                result=ToolResult(output="file.py", exit_code=0),
+                iteration=1,
+                timestamp=datetime.now(UTC),
+                duration_ms=10,
+            ),
+        ]
+        save_run(run, base_dir=tmp_path)
+
+        lines = (tmp_path / run.id / "events.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["tool_name"] == "run_shell"
+        assert data["result"]["exit_code"] == 0
+
+    def test_empty_messages_and_events(self, tmp_path: Path) -> None:
+        run = _make_run()
+        run.state = RunState.COMPLETED
+        save_run(run, base_dir=tmp_path)
+
+        assert (tmp_path / run.id / "messages.jsonl").read_text() == ""
+        assert (tmp_path / run.id / "events.jsonl").read_text() == ""


### PR DESCRIPTION
## Summary

Implement the run lifecycle state machine and persistence per spec §4.5 and §5.2.

### Changes

| File | What |
|------|------|
| `agent/state.py` | `VALID_TRANSITIONS` map, `InvalidStateTransitionError`, `transition(run, state)` |
| `agent/persistence.py` | `save_run()` → run.json + messages.jsonl + events.jsonl; `load_run()` round-trip |
| `agent/core.py` | Uses `transition()` for validated state changes + `save_run()` at end |
| `agent/__init__.py` | Exports: `transition`, `InvalidStateTransitionError`, `save_run`, `load_run` |
| `config.py` | Added `DEFAULT_SANDBOX_IMAGE` constant; persistence uses `USER_CONFIG_DIR` |

### State Machine

```
PENDING → RUNNING → COMPLETED
                   → FAILED
                   → TIMEOUT
                   → CANCELLED
```

Invalid transitions (e.g., COMPLETED→RUNNING) raise `InvalidStateTransitionError`.

### Persistence

```
~/.agent-forge/runs/<run_id>/
├── run.json         # metadata (state, config, timestamps, tokens)
├── messages.jsonl   # conversation history
└── events.jsonl     # tool invocations
```

### Tests

- 20 new tests (5 valid transitions, 6 invalid, map coverage, error attrs, persistence round-trip, file format)
- ✅ `make lint` clean, ✅ 150 passed, 8 deselected

Closes #8