### PR TITLE
fix(#10): e2e persistence test — skip rate-limited, avoid sandbox tmp_path

### DIFF
--- a/tests/e2e/test_agent_e2e.py
+++ b/tests/e2e/test_agent_e2e.py
@@ -310,9 +310,10 @@ class TestAgentPersistence:
     @pytest.mark.asyncio
     async def test_agent_persistence_round_trip(
         self, llm: GeminiProvider, tools: ToolRegistry, sandbox: DockerSandbox, workspace: Path,
-        tmp_path: Path,
     ) -> None:
         """save_run + load_run produces identical state."""
+        import tempfile
+
         run = _make_run("Read hello.py", workspace)
         await sandbox.start(str(workspace))
         try:
@@ -321,10 +322,13 @@ class TestAgentPersistence:
             await sandbox.stop()
             await llm.close()
 
-        # Save and reload
-        persist_dir = tmp_path / "persist"
-        save_run(result, base_dir=persist_dir)
-        loaded = load_run(result.id, base_dir=persist_dir)
+        _skip_if_rate_limited(result)
+
+        # Use a fresh temp dir for persistence (not tmp_path, which may
+        # have ownership changes from the Docker sandbox bind-mount).
+        with tempfile.TemporaryDirectory() as persist_dir:
+            save_run(result, base_dir=persist_dir)
+            loaded = load_run(result.id, base_dir=persist_dir)
 
         assert loaded.id == result.id
         assert loaded.task == result.task
@@ -333,3 +337,4 @@ class TestAgentPersistence:
         assert loaded.total_tokens.total_tokens == result.total_tokens.total_tokens
         assert len(loaded.messages) == len(result.messages)
         assert len(loaded.tool_invocations) == len(result.tool_invocations)
+


### PR DESCRIPTION
Fixes the `PermissionError` in `test_agent_persistence_round_trip` in CI.

### Root Cause
Two issues combined:
1. **Missing rate-limit check** — `save_run()` was called before `_skip_if_rate_limited()`, so a rate-limited run attempted to persist
2. **Docker bind-mount ownership** — `tmp_path` was bind-mounted into the sandbox container, which changed directory ownership to the container user. When pytest later tried to write to `tmp_path/persist/`, it got `PermissionError: [Errno 13]`

### Fix
- Call `_skip_if_rate_limited()` before `save_run()`
- Use `tempfile.TemporaryDirectory()` (never touches Docker) instead of `tmp_path` for persistence

### Validation
- ✅ `make lint` — clean
- ✅ `make test` — 160 passed

Closes #10