### PR TITLE
fix(#73): run Docker sandbox as host user to fix file ownership

### DIFF
--- a/agent_forge/sandbox/docker.py
+++ b/agent_forge/sandbox/docker.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 import docker
@@ -38,6 +39,8 @@ class DockerSandbox(Sandbox):
         self._container: Container | None = None
         self._state = SandboxState.IDLE
         self._config = SandboxConfig()
+        self._host_uid = os.getuid()
+        self._host_gid = os.getgid()
 
     @property
     def state(self) -> SandboxState:
@@ -88,20 +91,13 @@ class DockerSandbox(Sandbox):
         if not cfg.network_enabled:
             run_kwargs["network_mode"] = "none"
 
-        # Start as root so we can fix bind-mount permissions, then exec as 'agent'
-        run_kwargs["user"] = "root"
+        # Run as the host user so files are owned by them (avoids PermissionError
+        # when the host reads workspace files after the container writes them).
+        run_kwargs["user"] = f"{self._host_uid}:{self._host_gid}"
 
         try:
             self._container = await asyncio.to_thread(
                 lambda: self._client.containers.run(**run_kwargs)
-            )
-
-            # Fix ownership of bind-mounted workspace (host UID may differ
-            # from container's 'agent' user).
-            await asyncio.to_thread(
-                self._container.exec_run,  # type: ignore[union-attr]
-                "chown -R agent:agent /workspace",
-                user="root",
             )
 
             self._state = SandboxState.RUNNING
@@ -165,7 +161,7 @@ class DockerSandbox(Sandbox):
                     self._container.exec_run,
                     ["bash", "-c", command],
                     demux=True,
-                    user="agent",
+                    user=f"{self._host_uid}:{self._host_gid}",
                 ),
                 timeout=timeout_seconds,
             )

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -6,6 +6,7 @@ exec, read_file, write_file, and error handling.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -63,7 +64,7 @@ class TestSandboxLifecycle:
             assert call_kwargs["pids_limit"] == 256
             assert "/tmp" in call_kwargs["tmpfs"]
             assert call_kwargs["network_mode"] == "none"
-            assert call_kwargs["user"] == "root"  # starts as root for chown
+            assert call_kwargs["user"] == f"{os.getuid()}:{os.getgid()}"
 
     @pytest.mark.asyncio
     async def test_start_with_custom_config(self, mock_docker_client: MagicMock) -> None:
@@ -146,10 +147,10 @@ class TestSandboxExec:
             assert result.exit_code == 0
             assert result.stdout == "hello"
             container = mock_docker_client.containers.run.return_value
-            # First exec_run call is chown during start(); second is our command
-            assert container.exec_run.call_count == 2
+            # No chown during start anymore; just our command
+            assert container.exec_run.call_count == 1
             container.exec_run.assert_called_with(
-                ["bash", "-c", "echo hello"], demux=True, user="agent",
+                ["bash", "-c", "echo hello"], demux=True, user=f"{os.getuid()}:{os.getgid()}",
             )
 
     @pytest.mark.asyncio
@@ -221,8 +222,8 @@ class TestSandboxFileOps:
 
             await sandbox.write_file("/workspace/new.py", "print('hi')")
             # Should have called exec at least twice (mkdir -p + write)
-            # 1 chown during start + 1 mkdir + 1 write = at least 3
-            assert container.exec_run.call_count >= 3
+            # No chown during start anymore; just mkdir + write = at least 2
+            assert container.exec_run.call_count >= 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary — Closes #73

Fixes `PermissionError` in E2E tests on CI caused by Docker file ownership mismatch.

### Root Cause

The sandbox container ran commands as the `agent` user (container-local UID). Files written to the bind-mounted workspace were owned by that UID. On CI, the `runner` user has a different UID and can't read them.

### Fix

Run the container with `--user {host_uid}:{host_gid}` (from `os.getuid()`/`os.getgid()`) instead of container's `agent` user. Removed the `chown -R agent:agent /workspace` step during `start()`.

### Changes

| File | Change |
|------|--------|
| `agent_forge/sandbox/docker.py` | Use host UID/GID for `user=` in `run()` and `exec_run()`, remove `chown` step |
| `tests/unit/test_sandbox.py` | Update assertions: `user="agent"` → host UID, remove chown call count |

### Verification

- ✅ 160/160 unit tests pass locally