### PR TITLE
feat: upgrade to gemini-3.1-flash-lite + improve retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Create an `agent-forge.toml` in your project root:
 [agent]
 max_iterations = 25
 default_provider = "gemini"
-default_model = "gemini-2.0-flash"
+default_model = "gemini-3.1-flash-lite"
 
 [sandbox]
 memory_limit = "512m"

--- a/agent-forge.toml
+++ b/agent-forge.toml
@@ -2,7 +2,7 @@
 max_iterations = 25
 max_tokens_per_run = 200_000
 default_provider = "gemini"
-default_model = "gemini-2.0-flash"
+default_model = "gemini-3.1-flash-lite"
 temperature = 0.0
 system_prompt_path = ""          # Optional custom system prompt file
 
@@ -25,7 +25,7 @@ log_file = ""                    # Optional path for JSON log file
 
 [providers.gemini]
 api_key_env = "GEMINI_API_KEY"
-default_model = "gemini-2.0-flash"
+default_model = "gemini-3.1-flash-lite"
 
 [providers.openai]
 api_key_env = "OPENAI_API_KEY"

--- a/agent_forge/agent/models.py
+++ b/agent_forge/agent/models.py
@@ -30,7 +30,7 @@ class AgentConfig:
 
     max_iterations: int = 25
     max_tokens_per_run: int = 200_000
-    model: str = "gemini-2.0-flash"
+    model: str = "gemini-3.1-flash-lite"
     provider: str = "gemini"  # "gemini" | "openai" | "anthropic"
     temperature: float = 0.0
     system_prompt: str | None = None  # Override default system prompt

--- a/agent_forge/config.py
+++ b/agent_forge/config.py
@@ -34,7 +34,7 @@ class AgentSettings(BaseModel):
     max_iterations: int = 25
     max_tokens_per_run: int = 200_000
     default_provider: str = "gemini"
-    default_model: str = "gemini-2.0-flash"
+    default_model: str = "gemini-3.1-flash-lite"
     temperature: float = 0.0
     system_prompt_path: str = ""
 
