### PR TITLE
feat(#18): Redis-backed TaskQueue with priority, concurrency, docker-compose

### DIFF
--- a/agent_forge/orchestration/__init__.py
+++ b/agent_forge/orchestration/__init__.py
@@ -14,8 +14,19 @@ __all__ = [
     "EventBus",
     "EventType",
     "InMemoryQueue",
+    "RedisQueue",
     "Task",
     "TaskQueue",
     "TaskStatus",
     "Worker",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Lazy-import RedisQueue to avoid hard dependency on redis."""
+    if name == "RedisQueue":
+        from agent_forge.orchestration.redis_queue import RedisQueue
+
+        return RedisQueue
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/agent_forge/orchestration/redis_queue.py
+++ b/agent_forge/orchestration/redis_queue.py
@@ -1,0 +1,218 @@
+"""Redis-backed task queue for concurrent agent runs.
+
+Uses ``redis.asyncio`` with sorted sets for priority ordering and
+hashes for task metadata storage.  Implements the :class:`TaskQueue`
+ABC from spec § 4.5.
+
+Requires the ``redis`` optional dependency group::
+
+    pip install agent-forge[redis]
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent_forge.observability import get_logger
+from agent_forge.orchestration.queue import Task, TaskQueue, TaskStatus
+
+logger = get_logger("redis_queue")
+
+# Redis key prefixes
+_QUEUE_KEY = "agent_forge:queue"        # Sorted set: score = -priority
+_TASK_PREFIX = "agent_forge:task:"      # Hash per task
+_CONCURRENT_KEY = "agent_forge:active"  # Counter of active runs
+
+
+class RedisQueue(TaskQueue):
+    """Redis-backed priority task queue.
+
+    Tasks are stored in a sorted set keyed by *negative* priority
+    (``ZPOPMIN`` pops the lowest score, i.e. the highest priority).
+    Task metadata lives in individual hashes so status lookups are O(1).
+
+    Parameters
+    ----------
+    redis_url:
+        Redis connection URL (default ``redis://localhost:6379/0``).
+    max_concurrent_runs:
+        Maximum number of tasks that can be processed at once.
+        ``0`` means unlimited.
+    key_prefix:
+        Optional prefix for all Redis keys (useful for test isolation).
+    """
+
+    def __init__(
+        self,
+        redis_url: str = "redis://localhost:6379/0",
+        *,
+        max_concurrent_runs: int = 0,
+        key_prefix: str = "",
+    ) -> None:
+        try:
+            import redis.asyncio as aioredis
+        except ImportError as exc:
+            msg = (
+                "Redis support requires the 'redis' optional dependency. "
+                "Install with: pip install agent-forge[redis]"
+            )
+            raise ImportError(msg) from exc
+
+        self._redis: Any = aioredis.from_url(
+            redis_url, decode_responses=True,
+        )
+        self._max_concurrent = max_concurrent_runs
+        self._prefix = key_prefix
+        self._queue_key = f"{key_prefix}{_QUEUE_KEY}"
+        self._concurrent_key = f"{key_prefix}{_CONCURRENT_KEY}"
+
+    # ------------------------------------------------------------------
+    # TaskQueue ABC
+    # ------------------------------------------------------------------
+
+    async def enqueue(self, task: Task) -> str:
+        """Add a task to the queue."""
+        task.status = TaskStatus.QUEUED
+        task_key = self._task_key(task.id)
+
+        # Store task metadata as a hash
+        await self._redis.hset(task_key, mapping=self._task_to_dict(task))
+
+        # Add to sorted set: score = -priority (ZPOPMIN gets lowest score)
+        await self._redis.zadd(self._queue_key, {task.id: -task.priority})
+
+        logger.info(
+            "task_enqueued",
+            task_id=task.id,
+            priority=task.priority,
+        )
+        return task.id
+
+    async def dequeue(self) -> Task | None:
+        """Get the next highest-priority task, or ``None`` if empty.
+
+        Respects ``max_concurrent_runs`` — returns ``None`` if the
+        concurrency limit is reached even when tasks are queued.
+        """
+        # Concurrency check
+        if self._max_concurrent > 0:
+            active = await self._redis.get(self._concurrent_key)
+            if active is not None and int(active) >= self._max_concurrent:
+                return None
+
+        # Pop lowest-score (= highest-priority) task
+        result = await self._redis.zpopmin(self._queue_key, count=1)
+        if not result:
+            return None
+
+        task_id: str = result[0][0]
+        task_key = self._task_key(task_id)
+
+        # Update status to PROCESSING
+        await self._redis.hset(task_key, "status", TaskStatus.PROCESSING.value)
+
+        # Increment active counter
+        await self._redis.incr(self._concurrent_key)
+
+        task = await self._load_task(task_id)
+        if task is not None:
+            logger.info("task_dequeued", task_id=task.id)
+        return task
+
+    async def get_status(self, task_id: str) -> TaskStatus:
+        """Look up the current status of a task."""
+        task_key = self._task_key(task_id)
+        status_val = await self._redis.hget(task_key, "status")
+        if status_val is None:
+            msg = f"Unknown task ID: {task_id}"
+            raise KeyError(msg)
+        return TaskStatus(status_val)
+
+    async def cancel(self, task_id: str) -> bool:
+        """Cancel a queued task.
+
+        Only tasks with ``QUEUED`` status can be cancelled.
+        """
+        task_key = self._task_key(task_id)
+        status_val = await self._redis.hget(task_key, "status")
+        if status_val is None:
+            msg = f"Unknown task ID: {task_id}"
+            raise KeyError(msg)
+
+        if status_val != TaskStatus.QUEUED.value:
+            return False
+
+        # Remove from sorted set and mark as FAILED
+        await self._redis.zrem(self._queue_key, task_id)
+        await self._redis.hset(task_key, "status", TaskStatus.FAILED.value)
+        logger.info("task_cancelled", task_id=task_id)
+        return True
+
+    # ------------------------------------------------------------------
+    # Extended API
+    # ------------------------------------------------------------------
+
+    async def complete(self, task_id: str) -> None:
+        """Mark a task as completed and decrement the active counter."""
+        task_key = self._task_key(task_id)
+        await self._redis.hset(task_key, "status", TaskStatus.COMPLETED.value)
+        await self._redis.decr(self._concurrent_key)
+        logger.info("task_completed", task_id=task_id)
+
+    async def fail(self, task_id: str) -> None:
+        """Mark a task as failed and decrement the active counter."""
+        task_key = self._task_key(task_id)
+        await self._redis.hset(task_key, "status", TaskStatus.FAILED.value)
+        await self._redis.decr(self._concurrent_key)
+        logger.info("task_failed", task_id=task_id)
+
+    async def size(self) -> int:
+        """Number of tasks currently in the queue."""
+        result: int = await self._redis.zcard(self._queue_key)
+        return result
+
+    async def close(self) -> None:
+        """Close the Redis connection."""
+        await self._redis.aclose()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _task_key(self, task_id: str) -> str:
+        return f"{self._prefix}{_TASK_PREFIX}{task_id}"
+
+    @staticmethod
+    def _task_to_dict(task: Task) -> dict[str, str]:
+        """Serialize a Task to a flat dict for Redis HSET."""
+        return {
+            "id": task.id,
+            "task_description": task.task_description,
+            "repo_path": task.repo_path,
+            "config": json.dumps(
+                task.config if isinstance(task.config, dict) else {},
+            ),
+            "priority": str(task.priority),
+            "created_at": task.created_at.isoformat(),
+            "status": task.status.value,
+        }
+
+    async def _load_task(self, task_id: str) -> Task | None:
+        """Reconstruct a Task from its Redis hash."""
+        from datetime import datetime
+
+        task_key = self._task_key(task_id)
+        data: dict[str, Any] = await self._redis.hgetall(task_key)
+        if not data:
+            return None
+
+        return Task(
+            id=data["id"],
+            task_description=data["task_description"],
+            repo_path=data["repo_path"],
+            config=json.loads(data.get("config", "{}")),
+            priority=int(data.get("priority", "0")),
+            created_at=datetime.fromisoformat(data["created_at"]),
+            status=TaskStatus(data["status"]),
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.9"
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  redis_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 
+[[tool.mypy.overrides]]
+module = "redis.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/tests/integration/test_redis_queue_integration.py
+++ b/tests/integration/test_redis_queue_integration.py
@@ -1,0 +1,185 @@
+"""Integration tests for RedisQueue against a real Redis instance.
+
+These tests require a running Redis server on localhost:6379.
+They are automatically skipped if Redis is not available.
+
+Run with: docker compose up redis -d && pytest tests/integration/ -v
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from agent_forge.orchestration.queue import Task, TaskStatus
+
+# Skip entire module if redis is not installed or server is unreachable
+try:
+    import redis.asyncio as aioredis
+
+    _r = aioredis.from_url("redis://localhost:6379/0")
+except ImportError:
+    pytest.skip("redis package not installed", allow_module_level=True)
+
+
+async def _redis_available() -> bool:
+    """Check if a Redis server is reachable."""
+    try:
+        r = aioredis.from_url("redis://localhost:6379/0")
+        await r.ping()
+        await r.aclose()
+    except Exception:  # noqa: BLE001
+        return False
+    else:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PREFIX = "test_integration:"
+
+
+def _make_task(
+    *,
+    priority: int = 0,
+    task_id: str | None = None,
+) -> Task:
+    import uuid
+
+    return Task(
+        id=task_id or str(uuid.uuid4()),
+        task_description="Integration test task",
+        repo_path="/tmp/test-repo",
+        config={},
+        priority=priority,
+        created_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redis_available() -> None:
+    """Prerequisite — skip remaining tests if Redis is down."""
+    if not await _redis_available():
+        pytest.skip("Redis server not available at localhost:6379")
+
+
+@pytest.mark.asyncio
+async def test_full_lifecycle() -> None:
+    """Enqueue → dequeue → complete round-trip."""
+    if not await _redis_available():
+        pytest.skip("Redis server not available")
+
+    from agent_forge.orchestration.redis_queue import RedisQueue
+
+    q = RedisQueue(key_prefix=_PREFIX)
+    try:
+        task = _make_task()
+        task_id = await q.enqueue(task)
+        assert await q.get_status(task_id) == TaskStatus.QUEUED
+
+        dequeued = await q.dequeue()
+        assert dequeued is not None
+        assert dequeued.id == task_id
+        assert await q.get_status(task_id) == TaskStatus.PROCESSING
+
+        await q.complete(task_id)
+        assert await q.get_status(task_id) == TaskStatus.COMPLETED
+    finally:
+        # Cleanup
+        await q._redis.flushdb()
+        await q.close()
+
+
+@pytest.mark.asyncio
+async def test_priority_ordering() -> None:
+    """Higher priority tasks dequeue first."""
+    if not await _redis_available():
+        pytest.skip("Redis server not available")
+
+    from agent_forge.orchestration.redis_queue import RedisQueue
+
+    q = RedisQueue(key_prefix=_PREFIX)
+    try:
+        low = _make_task(priority=1, task_id="low")
+        high = _make_task(priority=10, task_id="high")
+        mid = _make_task(priority=5, task_id="mid")
+
+        await q.enqueue(low)
+        await q.enqueue(high)
+        await q.enqueue(mid)
+
+        first = await q.dequeue()
+        second = await q.dequeue()
+        third = await q.dequeue()
+
+        assert first is not None and first.id == "high"
+        assert second is not None and second.id == "mid"
+        assert third is not None and third.id == "low"
+    finally:
+        await q._redis.flushdb()
+        await q.close()
+
+
+@pytest.mark.asyncio
+async def test_cancel() -> None:
+    """Cancelled tasks are removed from the queue."""
+    if not await _redis_available():
+        pytest.skip("Redis server not available")
+
+    from agent_forge.orchestration.redis_queue import RedisQueue
+
+    q = RedisQueue(key_prefix=_PREFIX)
+    try:
+        task = _make_task()
+        task_id = await q.enqueue(task)
+
+        assert await q.cancel(task_id) is True
+        assert await q.get_status(task_id) == TaskStatus.FAILED
+
+        # Queue should now be empty
+        dequeued = await q.dequeue()
+        assert dequeued is None
+    finally:
+        await q._redis.flushdb()
+        await q.close()
+
+
+@pytest.mark.asyncio
+async def test_max_concurrent_runs() -> None:
+    """Dequeue respects max_concurrent_runs limit."""
+    if not await _redis_available():
+        pytest.skip("Redis server not available")
+
+    from agent_forge.orchestration.redis_queue import RedisQueue
+
+    q = RedisQueue(key_prefix=_PREFIX, max_concurrent_runs=1)
+    try:
+        t1 = _make_task(task_id="t1")
+        t2 = _make_task(task_id="t2")
+
+        await q.enqueue(t1)
+        await q.enqueue(t2)
+
+        # First dequeue should work
+        first = await q.dequeue()
+        assert first is not None
+
+        # Second should be blocked by concurrency limit
+        second = await q.dequeue()
+        assert second is None
+
+        # After completing first, second should work
+        await q.complete(first.id)
+        second = await q.dequeue()
+        assert second is not None
+    finally:
+        await q._redis.flushdb()
+        await q.close()

--- a/tests/unit/test_redis_queue.py
+++ b/tests/unit/test_redis_queue.py
@@ -1,0 +1,350 @@
+"""Unit tests for the Redis-backed task queue (mocked Redis)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent_forge.orchestration.queue import Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(
+    *,
+    priority: int = 0,
+    task_id: str = "test-task-1",
+) -> Task:
+    return Task(
+        id=task_id,
+        task_description="Fix the login bug",
+        repo_path="/tmp/test-repo",
+        config={},
+        priority=priority,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _mock_redis() -> AsyncMock:
+    """Create a mock async Redis client with required methods."""
+    r = AsyncMock()
+    r.hset = AsyncMock()
+    r.hget = AsyncMock()
+    r.hgetall = AsyncMock(return_value={})
+    r.zadd = AsyncMock()
+    r.zpopmin = AsyncMock(return_value=[])
+    r.zrem = AsyncMock()
+    r.zcard = AsyncMock(return_value=0)
+    r.get = AsyncMock(return_value=None)
+    r.incr = AsyncMock()
+    r.decr = AsyncMock()
+    r.aclose = AsyncMock()
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRedisQueueEnqueue:
+    """Enqueue stores task in hash and sorted set."""
+
+    @pytest.mark.asyncio
+    async def test_enqueue_stores_task(self) -> None:
+        mock_redis = _mock_redis()
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        task = _make_task()
+        result = await q.enqueue(task)
+
+        assert result == "test-task-1"
+        assert task.status == TaskStatus.QUEUED
+        mock_redis.hset.assert_called_once()
+        mock_redis.zadd.assert_called_once_with(
+            "agent_forge:queue", {"test-task-1": 0},
+        )
+
+    @pytest.mark.asyncio
+    async def test_enqueue_negative_score_for_priority(self) -> None:
+        mock_redis = _mock_redis()
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        task = _make_task(priority=5)
+        await q.enqueue(task)
+
+        mock_redis.zadd.assert_called_once_with(
+            "agent_forge:queue", {"test-task-1": -5},
+        )
+
+
+class TestRedisQueueDequeue:
+    """Dequeue pops from sorted set and updates status."""
+
+    @pytest.mark.asyncio
+    async def test_dequeue_empty_returns_none(self) -> None:
+        mock_redis = _mock_redis()
+        mock_redis.zpopmin.return_value = []
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        result = await q.dequeue()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_dequeue_returns_task(self) -> None:
+        mock_redis = _mock_redis()
+        now = datetime.now(UTC)
+        mock_redis.zpopmin.return_value = [("task-1", -5.0)]
+        mock_redis.hgetall.return_value = {
+            "id": "task-1",
+            "task_description": "Fix bug",
+            "repo_path": "/tmp/repo",
+            "config": "{}",
+            "priority": "5",
+            "created_at": now.isoformat(),
+            "status": "processing",
+        }
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        result = await q.dequeue()
+
+        assert result is not None
+        assert result.id == "task-1"
+        assert result.status == TaskStatus.PROCESSING
+        mock_redis.incr.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dequeue_respects_concurrency_limit(self) -> None:
+        mock_redis = _mock_redis()
+        mock_redis.get.return_value = "3"
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 3
+
+        result = await q.dequeue()
+        assert result is None
+        mock_redis.zpopmin.assert_not_called()
+
+
+class TestRedisQueueStatus:
+    """Status lookup from Redis hash."""
+
+    @pytest.mark.asyncio
+    async def test_get_status_returns_status(self) -> None:
+        mock_redis = _mock_redis()
+        mock_redis.hget.return_value = "queued"
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        status = await q.get_status("task-1")
+        assert status == TaskStatus.QUEUED
+
+    @pytest.mark.asyncio
+    async def test_get_status_unknown_raises(self) -> None:
+        mock_redis = _mock_redis()
+        mock_redis.hget.return_value = None
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        with pytest.raises(KeyError, match="Unknown task ID"):
+            await q.get_status("nonexistent")
+
+
+class TestRedisQueueCancel:
+    """Cancel removes from sorted set and marks FAILED."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_queued_task(self) -> None:
+        mock_redis = _mock_redis()
+        mock_redis.hget.return_value = "queued"
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        result = await q.cancel("task-1")
+
+        assert result is True
+        mock_redis.zrem.assert_called_once()
+        mock_redis.hset.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancel_processing_task_returns_false(self) -> None:
+        mock_redis = _mock_redis()
+        mock_redis.hget.return_value = "processing"
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        result = await q.cancel("task-1")
+        assert result is False
+
+
+class TestRedisQueueLifecycle:
+    """Complete/fail decrement the active counter."""
+
+    @pytest.mark.asyncio
+    async def test_complete_decrements_counter(self) -> None:
+        mock_redis = _mock_redis()
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        await q.complete("task-1")
+        mock_redis.decr.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fail_decrements_counter(self) -> None:
+        mock_redis = _mock_redis()
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        await q.fail("task-1")
+        mock_redis.decr.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close(self) -> None:
+        mock_redis = _mock_redis()
+        with patch(
+            "agent_forge.orchestration.redis_queue.RedisQueue.__init__",
+            return_value=None,
+        ):
+            from agent_forge.orchestration.redis_queue import RedisQueue
+
+            q = RedisQueue.__new__(RedisQueue)
+            q._redis = mock_redis
+            q._prefix = ""
+            q._queue_key = "agent_forge:queue"
+            q._concurrent_key = "agent_forge:active"
+            q._max_concurrent = 0
+
+        await q.close()
+        mock_redis.aclose.assert_called_once()
+
+
+class TestRedisQueueImportError:
+    """Missing redis dependency gives a helpful error."""
+
+    def test_import_error_message(self) -> None:
+        with patch.dict("sys.modules", {"redis": None, "redis.asyncio": None}):
+            # Force reimport
+            import importlib
+
+            import agent_forge.orchestration.redis_queue as mod
+
+            importlib.reload(mod)
+            with pytest.raises(ImportError, match="redis"):
+                mod.RedisQueue()


### PR DESCRIPTION
## Changes

- **`redis_queue.py`** — `RedisQueue(TaskQueue)` using sorted sets for priority ordering, hash-per-task metadata, `max_concurrent_runs` via counter key
- **`docker-compose.yml`** — Redis 7 Alpine dev service per spec § 11.2
- **`__init__.py`** — Lazy-import `RedisQueue` (no hard redis dependency)
- **`pyproject.toml`** — mypy override for `redis.*` optional dependency
- **`test_redis_queue.py`** — 13 unit tests (mocked Redis)
- **`test_redis_queue_integration.py`** — 4 integration tests (real Redis, auto-skipped)

## Testing

- 282 passed, 1 skipped, 89% coverage
- Lint + mypy clean

Closes #18