### PR TITLE
feat(#12): structured logging with structlog (JSON + colored console)

### DIFF
--- a/agent_forge/agent/core.py
+++ b/agent_forge/agent/core.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -11,13 +10,14 @@ from agent_forge.agent.persistence import save_run
 from agent_forge.agent.prompts import build_system_prompt
 from agent_forge.agent.state import transition
 from agent_forge.llm.base import LLMConfig, Message, Role
+from agent_forge.observability import get_logger, set_trace_context, update_iteration
 
 if TYPE_CHECKING:
     from agent_forge.llm.base import LLMProvider
     from agent_forge.sandbox.base import Sandbox
     from agent_forge.tools.base import ToolRegistry
 
-logger = logging.getLogger(__name__)
+logger = get_logger("agent_core")
 
 
 async def react_loop(
@@ -35,6 +35,7 @@ async def react_loop(
     - Unrecoverable error (→ FAILED)
     """
     transition(run, RunState.RUNNING)
+    set_trace_context(run.id)
 
     # Build system prompt from task + tool definitions
     system_content = run.config.system_prompt or build_system_prompt(
@@ -52,7 +53,12 @@ async def react_loop(
     try:
         while run.iterations < run.config.max_iterations:
             run.iterations += 1
-            logger.info("Iteration %d/%d", run.iterations, run.config.max_iterations)
+            update_iteration(run.iterations)
+            logger.info(
+                "iteration_started",
+                iteration=run.iterations,
+                max_iterations=run.config.max_iterations,
+            )
 
             # 1. REASON — ask the LLM what to do next
             response = await llm.complete(
@@ -64,7 +70,11 @@ async def react_loop(
 
             # 2. CHECK BUDGET
             if run.total_tokens.total_tokens > run.config.max_tokens_per_run:
-                logger.warning("Token budget exceeded: %d", run.total_tokens.total_tokens)
+                logger.warning(
+                    "token_budget_exceeded",
+                    total_tokens=run.total_tokens.total_tokens,
+                    budget=run.config.max_tokens_per_run,
+                )
                 transition(run, RunState.TIMEOUT)
                 run.error = "Token budget exceeded"
                 break
@@ -89,12 +99,15 @@ async def react_loop(
 
         else:
             # Loop exhausted without breaking → max iterations
-            logger.warning("Max iterations reached: %d", run.config.max_iterations)
+            logger.warning(
+                "max_iterations_reached",
+                max_iterations=run.config.max_iterations,
+            )
             transition(run, RunState.TIMEOUT)
             run.error = "Max iterations reached"
 
     except Exception as exc:
-        logger.exception("Unrecoverable error during agent run")
+        logger.exception("unrecoverable_error", exc_info=exc)
         transition(run, RunState.FAILED)
         run.error = str(exc)
 
@@ -119,7 +132,7 @@ async def _execute_tool_call(
         tool = tools.get(tool_call.name)
     except KeyError:
         # Unknown tool — inject error and let LLM self-correct
-        logger.warning("Unknown tool requested: %s", tool_call.name)
+        logger.warning("unknown_tool_requested", tool_name=tool_call.name)
         error_result = ToolResult(
             output="",
             error=f"Unknown tool: '{tool_call.name}'. Available tools: "

--- a/agent_forge/llm/gemini.py
+++ b/agent_forge/llm/gemini.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import random
 import uuid
 from typing import TYPE_CHECKING, Any
@@ -35,8 +34,9 @@ from agent_forge.llm.errors import (
     LLMResponseError,
     LLMTimeoutError,
 )
+from agent_forge.observability import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger("gemini")
 
 _GEMINI_BASE_URL = "https://generativelanguage.googleapis.com"
 _DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
@@ -320,11 +320,11 @@ class GeminiProvider(LLMProvider):
                     if attempt < _MAX_RETRIES:
                         delay = self._compute_delay(attempt, resp)
                         logger.warning(
-                            "Gemini API returned %d, retrying in %.1fs (attempt %d/%d)",
-                            resp.status_code,
-                            delay,
-                            attempt + 1,
-                            _MAX_RETRIES,
+                            "gemini_retryable_error",
+                            status_code=resp.status_code,
+                            delay=round(delay, 1),
+                            attempt=attempt + 1,
+                            max_retries=_MAX_RETRIES,
                         )
                         await asyncio.sleep(delay)
                         continue
@@ -344,9 +344,9 @@ class GeminiProvider(LLMProvider):
                 except (json.JSONDecodeError, ValueError) as exc:
                     if attempt < _MAX_RETRIES:
                         logger.warning(
-                            "Malformed response from Gemini, retrying (attempt %d/%d)",
-                            attempt + 1,
-                            _MAX_RETRIES,
+                            "gemini_malformed_response",
+                            attempt=attempt + 1,
+                            max_retries=_MAX_RETRIES,
                         )
                         await asyncio.sleep(_BACKOFF_BASE)
                         continue
@@ -356,9 +356,9 @@ class GeminiProvider(LLMProvider):
                 last_exc = exc
                 if attempt < _MAX_RETRIES:
                     logger.warning(
-                        "Gemini request timed out, retrying (attempt %d/%d)",
-                        attempt + 1,
-                        _MAX_RETRIES,
+                        "gemini_timeout",
+                        attempt=attempt + 1,
+                        max_retries=_MAX_RETRIES,
                     )
                     await asyncio.sleep(_BACKOFF_BASE)
                     continue
@@ -386,7 +386,7 @@ class GeminiProvider(LLMProvider):
                 detail = body.get("error", {}).get("message", resp.text[:500])
             except Exception:  # noqa: BLE001
                 detail = resp.text[:500]
-            logger.error("Gemini API error (HTTP %d): %s", status_code, detail)
+            logger.error("gemini_api_error", status_code=status_code, detail=detail)
             raise LLMResponseError(
                 f"Gemini API error (HTTP {status_code}): {detail}"
             )

--- a/agent_forge/observability/__init__.py
+++ b/agent_forge/observability/__init__.py
@@ -1,1 +1,31 @@
-"""Observability — structured logging, tracing, and cost tracking."""
+"""Observability — structured logging, tracing, and cost tracking.
+
+Public API
+----------
+.. autofunction:: setup_logging
+.. autofunction:: get_logger
+.. autoclass:: TraceContext
+.. autofunction:: set_trace_context
+.. autofunction:: get_trace_context
+.. autofunction:: clear_trace_context
+.. autofunction:: update_iteration
+"""
+
+from agent_forge.observability.logger import get_logger, setup_logging
+from agent_forge.observability.tracing import (
+    TraceContext,
+    clear_trace_context,
+    get_trace_context,
+    set_trace_context,
+    update_iteration,
+)
+
+__all__ = [
+    "clear_trace_context",
+    "get_logger",
+    "get_trace_context",
+    "set_trace_context",
+    "setup_logging",
+    "TraceContext",
+    "update_iteration",
+]

--- a/agent_forge/observability/logger.py
+++ b/agent_forge/observability/logger.py
@@ -1,1 +1,180 @@
-"""Structured logging setup — JSON + colored console output."""
+"""Structured logging setup — JSON + colored console output.
+
+Configures ``structlog`` with:
+- **Console (stderr):** colored, human-friendly renderer
+- **File:** JSON lines with consistent schema
+- **API key redaction:** strips known secret patterns before output
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from typing import Any
+
+import structlog
+
+from agent_forge.observability.tracing import inject_trace_context
+
+# ---------------------------------------------------------------------------
+# API Key Redaction
+# ---------------------------------------------------------------------------
+
+# Patterns that likely represent API keys / tokens.
+_SECRET_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"AIza[0-9A-Za-z\-_]{35}"),          # Google / Gemini
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),              # OpenAI
+    re.compile(r"sk-ant-[A-Za-z0-9\-]{20,}"),        # Anthropic
+    re.compile(r"key-[A-Za-z0-9]{20,}"),             # Generic key-* tokens
+    re.compile(r"ghp_[A-Za-z0-9]{36,}"),             # GitHub PAT
+    re.compile(r"ghs_[A-Za-z0-9]{36,}"),             # GitHub App token
+    re.compile(r"glpat-[A-Za-z0-9\-_]{20,}"),        # GitLab PAT
+]
+
+REDACTED = "***REDACTED***"
+
+
+def _redact_string(value: str) -> str:
+    """Replace any substring matching a known secret pattern."""
+    for pattern in _SECRET_PATTERNS:
+        value = pattern.sub(REDACTED, value)
+    return value
+
+
+def _redact_value(value: Any) -> Any:
+    """Recursively redact secrets in strings, lists, and dicts."""
+    if isinstance(value, str):
+        return _redact_string(value)
+    if isinstance(value, dict):
+        return {k: _redact_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return type(value)(_redact_value(item) for item in value)
+    return value
+
+
+def redact_secrets(
+    logger: Any, method_name: str, event_dict: dict[str, Any]
+) -> dict[str, Any]:
+    """structlog processor that redacts API key patterns from all values."""
+    return {key: _redact_value(val) for key, val in event_dict.items()}
+
+
+# ---------------------------------------------------------------------------
+# Logger Setup
+# ---------------------------------------------------------------------------
+
+_CONFIGURED = False
+
+
+def setup_logging(
+    *,
+    level: str = "INFO",
+    log_file: str = "",
+    console_format: str = "text",
+) -> None:
+    """Configure structlog + stdlib logging for the entire application.
+
+    Call once at startup (CLI entrypoint).  Subsequent calls are no-ops.
+
+    Args:
+        level: Log level name (DEBUG, INFO, WARNING, ERROR).
+        log_file: Path to a JSON-lines log file.  Empty string ⇒ no file.
+        console_format: ``"text"`` for colored console, ``"json"`` for JSON.
+    """
+    global _CONFIGURED  # noqa: PLW0603
+    if _CONFIGURED:
+        return
+    _CONFIGURED = True
+
+    numeric_level = getattr(logging, level.upper(), logging.INFO)
+
+    # --- shared structlog processors (run before final rendering) ----------
+    shared_processors: list[Any] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        inject_trace_context,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.UnicodeDecoder(),
+        redact_secrets,
+    ]
+
+    # --- stdlib root logger setup ------------------------------------------
+    root = logging.getLogger()
+    root.setLevel(numeric_level)
+
+    # Console handler (stderr) — always present
+    console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.setLevel(numeric_level)
+    root.addHandler(console_handler)
+
+    # File handler (JSON lines) — optional
+    if log_file:
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setLevel(logging.DEBUG)  # capture everything to file
+
+        # File always renders JSON
+        file_formatter = structlog.stdlib.ProcessorFormatter(
+            processors=[
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                structlog.processors.JSONRenderer(),
+            ],
+            foreign_pre_chain=shared_processors,
+        )
+        file_handler.setFormatter(file_formatter)
+        root.addHandler(file_handler)
+
+    # Console formatter
+    console_renderer: Any
+    if console_format == "json":
+        console_renderer = structlog.processors.JSONRenderer()
+    else:
+        console_renderer = structlog.dev.ConsoleRenderer()
+
+    console_formatter = structlog.stdlib.ProcessorFormatter(
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            console_renderer,
+        ],
+        foreign_pre_chain=shared_processors,
+    )
+    console_handler.setFormatter(console_formatter)
+
+    # --- structlog configuration -------------------------------------------
+    structlog.configure(
+        processors=[
+            *shared_processors,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public Logger Factory
+# ---------------------------------------------------------------------------
+
+
+def get_logger(component: str) -> Any:
+    """Return a structlog logger pre-bound with ``component``.
+
+    Usage::
+
+        from agent_forge.observability import get_logger
+        logger = get_logger("agent_core")
+        logger.info("iteration_started", iteration=1, max_iterations=25)
+    """
+    return structlog.get_logger(component=component)
+
+
+def reset_logging() -> None:
+    """Reset logging configuration. Intended **only** for tests."""
+    global _CONFIGURED  # noqa: PLW0603
+    _CONFIGURED = False
+    root = logging.getLogger()
+    root.handlers.clear()
+    structlog.reset_defaults()

--- a/agent_forge/observability/tracing.py
+++ b/agent_forge/observability/tracing.py
@@ -1,1 +1,84 @@
-"""Trace context — run_id propagation across components."""
+"""Trace context — run_id propagation across components.
+
+Provides a lightweight trace context using ``contextvars`` so that every log
+line automatically includes ``run_id`` and ``iteration`` without explicit
+passing through every call-site.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Trace Context
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TraceContext:
+    """Immutable trace context bound to a single agent run."""
+
+    run_id: str
+    iteration: int | None = None
+
+
+_trace_ctx_var: ContextVar[TraceContext | None] = ContextVar(
+    "agent_forge_trace_ctx", default=None
+)
+
+
+def set_trace_context(
+    run_id: str, *, iteration: int | None = None
+) -> TraceContext:
+    """Set the current trace context (thread/task-local).
+
+    Returns the newly created ``TraceContext``.
+    """
+    ctx = TraceContext(run_id=run_id, iteration=iteration)
+    _trace_ctx_var.set(ctx)
+    return ctx
+
+
+def get_trace_context() -> TraceContext | None:
+    """Return the current trace context, or ``None`` if unset."""
+    return _trace_ctx_var.get()
+
+
+def clear_trace_context() -> None:
+    """Remove the current trace context."""
+    _trace_ctx_var.set(None)
+
+
+def update_iteration(iteration: int) -> TraceContext | None:
+    """Update only the iteration number on the current trace context.
+
+    Returns the updated context or ``None`` if no context is set.
+    """
+    current = _trace_ctx_var.get()
+    if current is None:
+        return None
+    ctx = TraceContext(run_id=current.run_id, iteration=iteration)
+    _trace_ctx_var.set(ctx)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# structlog Processor
+# ---------------------------------------------------------------------------
+
+
+def inject_trace_context(
+    logger: Any, method_name: str, event_dict: dict[str, Any]
+) -> dict[str, Any]:
+    """structlog processor that injects ``run_id`` and ``iteration``.
+
+    If no trace context is active the event dict is returned unchanged.
+    """
+    ctx = _trace_ctx_var.get()
+    if ctx is not None:
+        event_dict.setdefault("run_id", ctx.run_id)
+        if ctx.iteration is not None:
+            event_dict.setdefault("iteration", ctx.iteration)
+    return event_dict

--- a/agent_forge/sandbox/docker.py
+++ b/agent_forge/sandbox/docker.py
@@ -7,19 +7,19 @@ Implements security constraints per spec § 4.3.
 from __future__ import annotations
 
 import asyncio
-import logging
 import os
 from typing import TYPE_CHECKING, Any
 
 import docker
 from docker.errors import APIError, NotFound
 
+from agent_forge.observability import get_logger
 from agent_forge.sandbox.base import ExecResult, Sandbox, SandboxConfig, SandboxState
 
 if TYPE_CHECKING:
     from docker.models.containers import Container
 
-logger = logging.getLogger(__name__)
+logger = get_logger("sandbox")
 
 
 class DockerSandbox(Sandbox):
@@ -102,9 +102,9 @@ class DockerSandbox(Sandbox):
 
             self._state = SandboxState.RUNNING
             logger.info(
-                "Sandbox started: container=%s, image=%s",
-                self._container.short_id,  # type: ignore[union-attr]
-                cfg.image,
+                "sandbox_started",
+                container=self._container.short_id,  # type: ignore[union-attr]
+                image=cfg.image,
             )
         except (APIError, Exception) as exc:
             self._state = SandboxState.STOPPED
@@ -123,11 +123,11 @@ class DockerSandbox(Sandbox):
             # Container already removed (--rm flag)
             pass
         except APIError as exc:
-            logger.warning("Error stopping container: %s", exc)
+            logger.warning("container_stop_error", error=str(exc))
         finally:
             self._container = None
             self._state = SandboxState.STOPPED
-            logger.info("Sandbox stopped")
+            logger.info("sandbox_stopped")
 
     async def is_alive(self) -> bool:
         """Check if the sandbox container is still running."""

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,0 +1,262 @@
+"""Tests for agent_forge.observability — structured logging and tracing."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+
+import pytest
+
+from agent_forge.observability.logger import (
+    REDACTED,
+    _redact_string,
+    get_logger,
+    redact_secrets,
+    reset_logging,
+    setup_logging,
+)
+from agent_forge.observability.tracing import (
+    TraceContext,
+    clear_trace_context,
+    get_trace_context,
+    inject_trace_context,
+    set_trace_context,
+    update_iteration,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_logging():
+    """Reset logging state before and after every test."""
+    reset_logging()
+    clear_trace_context()
+    yield
+    reset_logging()
+    clear_trace_context()
+
+
+# ===========================================================================
+# TraceContext Tests
+# ===========================================================================
+
+
+class TestTraceContext:
+    """Tests for trace context lifecycle."""
+
+    def test_set_and_get(self) -> None:
+        ctx = set_trace_context("run-123", iteration=5)
+        assert ctx.run_id == "run-123"
+        assert ctx.iteration == 5
+        assert get_trace_context() is ctx
+
+    def test_default_is_none(self) -> None:
+        assert get_trace_context() is None
+
+    def test_clear(self) -> None:
+        set_trace_context("run-abc")
+        clear_trace_context()
+        assert get_trace_context() is None
+
+    def test_update_iteration(self) -> None:
+        set_trace_context("run-456")
+        updated = update_iteration(10)
+        assert updated is not None
+        assert updated.run_id == "run-456"
+        assert updated.iteration == 10
+        # verify it's stored
+        assert get_trace_context() == updated
+
+    def test_update_iteration_without_context(self) -> None:
+        result = update_iteration(5)
+        assert result is None
+
+    def test_frozen(self) -> None:
+        ctx = TraceContext(run_id="r1", iteration=1)
+        with pytest.raises(AttributeError):
+            ctx.run_id = "r2"  # type: ignore[misc]
+
+
+class TestInjectTraceContextProcessor:
+    """Tests for the structlog processor."""
+
+    def test_injects_run_id_and_iteration(self) -> None:
+        set_trace_context("run-aaa", iteration=3)
+        event_dict: dict = {"event": "hello"}
+        result = inject_trace_context(None, "info", event_dict)
+        assert result["run_id"] == "run-aaa"
+        assert result["iteration"] == 3
+
+    def test_no_context_is_noop(self) -> None:
+        event_dict: dict = {"event": "world"}
+        result = inject_trace_context(None, "info", event_dict)
+        assert "run_id" not in result
+
+    def test_does_not_overwrite_explicit_run_id(self) -> None:
+        set_trace_context("run-bbb")
+        event_dict: dict = {"event": "x", "run_id": "explicit"}
+        result = inject_trace_context(None, "info", event_dict)
+        assert result["run_id"] == "explicit"
+
+
+# ===========================================================================
+# Redaction Tests
+# ===========================================================================
+
+
+class TestRedaction:
+    """Tests for API key redaction."""
+
+    @pytest.mark.parametrize(
+        "secret",
+        [
+            "AIzaSyD1234567890abcdefghijklmnopqrstuvw",  # Google
+            "sk-abc123def456ghi789jkl012mno345pqr678stu",  # OpenAI
+            "sk-ant-abc123-def456ghi789jkl012mno345pqr678stu",  # Anthropic
+            "key-abc123def456ghi789jkl012mno345pqr67",  # generic
+            "ghp_abcdefghijklmnopqrstuvwxyz1234567890",  # GitHub PAT
+        ],
+    )
+    def test_known_patterns_redacted(self, secret: str) -> None:
+        result = _redact_string(f"my key is {secret} here")
+        assert REDACTED in result
+        assert secret not in result
+
+    def test_safe_string_unmodified(self) -> None:
+        assert _redact_string("hello world") == "hello world"
+
+    def test_processor_redacts_all_values(self) -> None:
+        event_dict = {
+            "event": "test",
+            "api_key": "sk-abc123def456ghi789jkl012mno345pqr678stu",
+            "nested": {"key": "AIzaSyD1234567890abcdefghijklmnopqrstuvw"},
+            "list_val": ["safe", "sk-abc123def456ghi789jkl012mno345pqr678stu"],
+        }
+        result = redact_secrets(None, "info", event_dict)
+        assert REDACTED in result["api_key"]
+        assert REDACTED in result["nested"]["key"]
+        assert REDACTED in result["list_val"][1]
+        # Safe values untouched
+        assert result["event"] == "test"
+        assert result["list_val"][0] == "safe"
+
+    def test_non_string_values_unchanged(self) -> None:
+        event_dict = {"count": 42, "enabled": True, "rate": 3.14}
+        result = redact_secrets(None, "info", event_dict)
+        assert result == event_dict
+
+
+# ===========================================================================
+# Logger Setup Tests
+# ===========================================================================
+
+
+class TestSetupLogging:
+    """Tests for setup_logging and get_logger."""
+
+    def test_setup_logging_runs_without_error(self) -> None:
+        setup_logging(level="DEBUG")
+
+    def test_idempotent(self) -> None:
+        setup_logging(level="INFO")
+        setup_logging(level="DEBUG")  # should be a no-op
+
+    def test_get_logger_returns_bound_logger(self) -> None:
+        setup_logging(level="INFO")
+        lgr = get_logger("test_component")
+        assert lgr is not None
+
+    def test_json_file_output(self) -> None:
+        """Verify that log output to a file is valid JSON with required schema."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as f:
+            tmp_path = f.name
+
+        try:
+            setup_logging(level="DEBUG", log_file=tmp_path)
+            set_trace_context("run-json-test", iteration=1)
+
+            lgr = get_logger("my_comp")
+            lgr.info("test_event", extra_field="hello")
+
+            # Flush handlers
+            for handler in logging.getLogger().handlers:
+                handler.flush()
+
+            with open(tmp_path) as fh:
+                lines = [line.strip() for line in fh if line.strip()]
+
+            assert len(lines) >= 1, f"Expected at least 1 log line, got {len(lines)}"
+            record = json.loads(lines[-1])
+
+            # Schema checks
+            assert record["event"] == "test_event"
+            assert record.get("log_level") == "info" or record.get("level") == "info"
+            assert "component" in record
+            assert record["run_id"] == "run-json-test"
+            assert record["iteration"] == 1
+            assert "timestamp" in record
+        finally:
+            os.unlink(tmp_path)
+
+    def test_log_level_filtering(self) -> None:
+        """DEBUG messages should be suppressed at INFO level."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as f:
+            tmp_path = f.name
+
+        try:
+            # File handler always captures DEBUG, but console is filtered.
+            # Test that the file handler *does* capture debug.
+            setup_logging(level="DEBUG", log_file=tmp_path)
+
+            lgr = get_logger("filter_test")
+            lgr.debug("debug_msg")
+            lgr.info("info_msg")
+
+            for handler in logging.getLogger().handlers:
+                handler.flush()
+
+            with open(tmp_path) as fh:
+                lines = [line.strip() for line in fh if line.strip()]
+
+            events = [json.loads(line)["event"] for line in lines]
+            assert "debug_msg" in events
+            assert "info_msg" in events
+        finally:
+            os.unlink(tmp_path)
+
+    def test_console_format_json(self) -> None:
+        """Console output in JSON mode should produce JSON to stderr."""
+        import io
+
+        # Capture stderr directly
+        buf = io.StringIO()
+        setup_logging(level="INFO", console_format="json")
+
+        # Redirect the stderr handler to our buffer
+        root = logging.getLogger()
+        for handler in root.handlers:
+            if isinstance(handler, logging.StreamHandler) and not isinstance(
+                handler, logging.FileHandler
+            ):
+                handler.stream = buf
+                break
+
+        lgr = get_logger("json_console")
+        lgr.info("console_json_event")
+
+        for handler in root.handlers:
+            handler.flush()
+
+        output = buf.getvalue().strip()
+        assert output, "Expected some output"
+        # Output should contain at minimum event and level info
+        assert "console_json_event" in output


### PR DESCRIPTION
## Summary

Implements structured logging using `structlog` as defined in [spec.md § 4.6](spec.md#46-observability).

### Changes

- **`agent_forge/observability/logger.py`** — `setup_logging()` configures structlog + stdlib with:
  - Colored console output (stderr) via `ConsoleRenderer`
  - JSON lines file output via `JSONRenderer`
  - API key redaction processor (Google, OpenAI, Anthropic, GitHub patterns)
  - Log level configuration (DEBUG/INFO/WARNING/ERROR)
- **`agent_forge/observability/tracing.py`** — Trace context via `contextvars`:
  - `TraceContext` dataclass with `run_id` and `iteration`
  - `inject_trace_context` structlog processor for automatic propagation
- **`agent_forge/observability/__init__.py`** — Public API re-exports
- **Migrated** `core.py`, `docker.py`, `gemini.py` from `logging.getLogger` to `get_logger()` with structured event names
- **23 new unit tests** in `tests/unit/test_observability.py`

### Test Results

- **183/183 unit tests pass** (23 new + 160 existing, zero regressions)
- **92% code coverage** (100% on new observability modules)
- **Lint clean** (ruff + mypy)

Closes #12