### PR TITLE
feat(#81): comprehensive code quality gates — ruff, vulture, radon, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,21 @@ jobs:
 
       - name: Run integration tests
         run: make test-integration
+
+  quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    needs: [lint]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run quality checks
+        run: make quality

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup build-sandbox test test-unit test-integration test-e2e lint format run clean update-prices
+.PHONY: setup build-sandbox test test-unit test-integration test-e2e lint format quality run clean update-prices
 
 update-prices:             ## Refresh vendored model pricing from LiteLLM
 	python scripts/update_prices.py
@@ -27,6 +27,11 @@ lint:                      ## Run linters
 
 format:                    ## Auto-format code
 	ruff format agent_forge tests
+
+quality:                   ## Run code quality checks (dead code + maintainability)
+	vulture agent_forge/ vulture_whitelist.py --min-confidence 80
+	radon cc agent_forge/ -n C -s
+	radon mi agent_forge/ -n B -s
 
 run:                       ## Run a demo task
 	python -m agent_forge.cli run --task "Add input validation" --repo ./tests/fixtures/sample_repo

--- a/agent_forge/agent/core.py
+++ b/agent_forge/agent/core.py
@@ -270,7 +270,7 @@ async def _execute_with_retry(
     tool_call: object,
     sandbox: Sandbox,
     run: AgentRun,
-    event_bus: EventBus | None,
+    event_bus: EventBus | None,  # noqa: ARG001 — will be used when #80 wires events
 ) -> ToolResult:
     """Execute a tool with retry on transient sandbox failures.
 
@@ -288,7 +288,7 @@ async def _execute_with_retry(
                     await sandbox.stop()
                     await sandbox.start(run.repo_path)
                     logger.info("sandbox_restarted", task_id=run.id)
-                except Exception:  # noqa: BLE001
+                except Exception:
                     logger.exception(
                         "sandbox_restart_failed", task_id=run.id,
                     )

--- a/agent_forge/cli.py
+++ b/agent_forge/cli.py
@@ -119,7 +119,7 @@ async def _run_agent(
         try:
             await sandbox.start(repo_path=repo)
             result = await react_loop(agent_run, llm, tools, sandbox)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 — top-level catch-all for CLI
             err_console.print(f"[red]Agent failed:[/red] {exc}")
             sys.exit(1)
         finally:

--- a/agent_forge/llm/anthropic.py
+++ b/agent_forge/llm/anthropic.py
@@ -405,7 +405,7 @@ class AnthropicProvider(LLMProvider):
     def _check_status(resp: httpx.Response) -> None:
         """Raise specific errors for non-retryable status codes."""
         status_code = resp.status_code
-        if status_code == 401 or status_code == 403:  # noqa: PLR1714
+        if status_code == 401 or status_code == 403:
             raise LLMAuthError(
                 f"Anthropic authentication failed (HTTP {status_code}). "
                 "Check your ANTHROPIC_API_KEY."

--- a/agent_forge/llm/gemini.py
+++ b/agent_forge/llm/gemini.py
@@ -375,7 +375,7 @@ class GeminiProvider(LLMProvider):
     def _check_status(resp: httpx.Response) -> None:
         """Raise specific errors for non-retryable status codes."""
         status_code = resp.status_code
-        if status_code == 401 or status_code == 403:  # noqa: PLR1714
+        if status_code == 401 or status_code == 403:
             raise LLMAuthError(
                 f"Gemini authentication failed (HTTP {status_code}). Check your GEMINI_API_KEY."
             )

--- a/agent_forge/llm/openai.py
+++ b/agent_forge/llm/openai.py
@@ -394,7 +394,7 @@ class OpenAIProvider(LLMProvider):
     def _check_status(resp: httpx.Response) -> None:
         """Raise specific errors for non-retryable status codes."""
         status_code = resp.status_code
-        if status_code == 401 or status_code == 403:  # noqa: PLR1714
+        if status_code == 401 or status_code == 403:
             raise LLMAuthError(
                 f"OpenAI authentication failed (HTTP {status_code}). "
                 "Check your OPENAI_API_KEY."

--- a/agent_forge/observability/__init__.py
+++ b/agent_forge/observability/__init__.py
@@ -31,15 +31,15 @@ from agent_forge.observability.tracing import (
 )
 
 __all__ = [
-    "clear_trace_context",
     "CostEntry",
     "CostTracker",
+    "TraceContext",
+    "clear_trace_context",
     "get_logger",
     "get_trace_context",
     "print_run_summary",
     "save_summary",
     "set_trace_context",
     "setup_logging",
-    "TraceContext",
     "update_iteration",
 ]

--- a/agent_forge/observability/cost.py
+++ b/agent_forge/observability/cost.py
@@ -179,6 +179,39 @@ def _section_header(title: str) -> str:
     return f"╠{'─' * _BOX_WIDTH}╣\n║ {title:<{_BOX_WIDTH - 1}}║"
 
 
+def _tool_summary_lines(run: AgentRun) -> list[str]:
+    """Build the 'Tool Invocations' section lines."""
+    if not run.tool_invocations:
+        return []
+    lines = [_section_header("Tool Invocations")]
+    tool_counts: Counter[str] = Counter()
+    tool_times: dict[str, list[int]] = {}
+    for inv in run.tool_invocations:
+        tool_counts[inv.tool_name] += 1
+        tool_times.setdefault(inv.tool_name, []).append(inv.duration_ms)
+    for name, count in tool_counts.most_common():
+        avg_ms = sum(tool_times[name]) // len(tool_times[name])
+        call_word = "call" if count == 1 else "calls"
+        lines.append(_row(f"  {name}:", f"{count} {call_word} (avg {avg_ms:,}ms)"))
+    return lines
+
+
+def _modified_files_lines(run: AgentRun) -> list[str]:
+    """Build the 'Files Modified' section lines."""
+    modified: list[str] = []
+    for inv in run.tool_invocations:
+        if inv.tool_name in ("write_file", "edit_file") and not inv.result.error:
+            path = inv.arguments.get("path") or inv.arguments.get("file_path")
+            if isinstance(path, str) and path not in modified:
+                modified.append(path)
+    if not modified:
+        return []
+    lines = [_section_header("Files Modified")]
+    for fpath in modified:
+        lines.append(_row("  M", fpath))
+    return lines
+
+
 def print_run_summary(
     run: AgentRun,
     tracker: CostTracker,
@@ -202,54 +235,29 @@ def print_run_summary(
     # Truncate task to fit the box
     task_display = run.task[:38] + "…" if len(run.task) > 39 else run.task
 
-    lines: list[str] = []
-    lines.append(f"╔{'═' * _BOX_WIDTH}╗")
-    lines.append(f"║{'Agent Forge — Run Summary':^{_BOX_WIDTH}}║")
-    lines.append(f"╠{'═' * _BOX_WIDTH}╣")
-    lines.append(_row("Run ID:", run.id))
-    lines.append(_row("Status:", status_str))
-    lines.append(_row("Task:", task_display))
-    lines.append(_row("Duration:", duration))
-    lines.append(_row("Iterations:", str(run.iterations)))
-    lines.append(_row("Model:", run.config.model))
+    lines: list[str] = [
+        f"╔{'═' * _BOX_WIDTH}╗",
+        f"║{'Agent Forge — Run Summary':^{_BOX_WIDTH}}║",
+        f"╠{'═' * _BOX_WIDTH}╣",
+        _row("Run ID:", run.id),
+        _row("Status:", status_str),
+        _row("Task:", task_display),
+        _row("Duration:", duration),
+        _row("Iterations:", str(run.iterations)),
+        _row("Model:", run.config.model),
+        # Token usage
+        _section_header("Token Usage"),
+        _row("  Prompt:", f"{s['total_prompt_tokens']:,} tokens"),
+        _row("  Completion:", f"{s['total_completion_tokens']:,} tokens"),
+        _row("  Total:", f"{s['total_tokens']:,} tokens"),
+        _row("  Est. Cost:", f"${s['total_cost_usd']:.4f}"),
+    ]
 
-    # Token usage section
-    lines.append(_section_header("Token Usage"))
-    lines.append(_row("  Prompt:", f"{s['total_prompt_tokens']:,} tokens"))
-    lines.append(_row("  Completion:", f"{s['total_completion_tokens']:,} tokens"))
-    lines.append(_row("  Total:", f"{s['total_tokens']:,} tokens"))
-    lines.append(_row("  Est. Cost:", f"${s['total_cost_usd']:.4f}"))
-
-    # Tool invocations section
-    if run.tool_invocations:
-        lines.append(_section_header("Tool Invocations"))
-        tool_counts: Counter[str] = Counter()
-        tool_times: dict[str, list[int]] = {}
-        for inv in run.tool_invocations:
-            tool_counts[inv.tool_name] += 1
-            tool_times.setdefault(inv.tool_name, []).append(inv.duration_ms)
-        for name, count in tool_counts.most_common():
-            avg_ms = sum(tool_times[name]) // len(tool_times[name])
-            call_word = "call" if count == 1 else "calls"
-            lines.append(
-                _row(f"  {name}:", f"{count} {call_word} (avg {avg_ms:,}ms)")
-            )
-
-    # Files modified section — extract from write_file tool invocations
-    modified_files: list[str] = []
-    for inv in run.tool_invocations:
-        if inv.tool_name in ("write_file", "edit_file") and not inv.result.error:
-            path = inv.arguments.get("path") or inv.arguments.get("file_path")
-            if isinstance(path, str) and path not in modified_files:
-                modified_files.append(path)
-    if modified_files:
-        lines.append(_section_header("Files Modified"))
-        for fpath in modified_files:
-            lines.append(_row("  M", fpath))
-
+    lines.extend(_tool_summary_lines(run))
+    lines.extend(_modified_files_lines(run))
     lines.append(f"╚{'═' * _BOX_WIDTH}╝")
-    output = "\n".join(lines)
 
+    output = "\n".join(lines)
     print(output, file=file)
     return output
 

--- a/agent_forge/observability/logger.py
+++ b/agent_forge/observability/logger.py
@@ -54,7 +54,7 @@ def _redact_value(value: Any) -> Any:
 
 
 def redact_secrets(
-    logger: Any, method_name: str, event_dict: dict[str, Any]
+    _logger: Any, _method_name: str, event_dict: dict[str, Any]
 ) -> dict[str, Any]:
     """structlog processor that redacts API key patterns from all values."""
     return {key: _redact_value(val) for key, val in event_dict.items()}
@@ -82,7 +82,7 @@ def setup_logging(
         log_file: Path to a JSON-lines log file.  Empty string ⇒ no file.
         console_format: ``"text"`` for colored console, ``"json"`` for JSON.
     """
-    global _CONFIGURED  # noqa: PLW0603
+    global _CONFIGURED
     if _CONFIGURED:
         return
     _CONFIGURED = True
@@ -173,7 +173,7 @@ def get_logger(component: str) -> Any:
 
 def reset_logging() -> None:
     """Reset logging configuration. Intended **only** for tests."""
-    global _CONFIGURED  # noqa: PLW0603
+    global _CONFIGURED
     _CONFIGURED = False
     root = logging.getLogger()
     root.handlers.clear()

--- a/agent_forge/observability/tracing.py
+++ b/agent_forge/observability/tracing.py
@@ -70,7 +70,7 @@ def update_iteration(iteration: int) -> TraceContext | None:
 
 
 def inject_trace_context(
-    logger: Any, method_name: str, event_dict: dict[str, Any]
+    _logger: Any, _method_name: str, event_dict: dict[str, Any]
 ) -> dict[str, Any]:
     """structlog processor that injects ``run_id`` and ``iteration``.
 

--- a/agent_forge/orchestration/events.py
+++ b/agent_forge/orchestration/events.py
@@ -31,7 +31,7 @@ class EventType(Enum):
     ITERATION_COMPLETED = "iteration.completed"
     TOOL_CALLED = "tool.called"
     TOOL_COMPLETED = "tool.completed"
-    TOKEN_USAGE = "token.usage"
+    TOKEN_USAGE = "token.usage"  # noqa: S105 — not a password
 
 
 @dataclass
@@ -67,7 +67,7 @@ class EventBus:
         for sub_id, handler in handlers:
             try:
                 await handler(event)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 logger.exception(
                     "event_handler_error",
                     subscription_id=sub_id,

--- a/agent_forge/orchestration/worker.py
+++ b/agent_forge/orchestration/worker.py
@@ -116,7 +116,7 @@ class Worker:
             )
             logger.info("task_completed", task_id=task.id)
 
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             task.status = TaskStatus.FAILED
 
             await self._event_bus.publish(

--- a/agent_forge/sandbox/docker.py
+++ b/agent_forge/sandbox/docker.py
@@ -70,7 +70,7 @@ class DockerSandbox(Sandbox):
         self._config = cfg
 
         security_opts: list[str] = ["no-new-privileges"]
-        tmpfs: dict[str, str] = {"/tmp": "rw,noexec,nosuid,size=64m"}
+        tmpfs: dict[str, str] = {"/tmp": "rw,noexec,nosuid,size=64m"}  # noqa: S108
 
         # Parse memory limit to bytes for Docker SDK
         mem_limit = cfg.memory_limit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dev = [
     "respx>=0.21",
     "types-docker>=7.0",
     "python-semantic-release>=9.0",
+    "vulture>=2.11",
+    "radon>=6.0",
 ]
 
 [project.scripts]
@@ -62,16 +64,32 @@ line-length = 100
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "N",   # pep8-naming
-    "UP",  # pyupgrade
-    "B",   # flake8-bugbear
-    "SIM", # flake8-simplify
-    "TCH", # flake8-type-checking
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "N",    # pep8-naming
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+    "TCH",  # flake8-type-checking
+    "C901", # McCabe complexity
+    "S",    # flake8-bandit (security)
+    "PT",   # flake8-pytest-style
+    "RET",  # flake8-return
+    "ARG",  # flake8-unused-arguments
+    "ERA",  # flake8-eradicate (commented-out code)
+    "PIE",  # flake8-pie (misc)
+    "RUF",  # Ruff-specific rules
+    "BLE",  # flake8-blind-except
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101", "S108", "ARG001", "ARG002", "PT018", "RUF015"]
+"tests/fixtures/**" = ["S201"]  # sample Flask app uses debug=True by design
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/e2e/test_cli_e2e.py
+++ b/tests/e2e/test_cli_e2e.py
@@ -33,12 +33,12 @@ pytestmark = [
 ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()
 
 
-@pytest.fixture()
+@pytest.fixture
 def sample_repo(tmp_path: Path) -> Path:
     """Create a minimal repo for the agent to work on."""
     (tmp_path / "hello.py").write_text("# placeholder\n")

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,0 +1,65 @@
+"""Vulture whitelist — intentionally 'unused' code.
+
+These items are flagged by vulture but are used at runtime
+(ABC methods, dunder protocols, exported symbols, lazy imports).
+"""
+
+# --- ABC abstract methods (overridden by subclasses) ---
+from agent_forge.orchestration.queue import TaskQueue
+
+TaskQueue.enqueue
+TaskQueue.dequeue
+TaskQueue.get_status
+TaskQueue.cancel
+
+# --- Dunder protocols ---
+from agent_forge.orchestration.queue import Task
+
+Task.__lt__
+
+# --- Lazy module-level __getattr__ ---
+import agent_forge.orchestration  # noqa: E402
+
+agent_forge.orchestration.__getattr__
+
+# --- Dataclass fields used by external callers ---
+Task.task_description
+Task.repo_path
+Task.config
+Task.priority
+Task.created_at
+
+# --- RedisQueue extended API (used by workers, not yet wired) ---
+from agent_forge.orchestration.redis_queue import RedisQueue
+
+RedisQueue.complete
+RedisQueue.fail
+RedisQueue.size
+RedisQueue.close
+
+# --- Event/EventBus (used by react_loop, not yet wired in CLI — see #80) ---
+from agent_forge.orchestration.events import Event, EventBus, EventType
+
+Event.event_type
+Event.data
+Event.timestamp
+EventBus.subscribe
+EventBus.emit
+EventType.TASK_STARTED
+EventType.TASK_COMPLETED
+EventType.TASK_FAILED
+EventType.TOOL_CALLED
+EventType.TOOL_RESULT
+EventType.ITERATION_START
+EventType.ITERATION_END
+
+# --- Worker (not yet wired in CLI — see #80) ---
+from agent_forge.orchestration.worker import Worker
+
+Worker.start
+Worker.stop
+
+# --- CLI entry point ---
+import agent_forge.cli  # noqa: E402
+
+agent_forge.cli.main


### PR DESCRIPTION
## Changes

### Ruff Expansion (9 → 19 rule groups)
- **C901** — McCabe complexity (max 10)
- **S** — Security/bandit (hardcoded passwords, eval, weak crypto)
- **PT** — Pytest best practices
- **RET** — Return statement checks
- **ARG** — Unused function arguments
- **ERA** — Commented-out code detection
- **PIE** — Misc. lint catches
- **RUF** — Ruff-specific rules
- **BLE** — Blind exception catching

### New Quality Tools
- **vulture** — dead code detection with whitelist
- **radon** — maintainability index scoring (A→F)
- `make quality` Makefile target
- `Code Quality` CI job (runs after lint)

### Code Triage (54 findings resolved)
- Refactored `print_run_summary` (C901 11→6) into `_tool_summary_lines` + `_modified_files_lines`
- Structlog processors: underscore prefix convention for unused params
- Targeted `noqa` (BLE001, S105, S108, ARG001)
- Per-file-ignores for tests and fixtures

### Verification
- `make lint` ✅ | `make quality` ✅ | `make test` (287 passed, 89% coverage) ✅

Closes #81