### PR TITLE
fix: correct model name to gemini-3.1-flash-lite-preview + persistence str/Path bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Create an `agent-forge.toml` in your project root:
 [agent]
 max_iterations = 25
 default_provider = "gemini"
-default_model = "gemini-3.1-flash-lite"
+default_model = "gemini-3.1-flash-lite-preview"
 
 [sandbox]
 memory_limit = "512m"

--- a/agent-forge.toml
+++ b/agent-forge.toml
@@ -2,7 +2,7 @@
 max_iterations = 25
 max_tokens_per_run = 200_000
 default_provider = "gemini"
-default_model = "gemini-3.1-flash-lite"
+default_model = "gemini-3.1-flash-lite-preview"
 temperature = 0.0
 system_prompt_path = ""          # Optional custom system prompt file
 
@@ -25,7 +25,7 @@ log_file = ""                    # Optional path for JSON log file
 
 [providers.gemini]
 api_key_env = "GEMINI_API_KEY"
-default_model = "gemini-3.1-flash-lite"
+default_model = "gemini-3.1-flash-lite-preview"
 
 [providers.openai]
 api_key_env = "OPENAI_API_KEY"

--- a/agent_forge/agent/models.py
+++ b/agent_forge/agent/models.py
@@ -30,7 +30,7 @@ class AgentConfig:
 
     max_iterations: int = 25
     max_tokens_per_run: int = 200_000
-    model: str = "gemini-3.1-flash-lite"
+    model: str = "gemini-3.1-flash-lite-preview"
     provider: str = "gemini"  # "gemini" | "openai" | "anthropic"
     temperature: float = 0.0
     system_prompt: str | None = None  # Override default system prompt

--- a/agent_forge/agent/persistence.py
+++ b/agent_forge/agent/persistence.py
@@ -10,10 +10,8 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
+from typing import Any
 
 from agent_forge.agent.models import AgentConfig, AgentRun, RunState, ToolInvocation
 from agent_forge.config import USER_CONFIG_DIR
@@ -25,12 +23,12 @@ def _default_runs_dir() -> Path:
     return USER_CONFIG_DIR / "runs"
 
 
-def save_run(run: AgentRun, *, base_dir: Path | None = None) -> Path:
+def save_run(run: AgentRun, *, base_dir: Path | str | None = None) -> Path:
     """Persist an AgentRun to disk.
 
     Returns the run directory path.
     """
-    runs_dir = base_dir or _default_runs_dir()
+    runs_dir = Path(base_dir) if base_dir is not None else _default_runs_dir()
     run_dir = runs_dir / run.id
     run_dir.mkdir(parents=True, exist_ok=True)
 
@@ -87,7 +85,7 @@ def save_run(run: AgentRun, *, base_dir: Path | None = None) -> Path:
     return run_dir
 
 
