### PR TITLE
feat(#14): OpenAI + Anthropic LLM adapters

### DIFF
--- a/agent_forge/llm/__init__.py
+++ b/agent_forge/llm/__init__.py
@@ -1,5 +1,6 @@
 """LLM client layer — provider adapters and data models."""
 
+from agent_forge.llm.anthropic import AnthropicProvider
 from agent_forge.llm.base import (
     LLMConfig,
     LLMProvider,
@@ -21,9 +22,11 @@ from agent_forge.llm.errors import (
 )
 from agent_forge.llm.factory import create_provider
 from agent_forge.llm.gemini import GeminiProvider
+from agent_forge.llm.openai import OpenAIProvider
 
 __all__ = [
     "AgentForgeError",
+    "AnthropicProvider",
     "GeminiProvider",
     "LLMAuthError",
     "LLMConfig",
@@ -35,6 +38,7 @@ __all__ = [
     "LLMResponseError",
     "LLMTimeoutError",
     "Message",
+    "OpenAIProvider",
     "Role",
     "TokenUsage",
     "ToolCall",

--- a/agent_forge/llm/anthropic.py
+++ b/agent_forge/llm/anthropic.py
@@ -1,1 +1,428 @@
-"""Anthropic LLM provider adapter."""
+"""Anthropic LLM provider adapter.
+
+Uses the Anthropic Messages REST API via httpx. Handles tool mapping
+(``tool_use`` / ``tool_result`` content blocks), streaming, and retry
+logic per spec § 4.1 and § 7.2.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from agent_forge.llm.base import ToolDefinition
+
+import httpx
+
+from agent_forge.llm.base import (
+    LLMConfig,
+    LLMProvider,
+    LLMResponse,
+    Message,
+    Role,
+    TokenUsage,
+    ToolCall,
+)
+from agent_forge.llm.errors import (
+    LLMAuthError,
+    LLMRateLimitError,
+    LLMResponseError,
+    LLMTimeoutError,
+)
+from agent_forge.observability import get_logger
+
+logger = get_logger("anthropic")
+
+_ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1"
+_DEFAULT_MODEL = "claude-sonnet-4-6"
+_ANTHROPIC_VERSION = "2023-06-01"
+
+# Retry config per spec § 7.2
+_MAX_RETRIES = 5
+_BACKOFF_BASE = 2.0  # seconds
+_BACKOFF_MAX = 30.0  # cap delay at 30s
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 529}  # 529 = overloaded
+
+
+class AnthropicProvider(LLMProvider):
+    """Anthropic adapter using the Messages REST API with httpx."""
+
+    def __init__(self, api_key: str, *, base_url: str | None = None) -> None:
+        self._api_key = api_key
+        self._base_url = base_url or _ANTHROPIC_BASE_URL
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=httpx.Timeout(120.0),
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": _ANTHROPIC_VERSION,
+                "Content-Type": "application/json",
+            },
+        )
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: LLMConfig | None = None,
+    ) -> LLMResponse:
+        """Send a completion request and return the full response."""
+        cfg = config or LLMConfig(model=_DEFAULT_MODEL)
+        body = self._build_request_body(messages, tools, cfg)
+
+        data = await self._post_with_retry("/messages", body, cfg)
+        return self._parse_response(data, cfg.model)
+
+    async def stream(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: LLMConfig | None = None,
+    ) -> AsyncIterator[LLMResponse]:
+        """Stream partial responses as they arrive via SSE."""
+        cfg = config or LLMConfig(model=_DEFAULT_MODEL)
+        body = self._build_request_body(messages, tools, cfg)
+        body["stream"] = True
+
+        try:
+            async with self._client.stream(
+                "POST",
+                "/messages",
+                json=body,
+                timeout=httpx.Timeout(cfg.timeout_seconds),
+            ) as response:
+                self._check_status(response)
+                async for line in response.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    raw = line[6:]
+                    if raw.strip() == "[DONE]":
+                        break
+                    try:
+                        event = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    parsed = self._parse_stream_event(event, cfg.model)
+                    if parsed is not None:
+                        yield parsed
+        except httpx.TimeoutException as exc:
+            raise LLMTimeoutError(
+                f"Anthropic streaming request timed out after "
+                f"{cfg.timeout_seconds}s"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Request Building
+    # ------------------------------------------------------------------
+
+    def _build_request_body(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None,
+        config: LLMConfig,
+    ) -> dict[str, Any]:
+        """Build the Anthropic Messages API request body."""
+        system_text, api_messages = self._messages_to_anthropic(messages)
+
+        body: dict[str, Any] = {
+            "model": config.model,
+            "messages": api_messages,
+            "max_tokens": config.max_tokens,
+            "temperature": config.temperature,
+            "top_p": config.top_p,
+        }
+
+        if system_text:
+            body["system"] = system_text
+
+        if tools:
+            body["tools"] = [
+                {
+                    "name": t.name,
+                    "description": t.description,
+                    "input_schema": t.parameters,
+                }
+                for t in tools
+            ]
+
+        return body
+
+    @staticmethod
+    def _messages_to_anthropic(
+        messages: list[Message],
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Convert internal messages to Anthropic format.
+
+        Returns:
+            A tuple of (system_text, api_messages).
+        """
+        system_text: str | None = None
+        api_messages: list[dict[str, Any]] = []
+
+        for msg in messages:
+            if msg.role == Role.SYSTEM:
+                system_text = msg.content
+            elif msg.role == Role.USER:
+                api_messages.append({
+                    "role": "user",
+                    "content": msg.content,
+                })
+            elif msg.role == Role.ASSISTANT:
+                content: list[dict[str, Any]] = []
+                if msg.content:
+                    content.append({"type": "text", "text": msg.content})
+                if msg.tool_calls:
+                    for tc in msg.tool_calls:
+                        content.append({
+                            "type": "tool_use",
+                            "id": tc.id,
+                            "name": tc.name,
+                            "input": tc.arguments,
+                        })
+                api_messages.append({
+                    "role": "assistant",
+                    "content": content or msg.content,
+                })
+            elif msg.role == Role.TOOL:
+                api_messages.append({
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": msg.tool_call_id or "",
+                            "content": msg.content,
+                        }
+                    ],
+                })
+
+        return system_text, api_messages
+
+    # ------------------------------------------------------------------
+    # Response Parsing
+    # ------------------------------------------------------------------
+
+    def _parse_response(
+        self, data: dict[str, Any], model: str
+    ) -> LLMResponse:
+        """Parse an Anthropic Messages API response."""
+        content_blocks = data.get("content", [])
+        stop_reason = data.get("stop_reason", "end_turn")
+
+        text_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+
+        for block in content_blocks:
+            block_type = block.get("type")
+            if block_type == "text":
+                text_parts.append(block.get("text", ""))
+            elif block_type == "tool_use":
+                tool_calls.append(
+                    ToolCall(
+                        id=block.get("id", ""),
+                        name=block.get("name", ""),
+                        arguments=block.get("input", {}),
+                    )
+                )
+
+        usage_data = data.get("usage", {})
+        input_tokens = usage_data.get("input_tokens", 0)
+        output_tokens = usage_data.get("output_tokens", 0)
+        usage = TokenUsage(
+            prompt_tokens=input_tokens,
+            completion_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens,
+        )
+
+        mapped_reason = self._map_finish_reason(stop_reason, tool_calls)
+
+        return LLMResponse(
+            content="\n".join(text_parts) if text_parts else None,
+            tool_calls=tool_calls,
+            usage=usage,
+            model=model,
+            finish_reason=mapped_reason,
+        )
+
+    def _parse_stream_event(
+        self, event: dict[str, Any], model: str
+    ) -> LLMResponse | None:
+        """Parse a single SSE event from a streaming response."""
+        event_type = event.get("type")
+
+        if event_type == "content_block_delta":
+            delta = event.get("delta", {})
+            delta_type = delta.get("type")
+            if delta_type == "text_delta":
+                return LLMResponse(
+                    content=delta.get("text"),
+                    model=model,
+                    finish_reason="",
+                )
+        elif event_type == "message_delta":
+            stop_reason = event.get("delta", {}).get("stop_reason", "")
+            return LLMResponse(
+                content=None,
+                model=model,
+                finish_reason=self._map_finish_reason(stop_reason, []),
+            )
+        elif event_type == "message_stop":
+            return LLMResponse(
+                content=None,
+                model=model,
+                finish_reason="stop",
+            )
+
+        return None
+
+    @staticmethod
+    def _map_finish_reason(
+        anthropic_reason: str, tool_calls: list[ToolCall]
+    ) -> str:
+        """Map Anthropic stop reason to our standard reasons."""
+        if tool_calls:
+            return "tool_calls"
+        mapping = {
+            "end_turn": "stop",
+            "stop_sequence": "stop",
+            "max_tokens": "length",
+        }
+        return mapping.get(anthropic_reason, "stop")
+
+    # ------------------------------------------------------------------
+    # HTTP + Retry
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_delay(
+        attempt: int, resp: httpx.Response | None = None
+    ) -> float:
+        """Compute the retry delay, respecting Retry-After if present."""
+        if resp is not None:
+            retry_after = resp.headers.get(
+                "Retry-After"
+            ) or resp.headers.get("retry-after")
+            if retry_after:
+                try:
+                    parsed: float = float(retry_after)
+                    return min(parsed, _BACKOFF_MAX)
+                except ValueError:
+                    pass
+        # Exponential backoff with jitter
+        delay: float = _BACKOFF_BASE * (2**attempt)
+        jitter = random.uniform(0, delay * 0.25)  # noqa: S311
+        capped: float = min(delay + jitter, _BACKOFF_MAX)
+        return capped
+
+    async def _post_with_retry(
+        self,
+        url: str,
+        body: dict[str, Any],
+        config: LLMConfig,
+    ) -> dict[str, Any]:
+        """POST with exponential backoff retry on retryable errors."""
+        last_exc: Exception | None = None
+
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                resp = await self._client.post(
+                    url,
+                    json=body,
+                    timeout=httpx.Timeout(config.timeout_seconds),
+                )
+                if resp.status_code in _RETRYABLE_STATUS_CODES:
+                    if attempt < _MAX_RETRIES:
+                        delay = self._compute_delay(attempt, resp)
+                        logger.warning(
+                            "anthropic_retryable_error",
+                            status_code=resp.status_code,
+                            delay=round(delay, 1),
+                            attempt=attempt + 1,
+                            max_retries=_MAX_RETRIES,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+                    if resp.status_code == 429:
+                        raise LLMRateLimitError(
+                            f"Anthropic rate limit exceeded after "
+                            f"{_MAX_RETRIES} retries"
+                        )
+                    raise LLMResponseError(
+                        f"Anthropic API returned {resp.status_code} after "
+                        f"{_MAX_RETRIES} retries"
+                    )
+
+                self._check_status(resp)
+
+                try:
+                    return resp.json()  # type: ignore[no-any-return]
+                except (json.JSONDecodeError, ValueError) as exc:
+                    if attempt < _MAX_RETRIES:
+                        logger.warning(
+                            "anthropic_malformed_response",
+                            attempt=attempt + 1,
+                            max_retries=_MAX_RETRIES,
+                        )
+                        await asyncio.sleep(_BACKOFF_BASE)
+                        continue
+                    raise LLMResponseError(
+                        "Malformed JSON response from Anthropic API"
+                    ) from exc
+
+            except httpx.TimeoutException as exc:
+                last_exc = exc
+                if attempt < _MAX_RETRIES:
+                    logger.warning(
+                        "anthropic_timeout",
+                        attempt=attempt + 1,
+                        max_retries=_MAX_RETRIES,
+                    )
+                    await asyncio.sleep(_BACKOFF_BASE)
+                    continue
+                raise LLMTimeoutError(
+                    f"Anthropic request timed out after "
+                    f"{config.timeout_seconds}s "
+                    f"({_MAX_RETRIES} retries exhausted)"
+                ) from last_exc
+
+        # Should not reach here, but satisfy type checker
+        msg = "Unexpected retry loop exit"
+        raise LLMResponseError(msg)  # pragma: no cover
+
+    @staticmethod
+    def _check_status(resp: httpx.Response) -> None:
+        """Raise specific errors for non-retryable status codes."""
+        status_code = resp.status_code
+        if status_code == 401 or status_code == 403:  # noqa: PLR1714
+            raise LLMAuthError(
+                f"Anthropic authentication failed (HTTP {status_code}). "
+                "Check your ANTHROPIC_API_KEY."
+            )
+        if status_code >= 400:
+            try:
+                body = resp.json()
+                detail = body.get("error", {}).get(
+                    "message", resp.text[:500]
+                )
+            except Exception:  # noqa: BLE001
+                detail = resp.text[:500]
+            logger.error(
+                "anthropic_api_error",
+                status_code=status_code,
+                detail=detail,
+            )
+            raise LLMResponseError(
+                f"Anthropic API error (HTTP {status_code}): {detail}"
+            )

--- a/agent_forge/llm/factory.py
+++ b/agent_forge/llm/factory.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from agent_forge.llm.anthropic import AnthropicProvider
 from agent_forge.llm.gemini import GeminiProvider
+from agent_forge.llm.openai import OpenAIProvider
 
 if TYPE_CHECKING:
     from agent_forge.llm.base import LLMProvider
 
-_PROVIDERS: dict[str, type[GeminiProvider]] = {
+_PROVIDERS: dict[str, type[LLMProvider]] = {
     "gemini": GeminiProvider,
+    "openai": OpenAIProvider,
+    "anthropic": AnthropicProvider,
 }
 
 
@@ -22,7 +26,8 @@ def create_provider(
     """Create an LLM provider instance by name.
 
     Args:
-        name: Provider name (e.g. ``"gemini"``).
+        name: Provider name (e.g. ``"gemini"``, ``"openai"``,
+            ``"anthropic"``).
         api_key: API key for the provider.
         **kwargs: Additional keyword arguments forwarded to the provider
             constructor (e.g. ``base_url``).
@@ -39,4 +44,4 @@ def create_provider(
         msg = f"Unknown LLM provider '{name}'. Available: {available}"
         raise ValueError(msg)
 
-    return provider_cls(api_key=api_key, **kwargs)  # type: ignore[arg-type]
+    return provider_cls(api_key=api_key, **kwargs)  # type: ignore[call-arg]

--- a/agent_forge/llm/openai.py
+++ b/agent_forge/llm/openai.py
@@ -1,1 +1,415 @@
-"""OpenAI LLM provider adapter."""
+"""OpenAI LLM provider adapter.
+
+Uses the OpenAI Chat Completions REST API via httpx. Handles tool
+mapping, streaming, and retry logic per spec § 4.1 and § 7.2.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from agent_forge.llm.base import ToolDefinition
+
+import httpx
+
+from agent_forge.llm.base import (
+    LLMConfig,
+    LLMProvider,
+    LLMResponse,
+    Message,
+    Role,
+    TokenUsage,
+    ToolCall,
+)
+from agent_forge.llm.errors import (
+    LLMAuthError,
+    LLMRateLimitError,
+    LLMResponseError,
+    LLMTimeoutError,
+)
+from agent_forge.observability import get_logger
+
+logger = get_logger("openai")
+
+_OPENAI_BASE_URL = "https://api.openai.com/v1"
+_DEFAULT_MODEL = "gpt-5.4"
+
+# Retry config per spec § 7.2
+_MAX_RETRIES = 5
+_BACKOFF_BASE = 2.0  # seconds
+_BACKOFF_MAX = 30.0  # cap delay at 30s
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503}
+
+
+class OpenAIProvider(LLMProvider):
+    """OpenAI adapter using the Chat Completions REST API with httpx."""
+
+    def __init__(self, api_key: str, *, base_url: str | None = None) -> None:
+        self._api_key = api_key
+        self._base_url = base_url or _OPENAI_BASE_URL
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=httpx.Timeout(120.0),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: LLMConfig | None = None,
+    ) -> LLMResponse:
+        """Send a completion request and return the full response."""
+        cfg = config or LLMConfig(model=_DEFAULT_MODEL)
+        body = self._build_request_body(messages, tools, cfg)
+
+        data = await self._post_with_retry("/chat/completions", body, cfg)
+        return self._parse_response(data, cfg.model)
+
+    async def stream(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: LLMConfig | None = None,
+    ) -> AsyncIterator[LLMResponse]:
+        """Stream partial responses as they arrive via SSE."""
+        cfg = config or LLMConfig(model=_DEFAULT_MODEL)
+        body = self._build_request_body(messages, tools, cfg)
+        body["stream"] = True
+
+        try:
+            async with self._client.stream(
+                "POST",
+                "/chat/completions",
+                json=body,
+                timeout=httpx.Timeout(cfg.timeout_seconds),
+            ) as response:
+                self._check_status(response)
+                async for line in response.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    raw = line[6:]
+                    if raw.strip() == "[DONE]":
+                        break
+                    try:
+                        chunk = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    yield self._parse_stream_chunk(chunk, cfg.model)
+        except httpx.TimeoutException as exc:
+            raise LLMTimeoutError(
+                f"OpenAI streaming request timed out after {cfg.timeout_seconds}s"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Request Building
+    # ------------------------------------------------------------------
+
+    def _build_request_body(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None,
+        config: LLMConfig,
+    ) -> dict[str, Any]:
+        """Build the OpenAI Chat Completions request body."""
+        oai_messages = self._messages_to_openai(messages)
+        body: dict[str, Any] = {
+            "model": config.model,
+            "messages": oai_messages,
+            "temperature": config.temperature,
+            "max_tokens": config.max_tokens,
+            "top_p": config.top_p,
+        }
+
+        if tools:
+            body["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": t.name,
+                        "description": t.description,
+                        "parameters": t.parameters,
+                    },
+                }
+                for t in tools
+            ]
+            body["tool_choice"] = "auto"
+
+        return body
+
+    @staticmethod
+    def _messages_to_openai(messages: list[Message]) -> list[dict[str, Any]]:
+        """Convert internal messages to OpenAI chat format."""
+        oai_messages: list[dict[str, Any]] = []
+
+        for msg in messages:
+            if msg.role == Role.SYSTEM:
+                oai_messages.append({
+                    "role": "system",
+                    "content": msg.content,
+                })
+            elif msg.role == Role.USER:
+                oai_messages.append({
+                    "role": "user",
+                    "content": msg.content,
+                })
+            elif msg.role == Role.ASSISTANT:
+                m: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": msg.content,
+                }
+                if msg.tool_calls:
+                    m["tool_calls"] = [
+                        {
+                            "id": tc.id,
+                            "type": "function",
+                            "function": {
+                                "name": tc.name,
+                                "arguments": json.dumps(tc.arguments),
+                            },
+                        }
+                        for tc in msg.tool_calls
+                    ]
+                oai_messages.append(m)
+            elif msg.role == Role.TOOL:
+                oai_messages.append({
+                    "role": "tool",
+                    "tool_call_id": msg.tool_call_id or "",
+                    "content": msg.content,
+                })
+
+        return oai_messages
+
+    # ------------------------------------------------------------------
+    # Response Parsing
+    # ------------------------------------------------------------------
+
+    def _parse_response(self, data: dict[str, Any], model: str) -> LLMResponse:
+        """Parse an OpenAI Chat Completions response."""
+        choices = data.get("choices", [])
+        if not choices:
+            return LLMResponse(
+                content=None,
+                model=model,
+                finish_reason="error",
+            )
+
+        choice = choices[0]
+        message = choice.get("message", {})
+        finish_reason = choice.get("finish_reason", "stop")
+
+        content = message.get("content")
+        tool_calls = self._parse_tool_calls(message.get("tool_calls"))
+
+        usage_data = data.get("usage", {})
+        usage = TokenUsage(
+            prompt_tokens=usage_data.get("prompt_tokens", 0),
+            completion_tokens=usage_data.get("completion_tokens", 0),
+            total_tokens=usage_data.get("total_tokens", 0),
+        )
+
+        mapped_reason = self._map_finish_reason(finish_reason, tool_calls)
+
+        return LLMResponse(
+            content=content,
+            tool_calls=tool_calls,
+            usage=usage,
+            model=model,
+            finish_reason=mapped_reason,
+        )
+
+    def _parse_stream_chunk(
+        self, data: dict[str, Any], model: str
+    ) -> LLMResponse:
+        """Parse a single SSE chunk from a streaming response."""
+        choices = data.get("choices", [])
+        if not choices:
+            return LLMResponse(content=None, model=model, finish_reason="")
+
+        delta = choices[0].get("delta", {})
+        content = delta.get("content")
+        tool_calls = self._parse_tool_calls(delta.get("tool_calls"))
+        finish_reason = choices[0].get("finish_reason") or ""
+
+        return LLMResponse(
+            content=content,
+            tool_calls=tool_calls,
+            model=model,
+            finish_reason=finish_reason,
+        )
+
+    @staticmethod
+    def _parse_tool_calls(
+        raw_calls: list[dict[str, Any]] | None,
+    ) -> list[ToolCall]:
+        """Parse OpenAI tool_calls into our ToolCall objects."""
+        if not raw_calls:
+            return []
+        result: list[ToolCall] = []
+        for tc in raw_calls:
+            fn = tc.get("function", {})
+            args_str = fn.get("arguments", "{}")
+            try:
+                args = json.loads(args_str) if isinstance(args_str, str) else args_str
+            except json.JSONDecodeError:
+                args = {}
+            result.append(
+                ToolCall(
+                    id=tc.get("id", ""),
+                    name=fn.get("name", ""),
+                    arguments=args,
+                )
+            )
+        return result
+
+    @staticmethod
+    def _map_finish_reason(
+        oai_reason: str, tool_calls: list[ToolCall]
+    ) -> str:
+        """Map OpenAI finish reason to our standard reasons."""
+        if tool_calls:
+            return "tool_calls"
+        mapping = {
+            "stop": "stop",
+            "length": "length",
+            "content_filter": "error",
+        }
+        return mapping.get(oai_reason, "stop")
+
+    # ------------------------------------------------------------------
+    # HTTP + Retry
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_delay(
+        attempt: int, resp: httpx.Response | None = None
+    ) -> float:
+        """Compute the retry delay, respecting Retry-After if present."""
+        if resp is not None:
+            retry_after = resp.headers.get("Retry-After") or resp.headers.get(
+                "retry-after"
+            )
+            if retry_after:
+                try:
+                    parsed: float = float(retry_after)
+                    return min(parsed, _BACKOFF_MAX)
+                except ValueError:
+                    pass
+        # Exponential backoff with jitter
+        delay: float = _BACKOFF_BASE * (2**attempt)
+        jitter = random.uniform(0, delay * 0.25)  # noqa: S311
+        capped: float = min(delay + jitter, _BACKOFF_MAX)
+        return capped
+
+    async def _post_with_retry(
+        self,
+        url: str,
+        body: dict[str, Any],
+        config: LLMConfig,
+    ) -> dict[str, Any]:
+        """POST with exponential backoff retry on retryable errors."""
+        last_exc: Exception | None = None
+
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                resp = await self._client.post(
+                    url,
+                    json=body,
+                    timeout=httpx.Timeout(config.timeout_seconds),
+                )
+                if resp.status_code in _RETRYABLE_STATUS_CODES:
+                    if attempt < _MAX_RETRIES:
+                        delay = self._compute_delay(attempt, resp)
+                        logger.warning(
+                            "openai_retryable_error",
+                            status_code=resp.status_code,
+                            delay=round(delay, 1),
+                            attempt=attempt + 1,
+                            max_retries=_MAX_RETRIES,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+                    if resp.status_code == 429:
+                        raise LLMRateLimitError(
+                            f"OpenAI rate limit exceeded after {_MAX_RETRIES} retries"
+                        )
+                    raise LLMResponseError(
+                        f"OpenAI API returned {resp.status_code} after {_MAX_RETRIES} retries"
+                    )
+
+                self._check_status(resp)
+
+                try:
+                    return resp.json()  # type: ignore[no-any-return]
+                except (json.JSONDecodeError, ValueError) as exc:
+                    if attempt < _MAX_RETRIES:
+                        logger.warning(
+                            "openai_malformed_response",
+                            attempt=attempt + 1,
+                            max_retries=_MAX_RETRIES,
+                        )
+                        await asyncio.sleep(_BACKOFF_BASE)
+                        continue
+                    raise LLMResponseError(
+                        "Malformed JSON response from OpenAI API"
+                    ) from exc
+
+            except httpx.TimeoutException as exc:
+                last_exc = exc
+                if attempt < _MAX_RETRIES:
+                    logger.warning(
+                        "openai_timeout",
+                        attempt=attempt + 1,
+                        max_retries=_MAX_RETRIES,
+                    )
+                    await asyncio.sleep(_BACKOFF_BASE)
+                    continue
+                raise LLMTimeoutError(
+                    f"OpenAI request timed out after {config.timeout_seconds}s "
+                    f"({_MAX_RETRIES} retries exhausted)"
+                ) from last_exc
+
+        # Should not reach here, but satisfy type checker
+        msg = "Unexpected retry loop exit"
+        raise LLMResponseError(msg)  # pragma: no cover
+
+    @staticmethod
+    def _check_status(resp: httpx.Response) -> None:
+        """Raise specific errors for non-retryable status codes."""
+        status_code = resp.status_code
+        if status_code == 401 or status_code == 403:  # noqa: PLR1714
+            raise LLMAuthError(
+                f"OpenAI authentication failed (HTTP {status_code}). "
+                "Check your OPENAI_API_KEY."
+            )
+        if status_code >= 400:
+            try:
+                body = resp.json()
+                detail = (
+                    body.get("error", {}).get("message", resp.text[:500])
+                )
+            except Exception:  # noqa: BLE001
+                detail = resp.text[:500]
+            logger.error(
+                "openai_api_error", status_code=status_code, detail=detail
+            )
+            raise LLMResponseError(
+                f"OpenAI API error (HTTP {status_code}): {detail}"
+            )

--- a/tests/unit/test_llm_anthropic.py
+++ b/tests/unit/test_llm_anthropic.py
@@ -1,0 +1,443 @@
+"""Unit tests for the Anthropic LLM provider adapter.
+
+Uses respx to mock httpx requests to the Anthropic Messages API.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from agent_forge.llm.anthropic import AnthropicProvider
+from agent_forge.llm.base import (
+    LLMConfig,
+    Message,
+    Role,
+    ToolCall,
+    ToolDefinition,
+)
+from agent_forge.llm.errors import (
+    LLMAuthError,
+    LLMRateLimitError,
+    LLMResponseError,
+    LLMTimeoutError,
+)
+from agent_forge.llm.factory import create_provider
+
+_ANTHROPIC_URL = "https://api.anthropic.com/v1"
+_MODEL = "claude-sonnet-4-6"
+_MESSAGES_URL = f"{_ANTHROPIC_URL}/messages"
+
+
+def _text_response(text: str) -> dict[str, object]:
+    """Build a minimal Anthropic text response."""
+    return {
+        "content": [{"type": "text", "text": text}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+
+def _tool_use_response(
+    name: str, args: dict[str, object]
+) -> dict[str, object]:
+    """Build an Anthropic tool_use response."""
+    return {
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_abc123",
+                "name": name,
+                "input": args,
+            }
+        ],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 20, "output_tokens": 10},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Provider Construction
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicProvider:
+    """Tests for AnthropicProvider construction and lifecycle."""
+
+    def test_create_provider(self) -> None:
+        provider = AnthropicProvider(api_key="test-key")
+        assert isinstance(provider, AnthropicProvider)
+
+    def test_factory(self) -> None:
+        provider = create_provider("anthropic", api_key="test-key")
+        assert isinstance(provider, AnthropicProvider)
+
+
+# ---------------------------------------------------------------------------
+# Complete
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicComplete:
+    """Tests for AnthropicProvider.complete()."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_text_completion(self) -> None:
+        respx.post(_MESSAGES_URL).respond(
+            200, json=_text_response("Hello world!")
+        )
+
+        provider = AnthropicProvider(api_key="test-key")
+        config = LLMConfig(model=_MODEL)
+        messages = [Message(role=Role.USER, content="Say hello")]
+
+        resp = await provider.complete(messages, config=config)
+
+        assert resp.content == "Hello world!"
+        assert resp.finish_reason == "stop"
+        assert resp.usage.prompt_tokens == 10
+        assert resp.usage.completion_tokens == 5
+        assert resp.usage.total_tokens == 15
+        assert resp.model == _MODEL
+        assert resp.tool_calls == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_tool_use_completion(self) -> None:
+        respx.post(_MESSAGES_URL).respond(
+            200,
+            json=_tool_use_response("read_file", {"path": "main.py"}),
+        )
+
+        provider = AnthropicProvider(api_key="test-key")
+        tools = [
+            ToolDefinition(
+                name="read_file",
+                description="Read a file",
+                parameters={
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            )
+        ]
+        messages = [Message(role=Role.USER, content="Read main.py")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(
+            messages, tools=tools, config=config
+        )
+
+        assert resp.content is None
+        assert len(resp.tool_calls) == 1
+        assert resp.tool_calls[0].name == "read_file"
+        assert resp.tool_calls[0].arguments == {"path": "main.py"}
+        assert resp.tool_calls[0].id == "toolu_abc123"
+        assert resp.finish_reason == "tool_calls"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_system_message_handled(self) -> None:
+        respx.post(_MESSAGES_URL).respond(
+            200, json=_text_response("I understand.")
+        )
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [
+            Message(
+                role=Role.SYSTEM, content="You are a coding assistant."
+            ),
+            Message(role=Role.USER, content="Hello"),
+        ]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "I understand."
+
+        # Verify system as top-level field (not in messages)
+        request = respx.calls[0].request
+        body = json.loads(request.content)
+        assert body["system"] == "You are a coding assistant."
+        assert all(
+            m["role"] != "system" for m in body["messages"]
+        )
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_tool_result_message(self) -> None:
+        respx.post(_MESSAGES_URL).respond(
+            200,
+            json=_text_response("The file contains a function."),
+        )
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [
+            Message(role=Role.USER, content="Read main.py"),
+            Message(
+                role=Role.TOOL,
+                content="def main(): pass",
+                tool_call_id="toolu_abc",
+            ),
+        ]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "The file contains a function."
+
+        # Verify tool_result content block in request
+        request = respx.calls[0].request
+        body = json.loads(request.content)
+        tool_msg = body["messages"][1]
+        assert tool_msg["role"] == "user"
+        assert tool_msg["content"][0]["type"] == "tool_result"
+        assert tool_msg["content"][0]["tool_use_id"] == "toolu_abc"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_tools_in_request_body(self) -> None:
+        respx.post(_MESSAGES_URL).respond(
+            200, json=_text_response("ok")
+        )
+
+        provider = AnthropicProvider(api_key="test-key")
+        tools = [
+            ToolDefinition(
+                name="read_file",
+                description="Read a file",
+                parameters={
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            )
+        ]
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        await provider.complete(messages, tools=tools, config=config)
+
+        request = respx.calls[0].request
+        body = json.loads(request.content)
+        assert len(body["tools"]) == 1
+        assert body["tools"][0]["name"] == "read_file"
+        assert "input_schema" in body["tools"][0]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_assistant_tool_use_serialization(self) -> None:
+        respx.post(_MESSAGES_URL).respond(
+            200, json=_text_response("Done")
+        )
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [
+            Message(role=Role.USER, content="Read file"),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id="toolu_1",
+                        name="read_file",
+                        arguments={"path": "foo.py"},
+                    )
+                ],
+            ),
+            Message(
+                role=Role.TOOL,
+                content="file contents",
+                tool_call_id="toolu_1",
+            ),
+        ]
+        config = LLMConfig(model=_MODEL)
+
+        await provider.complete(messages, config=config)
+
+        request = respx.calls[0].request
+        body = json.loads(request.content)
+        assistant_msg = body["messages"][1]
+        assert assistant_msg["role"] == "assistant"
+        tool_use_block = [
+            b
+            for b in assistant_msg["content"]
+            if b["type"] == "tool_use"
+        ]
+        assert len(tool_use_block) == 1
+        assert tool_use_block[0]["id"] == "toolu_1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_anthropic_version_header(self) -> None:
+        respx.post(_MESSAGES_URL).respond(
+            200, json=_text_response("ok")
+        )
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        await provider.complete(messages, config=config)
+
+        request = respx.calls[0].request
+        assert request.headers["anthropic-version"] == "2023-06-01"
+        assert request.headers["x-api-key"] == "test-key"
+
+
+# ---------------------------------------------------------------------------
+# Error Handling
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicErrors:
+    """Tests for error handling and retry logic."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_auth_error(self) -> None:
+        respx.post(_MESSAGES_URL).respond(
+            401,
+            json={"error": {"message": "unauthorized"}},
+        )
+
+        provider = AnthropicProvider(api_key="bad-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        with pytest.raises(LLMAuthError, match="authentication failed"):
+            await provider.complete(messages, config=config)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_rate_limit_exhausts_retries(self) -> None:
+        respx.post(_MESSAGES_URL).respond(
+            429,
+            json={"error": {"message": "rate limited"}},
+        )
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        with pytest.raises(LLMRateLimitError, match="rate limit"):
+            await provider.complete(messages, config=config)
+
+        assert len(respx.calls) == 6
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_rate_limit_retries_then_succeeds(self) -> None:
+        route = respx.post(_MESSAGES_URL)
+        route.side_effect = [
+            httpx.Response(
+                429, json={"error": {"message": "rate limited"}}
+            ),
+            httpx.Response(
+                429, json={"error": {"message": "rate limited"}}
+            ),
+            httpx.Response(200, json=_text_response("Success!")),
+        ]
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "Success!"
+        assert len(respx.calls) == 3
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_timeout_error(self) -> None:
+        respx.post(_MESSAGES_URL).mock(
+            side_effect=httpx.ReadTimeout("timeout")
+        )
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL, timeout_seconds=1)
+
+        with pytest.raises(LLMTimeoutError, match="timed out"):
+            await provider.complete(messages, config=config)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_server_error_retries(self) -> None:
+        route = respx.post(_MESSAGES_URL)
+        route.side_effect = [
+            httpx.Response(500, text="Internal Server Error"),
+            httpx.Response(200, json=_text_response("Recovered")),
+        ]
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "Recovered"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_overloaded_retries(self) -> None:
+        """HTTP 529 (overloaded) is retryable for Anthropic."""
+        route = respx.post(_MESSAGES_URL)
+        route.side_effect = [
+            httpx.Response(529, text="Overloaded"),
+            httpx.Response(200, json=_text_response("Back")),
+        ]
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "Back"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_malformed_json_retries(self) -> None:
+        route = respx.post(_MESSAGES_URL)
+        route.side_effect = [
+            httpx.Response(200, text="not json"),
+            httpx.Response(200, json=_text_response("Fixed")),
+        ]
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "Fixed"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_malformed_json_exhausts_retries(self) -> None:
+        respx.post(_MESSAGES_URL).respond(200, text="not json at all")
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        with pytest.raises(LLMResponseError, match="Malformed JSON"):
+            await provider.complete(messages, config=config)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_empty_content(self) -> None:
+        respx.post(_MESSAGES_URL).respond(
+            200,
+            json={
+                "content": [],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            },
+        )
+
+        provider = AnthropicProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content is None
+        assert resp.finish_reason == "stop"

--- a/tests/unit/test_llm_openai.py
+++ b/tests/unit/test_llm_openai.py
@@ -1,0 +1,417 @@
+"""Unit tests for the OpenAI LLM provider adapter.
+
+Uses respx to mock httpx requests to the OpenAI Chat Completions API.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from agent_forge.llm.base import (
+    LLMConfig,
+    Message,
+    Role,
+    ToolCall,
+    ToolDefinition,
+)
+from agent_forge.llm.errors import (
+    LLMAuthError,
+    LLMRateLimitError,
+    LLMResponseError,
+    LLMTimeoutError,
+)
+from agent_forge.llm.factory import create_provider
+from agent_forge.llm.openai import OpenAIProvider
+
+_OPENAI_URL = "https://api.openai.com/v1"
+_MODEL = "gpt-5.4"
+_COMPLETIONS_URL = f"{_OPENAI_URL}/chat/completions"
+
+
+def _text_response(text: str) -> dict[str, object]:
+    """Build a minimal OpenAI text completion response."""
+    return {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+
+
+def _tool_call_response(
+    name: str, args: dict[str, object]
+) -> dict[str, object]:
+    """Build an OpenAI tool call response."""
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {
+                                "name": name,
+                                "arguments": json.dumps(args),
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 20,
+            "completion_tokens": 10,
+            "total_tokens": 30,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Provider Construction
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIProvider:
+    """Tests for OpenAIProvider construction and lifecycle."""
+
+    def test_create_provider(self) -> None:
+        provider = OpenAIProvider(api_key="test-key")
+        assert isinstance(provider, OpenAIProvider)
+
+    def test_factory(self) -> None:
+        provider = create_provider("openai", api_key="test-key")
+        assert isinstance(provider, OpenAIProvider)
+
+    def test_factory_unknown(self) -> None:
+        with pytest.raises(ValueError, match="Unknown LLM provider"):
+            create_provider("unknown", api_key="k")
+
+
+# ---------------------------------------------------------------------------
+# Complete
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIComplete:
+    """Tests for OpenAIProvider.complete()."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_text_completion(self) -> None:
+        respx.post(_COMPLETIONS_URL).respond(
+            200, json=_text_response("Hello world!")
+        )
+
+        provider = OpenAIProvider(api_key="test-key")
+        config = LLMConfig(model=_MODEL)
+        messages = [Message(role=Role.USER, content="Say hello")]
+
+        resp = await provider.complete(messages, config=config)
+
+        assert resp.content == "Hello world!"
+        assert resp.finish_reason == "stop"
+        assert resp.usage.total_tokens == 15
+        assert resp.model == _MODEL
+        assert resp.tool_calls == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_tool_call_completion(self) -> None:
+        respx.post(_COMPLETIONS_URL).respond(
+            200,
+            json=_tool_call_response("read_file", {"path": "main.py"}),
+        )
+
+        provider = OpenAIProvider(api_key="test-key")
+        tools = [
+            ToolDefinition(
+                name="read_file",
+                description="Read a file",
+                parameters={
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            )
+        ]
+        messages = [Message(role=Role.USER, content="Read main.py")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, tools=tools, config=config)
+
+        assert resp.content is None
+        assert len(resp.tool_calls) == 1
+        assert resp.tool_calls[0].name == "read_file"
+        assert resp.tool_calls[0].arguments == {"path": "main.py"}
+        assert resp.finish_reason == "tool_calls"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_system_message_handled(self) -> None:
+        respx.post(_COMPLETIONS_URL).respond(
+            200, json=_text_response("I understand.")
+        )
+
+        provider = OpenAIProvider(api_key="test-key")
+        messages = [
+            Message(
+                role=Role.SYSTEM, content="You are a coding assistant."
+            ),
+            Message(role=Role.USER, content="Hello"),
+        ]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "I understand."
+
+        # Verify system message in request
+        request = respx.calls[0].request
+        body = json.loads(request.content)
+        assert body["messages"][0]["role"] == "system"
+        assert (
+            body["messages"][0]["content"]
+            == "You are a coding assistant."
+        )
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_tool_result_message(self) -> None:
+        respx.post(_COMPLETIONS_URL).respond(
+            200, json=_text_response("The file contains a function.")
+        )
+
+        provider = OpenAIProvider(api_key="test-key")
+        messages = [
+            Message(role=Role.USER, content="Read main.py"),
+            Message(
+                role=Role.TOOL,
+                content="def main(): pass",
+                tool_call_id="call_abc",
+            ),
+        ]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "The file contains a function."
+
+        # Verify tool message in request body
+        request = respx.calls[0].request
+        body = json.loads(request.content)
+        tool_msg = body["messages"][1]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "call_abc"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_tool_choice_auto_when_tools_provided(self) -> None:
+        respx.post(_COMPLETIONS_URL).respond(
+            200, json=_text_response("ok")
+        )
+
+        provider = OpenAIProvider(api_key="test-key")
+        tools = [
+            ToolDefinition(
+                name="read_file",
+                description="Read a file",
+                parameters={
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            )
+        ]
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        await provider.complete(messages, tools=tools, config=config)
+
+        request = respx.calls[0].request
+        body = json.loads(request.content)
+        assert body["tool_choice"] == "auto"
+        assert len(body["tools"]) == 1
+        assert body["tools"][0]["type"] == "function"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_assistant_tool_call_serialization(self) -> None:
+        respx.post(_COMPLETIONS_URL).respond(
+            200, json=_text_response("Done")
+        )
+
+        provider = OpenAIProvider(api_key="test-key")
+        messages = [
+            Message(role=Role.USER, content="Read file"),
+            Message(
+                role=Role.ASSISTANT,
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id="call_1",
+                        name="read_file",
+                        arguments={"path": "foo.py"},
+                    )
+                ],
+            ),
+            Message(
+                role=Role.TOOL,
+                content="file contents",
+                tool_call_id="call_1",
+            ),
+        ]
+        config = LLMConfig(model=_MODEL)
+
+        await provider.complete(messages, config=config)
+
+        request = respx.calls[0].request
+        body = json.loads(request.content)
+        assistant_msg = body["messages"][1]
+        assert assistant_msg["role"] == "assistant"
+        assert len(assistant_msg["tool_calls"]) == 1
+        assert assistant_msg["tool_calls"][0]["id"] == "call_1"
+
+
+# ---------------------------------------------------------------------------
+# Error Handling
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIErrors:
+    """Tests for error handling and retry logic."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_auth_error(self) -> None:
+        respx.post(_COMPLETIONS_URL).respond(
+            401, json={"error": {"message": "unauthorized"}}
+        )
+
+        provider = OpenAIProvider(api_key="bad-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        with pytest.raises(LLMAuthError, match="authentication failed"):
+            await provider.complete(messages, config=config)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_rate_limit_exhausts_retries(self) -> None:
+        respx.post(_COMPLETIONS_URL).respond(
+            429, json={"error": {"message": "rate limited"}}
+        )
+
+        provider = OpenAIProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        with pytest.raises(LLMRateLimitError, match="rate limit"):
+            await provider.complete(messages, config=config)
+
+        assert len(respx.calls) == 6
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_rate_limit_retries_then_succeeds(self) -> None:
+        route = respx.post(_COMPLETIONS_URL)
+        route.side_effect = [
+            httpx.Response(
+                429, json={"error": {"message": "rate limited"}}
+            ),
+            httpx.Response(
+                429, json={"error": {"message": "rate limited"}}
+            ),
+            httpx.Response(200, json=_text_response("Success!")),
+        ]
+
+        provider = OpenAIProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "Success!"
+        assert len(respx.calls) == 3
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_timeout_error(self) -> None:
+        respx.post(_COMPLETIONS_URL).mock(
+            side_effect=httpx.ReadTimeout("timeout")
+        )
+
+        provider = OpenAIProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL, timeout_seconds=1)
+
+        with pytest.raises(LLMTimeoutError, match="timed out"):
+            await provider.complete(messages, config=config)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_server_error_retries(self) -> None:
+        route = respx.post(_COMPLETIONS_URL)
+        route.side_effect = [
+            httpx.Response(500, text="Internal Server Error"),
+            httpx.Response(200, json=_text_response("Recovered")),
+        ]
+
+        provider = OpenAIProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "Recovered"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_malformed_json_retries(self) -> None:
+        route = respx.post(_COMPLETIONS_URL)
+        route.side_effect = [
+            httpx.Response(200, text="not json"),
+            httpx.Response(200, json=_text_response("Fixed")),
+        ]
+
+        provider = OpenAIProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content == "Fixed"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_malformed_json_exhausts_retries(self) -> None:
+        respx.post(_COMPLETIONS_URL).respond(200, text="not json at all")
+
+        provider = OpenAIProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        with pytest.raises(LLMResponseError, match="Malformed JSON"):
+            await provider.complete(messages, config=config)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_empty_choices(self) -> None:
+        respx.post(_COMPLETIONS_URL).respond(
+            200, json={"choices": []}
+        )
+
+        provider = OpenAIProvider(api_key="test-key")
+        messages = [Message(role=Role.USER, content="Hello")]
+        config = LLMConfig(model=_MODEL)
+
+        resp = await provider.complete(messages, config=config)
+        assert resp.content is None
+        assert resp.finish_reason == "error"


### PR DESCRIPTION
## Summary

Implements OpenAI and Anthropic LLM provider adapters per spec § 4.1.

### OpenAI (`openai.py`)
- Chat Completions API via httpx
- `tools` array with `tool_choice: "auto"`
- SSE streaming with `stream: true`
- Exponential backoff retry (429/500/502/503)
- Default model: `gpt-5.4`

### Anthropic (`anthropic.py`)
- Messages API via httpx
- `tool_use` / `tool_result` content blocks
- System prompt as top-level `system` field
- SSE streaming, `anthropic-version: 2023-06-01`
- Exponential backoff retry (429/500/502/503/529)
- Default model: `claude-sonnet-4-6`

### Other changes
- `factory.py`: registers `"openai"` and `"anthropic"` providers
- `__init__.py`: exports `OpenAIProvider` and `AnthropicProvider`

### Tests
- 35 new unit tests (16 OpenAI + 17 Anthropic + 2 factory) with respx-mocked HTTP
- 241/241 total tests pass, lint clean

Closes #14