### PR TITLE
fix(#9): remove mix_stderr from e2e CliRunner (Click 8.3 compat)

### DIFF
--- a/tests/e2e/test_cli_e2e.py
+++ b/tests/e2e/test_cli_e2e.py
@@ -35,7 +35,7 @@ pytestmark = [
 
 @pytest.fixture()
 def runner() -> CliRunner:
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 @pytest.fixture()


### PR DESCRIPTION
Fix `CliRunner(mix_stderr=False)` in `test_cli_e2e.py` — `mix_stderr` was removed in Click 8.3.

This was missed when fixing the same issue in `test_cli.py` (unit tests).

**Root cause**: Click 8.3 removed the `mix_stderr` parameter from `CliRunner.__init__()`.

1 line changed.