-def load_run(run_id: str, *, base_dir: Path | None = None) -> AgentRun:
+def load_run(run_id: str, *, base_dir: Path | str | None = None) -> AgentRun:
     """Load an AgentRun from disk.
 
     Raises FileNotFoundError if the run directory doesn't exist.
@@ -96,7 +94,7 @@ def load_run(run_id: str, *, base_dir: Path | None = None) -> AgentRun:
 
     from agent_forge.tools.base import ToolResult
 
-    runs_dir = base_dir or _default_runs_dir()
+    runs_dir = Path(base_dir) if base_dir is not None else _default_runs_dir()
     run_dir = runs_dir / run_id
 
     if not run_dir.exists():

--- a/agent_forge/config.py
+++ b/agent_forge/config.py
@@ -34,7 +34,7 @@ class AgentSettings(BaseModel):
     max_iterations: int = 25
     max_tokens_per_run: int = 200_000
     default_provider: str = "gemini"
-    default_model: str = "gemini-3.1-flash-lite"
+    default_model: str = "gemini-3.1-flash-lite-preview"
     temperature: float = 0.0
     system_prompt_path: str = ""
 
@@ -83,7 +83,7 @@ class ForgeConfig(BaseModel):
         default_factory=lambda: {
             "gemini": ProviderSettings(
                 api_key_env="GEMINI_API_KEY",
-                default_model="gemini-3.1-flash-lite",
+                default_model="gemini-3.1-flash-lite-preview",
             ),
             "openai": ProviderSettings(
                 api_key_env="OPENAI_API_KEY",

--- a/agent_forge/llm/base.py
+++ b/agent_forge/llm/base.py
@@ -84,7 +84,7 @@ class LLMResponse:
 class LLMConfig:
     """Configuration for a single LLM request."""
 
-    model: str = "gemini-3.1-flash-lite"
+    model: str = "gemini-3.1-flash-lite-preview"
     temperature: float = 0.0
     max_tokens: int = 4096
     top_p: float = 1.0

--- a/agent_forge/llm/gemini.py
+++ b/agent_forge/llm/gemini.py
@@ -39,7 +39,7 @@ from agent_forge.llm.errors import (
 logger = logging.getLogger(__name__)
 
 _GEMINI_BASE_URL = "https://generativelanguage.googleapis.com"
-_DEFAULT_MODEL = "gemini-3.1-flash-lite"
+_DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
 
 # Retry config per spec § 7.2
 _MAX_RETRIES = 5

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ Both project and user configs use TOML:
 max_iterations = 25
 max_tokens_per_run = 200000
 default_provider = "gemini"
-default_model = "gemini-3.1-flash-lite"
+default_model = "gemini-3.1-flash-lite-preview"
 temperature = 0.0
 system_prompt_path = ""
 
@@ -44,7 +44,7 @@ log_file = ""
 
 [providers.gemini]
 api_key_env = "GEMINI_API_KEY"
-default_model = "gemini-3.1-flash-lite"
+default_model = "gemini-3.1-flash-lite-preview"
 
 [providers.openai]
 api_key_env = "OPENAI_API_KEY"
@@ -88,7 +88,7 @@ agent-forge run \
   --task "Fix the bug in auth.py" \
   --repo ./my-project \
   --provider gemini \
-  --model gemini-3.1-flash-lite \
+  --model gemini-3.1-flash-lite-preview \
   --max-iterations 25
 
 agent-forge status <run-id>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def agent_config() -> AgentConfig:
     return AgentConfig(
         max_iterations=5,
         max_tokens_per_run=50_000,
-        model="gemini-3.1-flash-lite",
+        model="gemini-3.1-flash-lite-preview",
         provider="gemini",
         temperature=0.0,
     )

--- a/tests/e2e/test_agent_e2e.py
+++ b/tests/e2e/test_agent_e2e.py
@@ -114,7 +114,7 @@ def _make_run(task: str, workspace: Path, **overrides: object) -> AgentRun:
     config_kwargs = {
         "max_iterations": 3,
         "max_tokens_per_run": 100_000,
-        "model": "gemini-3.1-flash-lite",
+        "model": "gemini-3.1-flash-lite-preview",
         "provider": "gemini",
         "temperature": 0.0,
     }

--- a/tests/e2e/test_cli_e2e.py
+++ b/tests/e2e/test_cli_e2e.py
@@ -166,7 +166,7 @@ class TestRunFlagsE2E:
                 "--task", "Say hello",
                 "--repo", str(sample_repo),
                 "--max-iterations", "1",
-                "--model", "gemini-3.1-flash-lite",
+                "--model", "gemini-3.1-flash-lite-preview",
             ],
         )
         assert result.exit_code in (0, 1), f"Unexpected exit: {result.output}"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -163,7 +163,7 @@ class TestDefaults:
         assert cfg.agent.max_iterations == 25
         assert cfg.agent.max_tokens_per_run == 200_000
         assert cfg.agent.default_provider == "gemini"
-        assert cfg.agent.default_model == "gemini-3.1-flash-lite"
+        assert cfg.agent.default_model == "gemini-3.1-flash-lite-preview"
         assert cfg.agent.temperature == 0.0
         assert cfg.sandbox.image == "agent-forge-sandbox:latest"
         assert cfg.sandbox.memory_limit == "512m"

--- a/tests/unit/test_llm_base.py
+++ b/tests/unit/test_llm_base.py
@@ -64,7 +64,7 @@ class TestLLMConfig:
 
     def test_defaults(self) -> None:
         cfg = LLMConfig()
-        assert cfg.model == "gemini-3.1-flash-lite"
+        assert cfg.model == "gemini-3.1-flash-lite-preview"
         assert cfg.temperature == 0.0
         assert cfg.max_tokens == 4096
         assert cfg.top_p == 1.0
@@ -84,7 +84,7 @@ class TestLLMResponse:
         resp = LLMResponse(
             content="Hello!",
             usage=TokenUsage(10, 5, 15),
-            model="gemini-3.1-flash-lite",
+            model="gemini-3.1-flash-lite-preview",
             finish_reason="stop",
         )
         assert resp.content == "Hello!"
@@ -96,7 +96,7 @@ class TestLLMResponse:
         resp = LLMResponse(
             content=None,
             tool_calls=[tc],
-            model="gemini-3.1-flash-lite",
+            model="gemini-3.1-flash-lite-preview",
             finish_reason="tool_calls",
         )
         assert resp.content is None

--- a/tests/unit/test_llm_gemini.py
+++ b/tests/unit/test_llm_gemini.py
@@ -27,7 +27,7 @@ from agent_forge.llm.factory import create_provider
 from agent_forge.llm.gemini import GeminiProvider
 
 _GEMINI_URL = "https://generativelanguage.googleapis.com"
-_MODEL = "gemini-3.1-flash-lite"
+_MODEL = "gemini-3.1-flash-lite-preview"
 _GENERATE_URL = f"{_GEMINI_URL}/v1beta/models/{_MODEL}:generateContent"
 _STREAM_URL = f"{_GEMINI_URL}/v1beta/models/{_MODEL}:streamGenerateContent"
 


### PR DESCRIPTION
## Root Cause

E2E tests **FAILED** (not skipped) because:

1. **`gemini-3.1-flash-lite` → HTTP 404** — the Gemini REST API requires the `-preview` suffix for all 3.1 models. The correct model ID is `gemini-3.1-flash-lite-preview`.

2. **`TypeError: unsupported operand type(s) for /: 'str' and 'str'`** — `tempfile.TemporaryDirectory()` returns `str`, but `save_run()`/`load_run()` expected `pathlib.Path`.

## Fixes

- Model name: `gemini-3.1-flash-lite` → `gemini-3.1-flash-lite-preview` (all 14 files)
- `persistence.py`: `save_run`/`load_run` now accept `str | Path` for `base_dir`
- Move `Path` import from `TYPE_CHECKING` to runtime

## Verification
- ✅ `make lint` — clean
- ✅ `make test` — 160 passed, 92% coverage