### PR TITLE
feat(#9): Click CLI with run, status, list, config + e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,31 @@
+name: E2E Tests
+
+on:
+  workflow_dispatch: # Manual trigger only — prevents automated API cost
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E Tests (Real LLM)
+    if: github.actor == 'akoita' # Owner-only guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Build sandbox Docker image
+        run: make build-sandbox
+
+      - name: Run e2e tests
+        run: make test-e2e
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup build-sandbox test test-unit test-integration lint format run clean
+.PHONY: setup build-sandbox test test-unit test-integration test-e2e lint format run clean
 
 setup:                     ## Install dependencies
 	pip install -e ".[dev,redis]"
@@ -6,14 +6,17 @@ setup:                     ## Install dependencies
 build-sandbox:             ## Build the sandbox Docker image
 	docker build -t agent-forge-sandbox:latest -f agent_forge/sandbox/Dockerfile .
 
-test:                      ## Run all tests (excludes integration — use test-integration)
-	pytest --cov=agent_forge --cov-report=term-missing -m "not integration"
+test:                      ## Run all tests (excludes integration + e2e)
+	pytest --cov=agent_forge --cov-report=term-missing -m "not integration and not e2e"
 
 test-unit:                 ## Run unit tests only
 	pytest tests/unit -v
 
 test-integration:          ## Run integration tests (requires Docker)
 	pytest tests/integration -v
+
+test-e2e:                  ## Run e2e tests (requires GEMINI_API_KEY + Docker)
+	pytest tests/e2e -v -m e2e
 
 lint:                      ## Run linters
 	ruff check agent_forge tests

--- a/agent_forge/cli.py
+++ b/agent_forge/cli.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import os
+import sys
 from typing import Any
 
 import click
+from rich.console import Console
+from rich.json import JSON
+from rich.panel import Panel
+from rich.table import Table
 
-from agent_forge.config import load_config
+from agent_forge.config import USER_CONFIG_DIR, load_config
+
+console = Console()
+err_console = Console(stderr=True)
 
 
 @click.group()
 @click.version_option(package_name="agent-forge")
 def main() -> None:
     """Agent Forge — Sandboxed AI coding agent runtime."""
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
 
 
 @main.command()
@@ -38,20 +54,204 @@ def run(
     if max_iterations is not None:
         cli_overrides["agent.max_iterations"] = max_iterations
 
-    config = load_config(cli_overrides=cli_overrides or None)
+    cfg = load_config(cli_overrides=cli_overrides or None)
 
-    click.echo(f"Task:     {task}")
-    click.echo(f"Repo:     {repo}")
-    click.echo(f"Provider: {config.agent.default_provider}")
-    click.echo(f"Model:    {config.agent.default_model}")
-    click.echo("Agent Forge is not yet implemented. See spec.md for details.")
+    # Resolve API key
+    provider_name = cfg.agent.default_provider
+    provider_cfg = cfg.providers.get(provider_name)
+    if provider_cfg is None:
+        err_console.print(
+            f"[red]Unknown provider:[/red] '{provider_name}'. "
+            f"Available: {', '.join(cfg.providers)}"
+        )
+        sys.exit(1)
+
+    api_key = os.environ.get(provider_cfg.api_key_env, "")
+    if not api_key:
+        err_console.print(
+            f"[red]Missing API key:[/red] set [bold]{provider_cfg.api_key_env}[/bold] "
+            f"environment variable for provider '{provider_name}'"
+        )
+        sys.exit(1)
+
+    asyncio.run(_run_agent(task, repo, cfg, provider_name, api_key))
+
+
+async def _run_agent(
+    task: str,
+    repo: str,
+    cfg: Any,
+    provider_name: str,
+    api_key: str,
+) -> None:
+    """Execute the full agent pipeline."""
+    from agent_forge.agent.core import react_loop
+    from agent_forge.agent.models import AgentConfig, AgentRun
+    from agent_forge.llm.gemini import GeminiProvider
+    from agent_forge.sandbox.docker import DockerSandbox
+    from agent_forge.tools import create_default_registry
+
+    # Build agent config from resolved settings
+    agent_config = AgentConfig(
+        model=cfg.agent.default_model,
+        max_iterations=cfg.agent.max_iterations,
+        max_tokens_per_run=cfg.agent.max_tokens_per_run,
+        temperature=cfg.agent.temperature,
+    )
+
+    agent_run = AgentRun(task=task, repo_path=repo, config=agent_config)
+
+    # Create LLM provider
+    if provider_name == "gemini":
+        llm = GeminiProvider(api_key=api_key)
+    else:
+        err_console.print(
+            f"[red]Provider '{provider_name}' not yet implemented.[/red] "
+            "Only 'gemini' is available."
+        )
+        sys.exit(1)
+
+    # Create tools and sandbox
+    tools = create_default_registry()
+    sandbox = DockerSandbox()
+
+    with console.status("[bold green]Agent running...", spinner="dots"):
+        try:
+            await sandbox.start(repo_path=repo)
+            result = await react_loop(agent_run, llm, tools, sandbox)
+        except Exception as exc:
+            err_console.print(f"[red]Agent failed:[/red] {exc}")
+            sys.exit(1)
+        finally:
+            await sandbox.stop()
+            await llm.close()
+
+    # Display results
+    _display_run_summary(result)
+
+
+def _display_run_summary(run: Any) -> None:
+    """Display a rich summary panel for a completed agent run."""
+    state_color = {
+        "completed": "green",
+        "failed": "red",
+        "timeout": "yellow",
+        "cancelled": "dim",
+    }.get(run.state.value, "white")
+
+    table = Table(show_header=False, padding=(0, 2))
+    table.add_column("Key", style="bold")
+    table.add_column("Value")
+    table.add_row("Run ID", run.id)
+    table.add_row("State", f"[{state_color}]{run.state.value}[/{state_color}]")
+    table.add_row("Task", run.task[:80] + ("..." if len(run.task) > 80 else ""))
+    table.add_row("Iterations", str(run.iterations))
+    table.add_row("Tokens", f"{run.total_tokens.total_tokens:,}")
+    if run.completed_at:
+        elapsed = (run.completed_at - run.created_at).total_seconds()
+        table.add_row("Duration", f"{elapsed:.1f}s")
+    if run.error:
+        table.add_row("Error", f"[red]{run.error}[/red]")
+
+    console.print(Panel(table, title="[bold]Agent Run Complete", border_style=state_color))
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+@main.command()
+@click.argument("run_id")
+def status(run_id: str) -> None:
+    """Show the status and summary of a specific run."""
+    from agent_forge.agent.persistence import load_run
+
+    try:
+        agent_run = load_run(run_id)
+    except FileNotFoundError:
+        err_console.print(f"[red]Run not found:[/red] {run_id}")
+        sys.exit(1)
+
+    _display_run_summary(agent_run)
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+@main.command("list")
+def list_runs() -> None:
+    """List recent agent runs."""
+    runs_dir = USER_CONFIG_DIR / "runs"
+
+    if not runs_dir.exists():
+        console.print("[dim]No runs found yet.[/dim]")
+        return
+
+    run_dirs = sorted(runs_dir.iterdir(), reverse=True)
+    if not run_dirs:
+        console.print("[dim]No runs found yet.[/dim]")
+        return
+
+    table = Table(title="Recent Runs")
+    table.add_column("Run ID", style="cyan", max_width=36)
+    table.add_column("State", justify="center")
+    table.add_column("Task", max_width=50)
+    table.add_column("Iterations", justify="right")
+    table.add_column("Created")
+
+    for run_dir in run_dirs[:20]:  # Show last 20
+        run_json = run_dir / "run.json"
+        if not run_json.exists():
+            continue
+        try:
+            meta = json.loads(run_json.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        state = meta.get("state", "unknown")
+        state_color = {
+            "completed": "green",
+            "failed": "red",
+            "timeout": "yellow",
+            "cancelled": "dim",
+            "running": "blue",
+            "pending": "white",
+        }.get(state, "white")
+
+        task_text = meta.get("task", "")
+        if len(task_text) > 50:
+            task_text = task_text[:47] + "..."
+
+        table.add_row(
+            meta.get("id", run_dir.name),
+            f"[{state_color}]{state}[/{state_color}]",
+            task_text,
+            str(meta.get("iterations", 0)),
+            meta.get("created_at", "")[:19],
+        )
+
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# config
+# ---------------------------------------------------------------------------
 
 
 @main.command()
 def config() -> None:
     """Show the resolved configuration."""
     cfg = load_config()
-    click.echo(cfg.model_dump_json(indent=2))
+    console.print(
+        Panel(
+            JSON(cfg.model_dump_json(indent=2)),
+            title="[bold]Resolved Configuration",
+            border_style="blue",
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_cli_e2e.py
+++ b/tests/e2e/test_cli_e2e.py
@@ -1,0 +1,137 @@
+"""E2E tests for the CLI using real LLM API.
+
+These tests require:
+  - GEMINI_API_KEY environment variable
+  - Docker running (for sandbox)
+
+They are marked with @pytest.mark.e2e and excluded from the default test suite.
+Run manually: make test-e2e
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from agent_forge.cli import main
+from agent_forge.config import USER_CONFIG_DIR
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Skip all tests in this module if no API key is set
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        not os.environ.get("GEMINI_API_KEY"),
+        reason="GEMINI_API_KEY not set — skipping e2e tests",
+    ),
+]
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner(mix_stderr=False)
+
+
+@pytest.fixture()
+def sample_repo(tmp_path: Path) -> Path:
+    """Create a minimal repo for the agent to work on."""
+    (tmp_path / "hello.py").write_text("# placeholder\n")
+    return tmp_path
+
+
+class TestRunE2E:
+    """End-to-end tests for the `run` command with real LLM."""
+
+    def test_run_simple_task(self, runner: CliRunner, sample_repo: Path) -> None:
+        """Agent completes a trivial task using real Gemini API."""
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "--task", "Read the file hello.py and tell me what it contains",
+                "--repo", str(sample_repo),
+                "--max-iterations", "3",
+            ],
+        )
+        # Agent should complete (exit 0) or fail gracefully
+        # We accept either — the point is it runs without crashing
+        assert result.exit_code in (0, 1), f"Unexpected exit: {result.output}"
+
+    def test_run_produces_persisted_run(self, runner: CliRunner, sample_repo: Path) -> None:
+        """The run command persists results to disk."""
+        runner.invoke(
+            main,
+            [
+                "run",
+                "--task", "List the files in the workspace",
+                "--repo", str(sample_repo),
+                "--max-iterations", "2",
+            ],
+        )
+        runs_dir = USER_CONFIG_DIR / "runs"
+        if runs_dir.exists():
+            run_dirs = list(runs_dir.iterdir())
+            if run_dirs:
+                latest = max(run_dirs, key=lambda d: d.stat().st_mtime)
+                assert (latest / "run.json").exists()
+                meta = json.loads((latest / "run.json").read_text())
+                assert meta["state"] in ("completed", "failed", "timeout")
+
+
+class TestStatusE2E:
+    """E2E tests for `status` command after a real run."""
+
+    def test_status_shows_run(self, runner: CliRunner, sample_repo: Path) -> None:
+        """After a run, status displays the run info."""
+        # First run
+        runner.invoke(
+            main,
+            [
+                "run",
+                "--task", "Read hello.py",
+                "--repo", str(sample_repo),
+                "--max-iterations", "2",
+            ],
+        )
+        # Find the run ID
+        runs_dir = USER_CONFIG_DIR / "runs"
+        if not runs_dir.exists():
+            pytest.skip("No runs persisted")
+        run_dirs = list(runs_dir.iterdir())
+        if not run_dirs:
+            pytest.skip("No runs persisted")
+
+        latest = max(run_dirs, key=lambda d: d.stat().st_mtime)
+        run_id = latest.name
+
+        # Check status
+        result = runner.invoke(main, ["status", run_id])
+        assert result.exit_code == 0
+        assert run_id in result.output or "Run" in result.output
+
+
+class TestListE2E:
+    """E2E tests for `list` command."""
+
+    def test_list_shows_runs(self, runner: CliRunner) -> None:
+        """List command shows recent runs."""
+        result = runner.invoke(main, ["list"])
+        assert result.exit_code == 0
+
+
+class TestConfigE2E:
+    """E2E tests for `config` command."""
+
+    def test_config_shows_resolved(self, runner: CliRunner) -> None:
+        """Config command outputs valid JSON."""
+        result = runner.invoke(main, ["config"])
+        assert result.exit_code == 0
+        # Rich JSON output contains the config keys
+        assert "agent" in result.output
+        assert "sandbox" in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,143 @@
+"""Unit tests for the CLI (mocked, no API key needed)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from agent_forge.cli import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestRunCommand:
+    """Tests for the `run` command."""
+
+    def test_run_missing_api_key(self) -> None:
+        """Run exits with error when API key is not set."""
+        runner = _runner()
+        env = {k: v for k, v in __import__("os").environ.items() if not k.endswith("_API_KEY")}
+        result = runner.invoke(
+            main,
+            ["run", "--task", "Fix a bug", "--repo", "/tmp/fake-repo"],
+            env=env,
+        )
+        assert result.exit_code != 0
+        assert "Missing API key" in result.output
+
+    def test_run_unknown_provider(self) -> None:
+        """Run exits with error for unknown provider."""
+        runner = _runner()
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "--task", "Fix a bug",
+                "--repo", "/tmp/fake-repo",
+                "--provider", "nonexistent",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Unknown provider" in result.output
+
+
+class TestStatusCommand:
+    """Tests for the `status` command."""
+
+    def test_status_nonexistent_run(self) -> None:
+        """Status exits with error for unknown run ID."""
+        runner = _runner()
+        result = runner.invoke(main, ["status", "nonexistent-run-id"])
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_status_existing_run(self, tmp_path: Path) -> None:
+        """Status displays info for a persisted run."""
+        from datetime import UTC, datetime
+
+        from agent_forge.agent.models import AgentConfig, AgentRun, RunState
+        from agent_forge.agent.persistence import save_run
+
+        run = AgentRun(task="Test task", repo_path="/tmp/repo", config=AgentConfig())
+        run.state = RunState.COMPLETED
+        run.iterations = 5
+        run.completed_at = datetime.now(UTC)
+        save_run(run, base_dir=tmp_path)
+
+        runner = _runner()
+        with patch("agent_forge.agent.persistence._default_runs_dir", return_value=tmp_path):
+            result = runner.invoke(main, ["status", run.id])
+
+        assert result.exit_code == 0
+
+
+class TestListCommand:
+    """Tests for the `list` command."""
+
+    def test_list_empty(self, tmp_path: Path) -> None:
+        """List with no runs shows empty message."""
+        runner = _runner()
+        with patch("agent_forge.cli.USER_CONFIG_DIR", tmp_path):
+            result = runner.invoke(main, ["list"])
+        assert result.exit_code == 0
+        assert "No runs" in result.output
+
+    def test_list_with_runs(self, tmp_path: Path) -> None:
+        """List shows runs from the runs directory."""
+        from datetime import UTC, datetime
+
+        from agent_forge.agent.models import AgentConfig, AgentRun, RunState
+        from agent_forge.agent.persistence import save_run
+
+        run = AgentRun(task="Fix the login bug", repo_path="/tmp/repo", config=AgentConfig())
+        run.state = RunState.COMPLETED
+        run.iterations = 3
+        run.completed_at = datetime.now(UTC)
+        save_run(run, base_dir=tmp_path / "runs")
+
+        runner = _runner()
+        with patch("agent_forge.cli.USER_CONFIG_DIR", tmp_path):
+            result = runner.invoke(main, ["list"])
+
+        assert result.exit_code == 0
+        assert "login" in result.output
+
+
+class TestConfigCommand:
+    """Tests for the `config` command."""
+
+    def test_config_shows_json(self) -> None:
+        """Config outputs resolved configuration."""
+        runner = _runner()
+        result = runner.invoke(main, ["config"])
+        assert result.exit_code == 0
+        assert "agent" in result.output
+
+    def test_config_valid_structure(self) -> None:
+        """Config output contains expected sections."""
+        runner = _runner()
+        result = runner.invoke(main, ["config"])
+        assert result.exit_code == 0
+        assert "max_iterations" in result.output
+
+
+class TestMainGroup:
+    """Tests for the CLI group itself."""
+
+    def test_help(self) -> None:
+        runner = _runner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "Agent Forge" in result.output
+
+    def test_version(self) -> None:
+        runner = _runner()
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Complete the Click CLI with all 4 commands and add real-world e2e tests.

### CLI Commands

| Command | Description |
|---------|-------------|
| `agent-forge run` | Full agent pipeline: config → LLM → tools → sandbox → react_loop. Rich spinner + summary panel. |
| `agent-forge status <run_id>` | Load persisted run → rich summary panel (state, iterations, tokens, duration). |
| `agent-forge list` | Scan `~/.agent-forge/runs/` → rich table (last 20 runs). |
| `agent-forge config` | Syntax-highlighted JSON of resolved configuration. |

### E2E Test Infrastructure

- `tests/e2e/test_cli_e2e.py`: 5 real-world tests against live Gemini API (skip if `GEMINI_API_KEY` not set)
- `.github/workflows/e2e-tests.yml`: Manual dispatch only (`workflow_dispatch`) + owner-only guard (`github.actor == 'akoita'`)
- `Makefile`: Added `test-e2e` target, default `test` excludes both `integration` and `e2e`

### Tests

- 10 new unit tests (`test_cli.py`) using CliRunner
- 5 new e2e tests (`test_cli_e2e.py`) — deselected by default
- ✅ `make lint` clean, ✅ 160 passed, 13 deselected

Closes #9