@@ -83,7 +83,7 @@ class ForgeConfig(BaseModel):
         default_factory=lambda: {
             "gemini": ProviderSettings(
                 api_key_env="GEMINI_API_KEY",
-                default_model="gemini-2.0-flash",
+                default_model="gemini-3.1-flash-lite",
             ),
             "openai": ProviderSettings(
                 api_key_env="OPENAI_API_KEY",

--- a/agent_forge/llm/base.py
+++ b/agent_forge/llm/base.py
@@ -84,7 +84,7 @@ class LLMResponse:
 class LLMConfig:
     """Configuration for a single LLM request."""
 
-    model: str = "gemini-2.0-flash"
+    model: str = "gemini-3.1-flash-lite"
     temperature: float = 0.0
     max_tokens: int = 4096
     top_p: float = 1.0

--- a/agent_forge/llm/gemini.py
+++ b/agent_forge/llm/gemini.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import random
 import uuid
 from typing import TYPE_CHECKING, Any
 
@@ -38,11 +39,12 @@ from agent_forge.llm.errors import (
 logger = logging.getLogger(__name__)
 
 _GEMINI_BASE_URL = "https://generativelanguage.googleapis.com"
-_DEFAULT_MODEL = "gemini-2.0-flash"
+_DEFAULT_MODEL = "gemini-3.1-flash-lite"
 
 # Retry config per spec § 7.2
-_MAX_RETRIES = 3
-_BACKOFF_BASE = 1.0  # seconds
+_MAX_RETRIES = 5
+_BACKOFF_BASE = 2.0  # seconds
+_BACKOFF_MAX = 30.0  # cap delay at 30s
 _RETRYABLE_STATUS_CODES = {429, 500, 502, 503}
 
 
@@ -276,6 +278,23 @@ class GeminiProvider(LLMProvider):
     # HTTP + Retry
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _compute_delay(attempt: int, resp: httpx.Response | None = None) -> float:
+        """Compute the retry delay, respecting Retry-After if present."""
+        if resp is not None:
+            retry_after = resp.headers.get("Retry-After") or resp.headers.get("retry-after")
+            if retry_after:
+                try:
+                    parsed: float = float(retry_after)
+                    return min(parsed, _BACKOFF_MAX)
+                except ValueError:
+                    pass
+        # Exponential backoff with jitter
+        delay: float = _BACKOFF_BASE * (2**attempt)
+        jitter = random.uniform(0, delay * 0.25)  # noqa: S311
+        capped: float = min(delay + jitter, _BACKOFF_MAX)
+        return capped
+
     async def _post_with_retry(
         self,
         url: str,
@@ -296,7 +315,7 @@ class GeminiProvider(LLMProvider):
                 )
                 if resp.status_code in _RETRYABLE_STATUS_CODES:
                     if attempt < _MAX_RETRIES:
-                        delay = _BACKOFF_BASE * (2**attempt)
+                        delay = self._compute_delay(attempt, resp)
                         logger.warning(
                             "Gemini API returned %d, retrying in %.1fs (attempt %d/%d)",
                             resp.status_code,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ Both project and user configs use TOML:
 max_iterations = 25
 max_tokens_per_run = 200000
 default_provider = "gemini"
-default_model = "gemini-2.0-flash"
+default_model = "gemini-3.1-flash-lite"
 temperature = 0.0
 system_prompt_path = ""
 
@@ -44,7 +44,7 @@ log_file = ""
 
 [providers.gemini]
 api_key_env = "GEMINI_API_KEY"
-default_model = "gemini-2.0-flash"
+default_model = "gemini-3.1-flash-lite"
 
 [providers.openai]
 api_key_env = "OPENAI_API_KEY"
@@ -88,7 +88,7 @@ agent-forge run \
   --task "Fix the bug in auth.py" \
   --repo ./my-project \
   --provider gemini \
-  --model gemini-2.0-flash \
+  --model gemini-3.1-flash-lite \
   --max-iterations 25
 
 agent-forge status <run-id>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def agent_config() -> AgentConfig:
     return AgentConfig(
         max_iterations=5,
         max_tokens_per_run=50_000,
-        model="gemini-2.0-flash",
+        model="gemini-3.1-flash-lite",
         provider="gemini",
         temperature=0.0,
     )

--- a/tests/e2e/test_agent_e2e.py
+++ b/tests/e2e/test_agent_e2e.py
@@ -114,7 +114,7 @@ def _make_run(task: str, workspace: Path, **overrides: object) -> AgentRun:
     config_kwargs = {
         "max_iterations": 3,
         "max_tokens_per_run": 100_000,
-        "model": "gemini-2.0-flash",
+        "model": "gemini-3.1-flash-lite",
         "provider": "gemini",
         "temperature": 0.0,
     }

--- a/tests/e2e/test_cli_e2e.py
+++ b/tests/e2e/test_cli_e2e.py
@@ -166,7 +166,7 @@ class TestRunFlagsE2E:
                 "--task", "Say hello",
                 "--repo", str(sample_repo),
                 "--max-iterations", "1",
-                "--model", "gemini-2.0-flash",
+                "--model", "gemini-3.1-flash-lite",
             ],
         )
         assert result.exit_code in (0, 1), f"Unexpected exit: {result.output}"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -163,7 +163,7 @@ class TestDefaults:
         assert cfg.agent.max_iterations == 25
         assert cfg.agent.max_tokens_per_run == 200_000
         assert cfg.agent.default_provider == "gemini"
-        assert cfg.agent.default_model == "gemini-2.0-flash"
+        assert cfg.agent.default_model == "gemini-3.1-flash-lite"
         assert cfg.agent.temperature == 0.0
         assert cfg.sandbox.image == "agent-forge-sandbox:latest"
         assert cfg.sandbox.memory_limit == "512m"

--- a/tests/unit/test_llm_base.py
+++ b/tests/unit/test_llm_base.py
@@ -64,7 +64,7 @@ class TestLLMConfig:
 
     def test_defaults(self) -> None:
         cfg = LLMConfig()
-        assert cfg.model == "gemini-2.0-flash"
+        assert cfg.model == "gemini-3.1-flash-lite"
         assert cfg.temperature == 0.0
         assert cfg.max_tokens == 4096
         assert cfg.top_p == 1.0
@@ -84,7 +84,7 @@ class TestLLMResponse:
         resp = LLMResponse(
             content="Hello!",
             usage=TokenUsage(10, 5, 15),
-            model="gemini-2.0-flash",
+            model="gemini-3.1-flash-lite",
             finish_reason="stop",
         )
         assert resp.content == "Hello!"
@@ -96,7 +96,7 @@ class TestLLMResponse:
         resp = LLMResponse(
             content=None,
             tool_calls=[tc],
-            model="gemini-2.0-flash",
+            model="gemini-3.1-flash-lite",
             finish_reason="tool_calls",
         )
         assert resp.content is None

--- a/tests/unit/test_llm_gemini.py
+++ b/tests/unit/test_llm_gemini.py
@@ -27,7 +27,7 @@ from agent_forge.llm.factory import create_provider
 from agent_forge.llm.gemini import GeminiProvider
 
 _GEMINI_URL = "https://generativelanguage.googleapis.com"
-_MODEL = "gemini-2.0-flash"
+_MODEL = "gemini-3.1-flash-lite"
 _GENERATE_URL = f"{_GEMINI_URL}/v1beta/models/{_MODEL}:generateContent"
 _STREAM_URL = f"{_GEMINI_URL}/v1beta/models/{_MODEL}:streamGenerateContent"
 
@@ -204,7 +204,7 @@ class TestGeminiErrors:
     @respx.mock
     @pytest.mark.asyncio
     async def test_rate_limit_exhausts_retries(self) -> None:
-        # All 4 attempts (1 initial + 3 retries) return 429
+        # All 6 attempts (1 initial + 5 retries) return 429
         respx.post(_GENERATE_URL).respond(429, json={"error": "rate limited"})
 
         provider = GeminiProvider(api_key="test-key")
@@ -214,8 +214,8 @@ class TestGeminiErrors:
         with pytest.raises(LLMRateLimitError, match="rate limit"):
             await provider.complete(messages, config=config)
 
-        # Should have made 4 attempts
-        assert len(respx.calls) == 4
+        # Should have made 6 attempts (1 initial + 5 retries)
+        assert len(respx.calls) == 6
 
     @respx.mock
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two improvements to the Gemini LLM adapter:

### 1. Improved retry logic
The previous config (3 retries, 1s base backoff, ~7s total wait) was too aggressive — tests and real usage would hit rate limits and give up too quickly.

**Before:** 3 retries, 1/2/4s delays (7s total), no jitter, no Retry-After support
**After:** 5 retries, 2/4/8/16/30s delays (~60s total), random jitter, respects `Retry-After` header

| Setting | Before | After |
|---------|--------|-------|
| Max retries | 3 | 5 |
| Base backoff | 1.0s | 2.0s |
| Max delay cap | ∞ | 30s |
| Jitter | None | 0-25% |
| Retry-After header | Ignored | Respected |

### 2. Default model upgrade
`gemini-2.0-flash` → `gemini-3.1-flash-lite` across all 13 files (source, config, TOML, tests, docs).

### Verification
- ✅ `make lint` — clean
- ✅ `make test` — 160 passed, 92% coverage