### PR TITLE
feat(#80): wire orchestration layer into CLI — EventBus, queue mode, worker

### DIFF
--- a/.agent/workflows/finish-issue.md
+++ b/.agent/workflows/finish-issue.md
@@ -44,10 +44,17 @@ When the user says "finish issue", "wrap up", or indicates the work is done, fol
 
 ## 6. Update documentation
 
-- Check if the change affects any existing docs (README, spec.md, docstrings)
-- If so, update them in the same branch — keep docs close to the code they describe
-- For new features or architectural changes, add documentation in the appropriate location
-- Skip this step if the change is trivial or purely internal refactoring
+- Review **all** documentation for relevance to the change:
+  - `README.md` — usage examples, feature list, project structure
+  - `spec.md` — technical specification, interface contracts
+  - `docs/` — architecture, configuration, extending, testing guides
+  - Inline docstrings in changed modules
+- For each doc, decide whether it needs to be **updated**, **created**, or **removed**:
+  - **Update** docs that describe changed behavior, CLI options, APIs, or architecture
+  - **Create** new docs when introducing a feature, pattern, or component that users/developers need to understand
+  - **Remove** or trim docs that describe deleted functionality or obsolete patterns
+- Keep docs close to the code they describe — commit doc changes in the same branch
+- Skip this step only if the change is trivial or purely internal refactoring with no user-facing impact
 
 ## 7. Clean commit(s)
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,24 @@ export GEMINI_API_KEY="your-key-here"
 ### Usage
 
 ```bash
-# Run an agent task
+# Run an agent task (direct mode — default)
 agent-forge run \
   --task "Add input validation to the /api/users endpoint" \
   --repo ./path/to/your/repo
+
+# Run via queue → worker pipeline (in-memory)
+agent-forge run \
+  --task "Fix login bug" \
+  --repo ./my-app \
+  --queue memory
+
+# Run via Redis queue (requires Redis)
+agent-forge run \
+  --task "Refactor auth module" \
+  --repo ./my-app \
+  --queue redis \
+  --redis-url redis://localhost:6379/0 \
+  --max-concurrent-runs 4
 
 # Check run status
 agent-forge status <run-id>

--- a/agent_forge/cli.py
+++ b/agent_forge/cli.py
@@ -37,12 +37,33 @@ def main() -> None:
 @click.option("--model", default=None, help="LLM model to use")
 @click.option("--provider", default=None, help="LLM provider (gemini, openai, anthropic)")
 @click.option("--max-iterations", default=None, type=int, help="Max ReAct loop iterations")
+@click.option(
+    "--queue",
+    "queue_backend",
+    default=None,
+    type=click.Choice(["memory", "redis"], case_sensitive=False),
+    help="Enable queue mode (memory or redis)",
+)
+@click.option(
+    "--redis-url",
+    default="redis://localhost:6379/0",
+    help="Redis URL when --queue=redis",
+)
+@click.option(
+    "--max-concurrent-runs",
+    default=0,
+    type=int,
+    help="Max concurrent tasks for queue worker (0=unlimited)",
+)
 def run(
     task: str,
     repo: str,
     model: str | None,
     provider: str | None,
     max_iterations: int | None,
+    queue_backend: str | None,
+    redis_url: str,
+    max_concurrent_runs: int,
 ) -> None:
     """Run an agent task on a repository."""
     # Build CLI overrides from provided flags
@@ -74,7 +95,17 @@ def run(
         )
         sys.exit(1)
 
-    asyncio.run(_run_agent(task, repo, cfg, provider_name, api_key))
+    if queue_backend is not None:
+        asyncio.run(
+            _run_agent_queued(
+                task, repo, cfg, provider_name, api_key,
+                queue_backend=queue_backend,
+                redis_url=redis_url,
+                max_concurrent_runs=max_concurrent_runs,
+            )
+        )
+    else:
+        asyncio.run(_run_agent(task, repo, cfg, provider_name, api_key))
 
 
 async def _run_agent(
@@ -84,14 +115,17 @@ async def _run_agent(
     provider_name: str,
     api_key: str,
 ) -> None:
-    """Execute the full agent pipeline."""
+    """Execute the full agent pipeline (direct mode).
+
+    Creates an ``EventBus`` so lifecycle events are emitted even in
+    direct mode — this enables observability subscribers.
+    """
     from agent_forge.agent.core import react_loop
     from agent_forge.agent.models import AgentConfig, AgentRun
-    from agent_forge.llm.gemini import GeminiProvider
+    from agent_forge.orchestration.events import EventBus
     from agent_forge.sandbox.docker import DockerSandbox
     from agent_forge.tools import create_default_registry
 
-    # Build agent config from resolved settings
     agent_config = AgentConfig(
         model=cfg.agent.default_model,
         max_iterations=cfg.agent.max_iterations,
@@ -100,25 +134,17 @@ async def _run_agent(
     )
 
     agent_run = AgentRun(task=task, repo_path=repo, config=agent_config)
-
-    # Create LLM provider
-    if provider_name == "gemini":
-        llm = GeminiProvider(api_key=api_key)
-    else:
-        err_console.print(
-            f"[red]Provider '{provider_name}' not yet implemented.[/red] "
-            "Only 'gemini' is available."
-        )
-        sys.exit(1)
-
-    # Create tools and sandbox
+    event_bus = EventBus()
+    llm = _create_llm(provider_name, api_key)
     tools = create_default_registry()
     sandbox = DockerSandbox()
 
     with console.status("[bold green]Agent running...", spinner="dots"):
         try:
             await sandbox.start(repo_path=repo)
-            result = await react_loop(agent_run, llm, tools, sandbox)
+            result = await react_loop(
+                agent_run, llm, tools, sandbox, event_bus=event_bus,
+            )
         except Exception as exc:  # noqa: BLE001 — top-level catch-all for CLI
             err_console.print(f"[red]Agent failed:[/red] {exc}")
             sys.exit(1)
@@ -126,8 +152,136 @@ async def _run_agent(
             await sandbox.stop()
             await llm.close()
 
-    # Display results
     _display_run_summary(result)
+
+
+async def _run_agent_queued(
+    task: str,
+    repo: str,
+    cfg: Any,
+    provider_name: str,
+    api_key: str,
+    *,
+    queue_backend: str,
+    redis_url: str,
+    max_concurrent_runs: int,
+) -> None:
+    """Execute the agent via queue → worker → react_loop.
+
+    Enqueues a :class:`Task`, starts a :class:`Worker`, and waits for
+    the task to complete or fail.
+    """
+    from agent_forge.agent.models import AgentConfig
+    from agent_forge.orchestration.events import EventBus
+    from agent_forge.orchestration.queue import InMemoryQueue, Task, TaskQueue, TaskStatus
+    from agent_forge.orchestration.worker import Worker
+
+    agent_config = AgentConfig(
+        model=cfg.agent.default_model,
+        max_iterations=cfg.agent.max_iterations,
+        max_tokens_per_run=cfg.agent.max_tokens_per_run,
+        temperature=cfg.agent.temperature,
+    )
+
+    event_bus = EventBus()
+
+    # Select queue backend
+    queue: TaskQueue
+    if queue_backend == "redis":
+        from agent_forge.orchestration.redis_queue import RedisQueue
+
+        queue = RedisQueue(
+            redis_url=redis_url,
+            max_concurrent_runs=max_concurrent_runs or 0,
+        )
+    else:
+        queue = InMemoryQueue()
+
+    # Build the task runner — this is what the Worker calls for each task
+    task_runner = _make_task_runner(cfg, provider_name, api_key, event_bus)
+
+    worker = Worker(queue=queue, event_bus=event_bus, task_runner=task_runner)
+
+    # Enqueue and run
+    queue_task = Task(
+        id="",
+        task_description=task,
+        repo_path=repo,
+        config=agent_config,
+    )
+
+    with console.status("[bold green]Agent running (queue mode)...", spinner="dots"):
+        try:
+            task_id = await queue.enqueue(queue_task)
+            console.print(f"[dim]Enqueued task {task_id}[/dim]")
+            await worker.start()
+
+            # Poll until the task completes or fails
+            while True:
+                status = await queue.get_status(task_id)
+                if status in (TaskStatus.COMPLETED, TaskStatus.FAILED):
+                    break
+                await asyncio.sleep(0.5)
+
+            if status == TaskStatus.FAILED:
+                err_console.print("[red]Task failed.[/red]")
+                sys.exit(1)
+            console.print("[green]Task completed.[/green]")
+        except Exception as exc:  # noqa: BLE001 — top-level catch-all
+            err_console.print(f"[red]Agent failed:[/red] {exc}")
+            sys.exit(1)
+        finally:
+            await worker.stop()
+            if hasattr(queue, "close"):
+                await queue.close()
+
+
+def _create_llm(provider_name: str, api_key: str) -> Any:
+    """Create an LLM provider instance by name."""
+    from agent_forge.llm.gemini import GeminiProvider
+
+    if provider_name == "gemini":
+        return GeminiProvider(api_key=api_key)
+    err_console.print(
+        f"[red]Provider '{provider_name}' not yet implemented.[/red] "
+        "Only 'gemini' is available."
+    )
+    sys.exit(1)
+
+
+def _make_task_runner(
+    _cfg: Any, provider_name: str, api_key: str, event_bus: Any,
+) -> Any:
+    """Build an async callable that the Worker invokes for each task.
+
+    Each invocation creates its own LLM client, sandbox, and tool
+    registry — resources are scoped to the single run.
+    """
+    from agent_forge.agent.core import react_loop
+    from agent_forge.agent.models import AgentRun
+    from agent_forge.sandbox.docker import DockerSandbox
+    from agent_forge.tools import create_default_registry
+
+    async def _runner(task: Any) -> None:
+        agent_run = AgentRun(
+            task=task.task_description,
+            repo_path=task.repo_path,
+            config=task.config,
+        )
+        llm = _create_llm(provider_name, api_key)
+        tools = create_default_registry()
+        sandbox = DockerSandbox()
+
+        try:
+            await sandbox.start(repo_path=task.repo_path)
+            await react_loop(
+                agent_run, llm, tools, sandbox, event_bus=event_bus,
+            )
+        finally:
+            await sandbox.stop()
+            await llm.close()
+
+    return _runner
 
 
 def _display_run_summary(run: Any) -> None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,9 @@ graph TD
 ### CLI Layer (`agent_forge/cli.py`)
 
 - Click-based commands: `run`, `status`, `list`, `config`
+- Two execution modes for `run`:
+  - **Direct mode** (default) — CLI creates an `EventBus` and calls `react_loop()` directly
+  - **Queue mode** (`--queue memory|redis`) — CLI enqueues a `Task`, a `Worker` dequeues and runs it
 - Wires configuration, API keys, LLM providers, and sandbox
 - Rich terminal output (tables, panels, syntax-highlighted JSON)
 
@@ -115,8 +118,14 @@ Tools are registered in `ToolRegistry` and their schemas are passed to the LLM a
 
 ### Orchestration (`agent_forge/orchestration/`)
 
-- `queue.py` — Task queue (Redis or in-memory) for concurrent runs
-- `events.py` — In-process pub/sub event bus
+| Module           | Purpose                                                           |
+| ---------------- | ----------------------------------------------------------------- |
+| `queue.py`       | Task queue ABC + in-memory priority queue implementation          |
+| `redis_queue.py` | Redis-backed task queue (requires `redis` extra)                  |
+| `worker.py`      | Polls the queue, invokes the task runner, emits lifecycle events  |
+| `events.py`      | In-process async pub/sub event bus (run started/completed/failed) |
+
+The CLI wires these together: `CLI → TaskQueue.enqueue() → Worker.dequeue() → react_loop()`.
 
 ## ReAct Loop Sequence
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,7 +89,10 @@ agent-forge run \
   --repo ./my-project \
   --provider gemini \
   --model gemini-3.1-flash-lite-preview \
-  --max-iterations 25
+  --max-iterations 25 \
+  --queue memory \                  # or "redis" (omit for direct mode)
+  --redis-url redis://localhost:6379/0 \   # only with --queue redis
+  --max-concurrent-runs 4           # worker concurrency limit
 
 agent-forge status <run-id>
 agent-forge list

--- a/tests/unit/test_cli_orchestration.py
+++ b/tests/unit/test_cli_orchestration.py
@@ -1,0 +1,216 @@
+"""Tests for CLI orchestration wiring (issue #80).
+
+Verifies that:
+- Direct mode creates EventBus and passes it to react_loop
+- Queue mode creates queue + worker, enqueues task, waits for completion
+- --queue=redis creates RedisQueue
+- _create_llm and _make_task_runner work correctly
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_forge.orchestration.events import EventBus
+from agent_forge.orchestration.queue import Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_config() -> MagicMock:
+    """Return a minimal config mock."""
+    cfg = MagicMock()
+    cfg.agent.default_model = "gemini-2.0-flash"
+    cfg.agent.max_iterations = 10
+    cfg.agent.max_tokens_per_run = 100_000
+    cfg.agent.temperature = 0.0
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Direct mode
+# ---------------------------------------------------------------------------
+
+class TestDirectModeEventBus:
+    """_run_agent should create EventBus and pass it to react_loop."""
+
+    @pytest.mark.asyncio
+    async def test_event_bus_passed_to_react_loop(self) -> None:
+        """EventBus is created and passed as kwarg to react_loop."""
+        from agent_forge.cli import _run_agent
+
+        with (
+            patch("agent_forge.cli._create_llm") as mock_llm_factory,
+            patch("agent_forge.tools.create_default_registry") as mock_tools,
+            patch("agent_forge.agent.core.react_loop", new_callable=AsyncMock) as mock_react,
+            patch("agent_forge.sandbox.docker.DockerSandbox") as mock_sandbox_cls,
+        ):
+            mock_sandbox = AsyncMock()
+            mock_sandbox_cls.return_value = mock_sandbox
+            mock_llm = AsyncMock()
+            mock_llm_factory.return_value = mock_llm
+            mock_tools.return_value = MagicMock()
+
+            # react_loop returns the run — Rich needs real strings
+            mock_result = MagicMock()
+            mock_result.state.value = "completed"
+            mock_result.id = "run-123"
+            mock_result.task = "test"
+            mock_result.iterations = 1
+            mock_result.total_tokens.total_tokens = 100
+            mock_result.completed_at = None
+            mock_result.error = None
+            mock_react.return_value = mock_result
+
+            await _run_agent("test task", "/tmp/repo", _fake_config(), "gemini", "key")
+
+            # Verify react_loop was called with event_bus kwarg
+            mock_react.assert_called_once()
+            call_kwargs = mock_react.call_args
+            assert "event_bus" in call_kwargs.kwargs
+            assert isinstance(call_kwargs.kwargs["event_bus"], EventBus)
+
+
+# ---------------------------------------------------------------------------
+# Queue mode
+# ---------------------------------------------------------------------------
+
+class TestQueueModeWiring:
+    """_run_agent_queued wires queue → worker → task_runner pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_memory_queue_enqueue_and_complete(self) -> None:
+        """Queue mode with memory backend enqueues task and waits."""
+        from agent_forge.cli import _run_agent_queued
+
+        with (
+            patch("agent_forge.cli._make_task_runner") as mock_make_runner,
+            patch("agent_forge.orchestration.worker.Worker.start", new_callable=AsyncMock),
+            patch("agent_forge.orchestration.worker.Worker.stop", new_callable=AsyncMock),
+            patch(
+                "agent_forge.orchestration.queue.InMemoryQueue.get_status",
+                new_callable=AsyncMock,
+                return_value=TaskStatus.COMPLETED,
+            ),
+            patch(
+                "agent_forge.orchestration.queue.InMemoryQueue.enqueue",
+                new_callable=AsyncMock,
+                return_value="task-abc",
+            ),
+        ):
+            async def fake_runner(task: Task) -> None:
+                pass
+
+            mock_make_runner.return_value = fake_runner
+
+            await _run_agent_queued(
+                "fix bug", "/tmp/repo", _fake_config(), "gemini", "key",
+                queue_backend="memory",
+                redis_url="redis://localhost",
+                max_concurrent_runs=0,
+            )
+
+            mock_make_runner.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_redis_queue_selected(self) -> None:
+        """--queue=redis creates RedisQueue."""
+        from agent_forge.cli import _run_agent_queued
+
+        with (
+            patch("agent_forge.cli._make_task_runner") as mock_make_runner,
+            patch("agent_forge.orchestration.redis_queue.RedisQueue") as mock_redis_cls,
+            patch("agent_forge.orchestration.worker.Worker.start", new_callable=AsyncMock),
+            patch("agent_forge.orchestration.worker.Worker.stop", new_callable=AsyncMock),
+        ):
+            # Mock RedisQueue instance
+            mock_queue = AsyncMock()
+            mock_queue.enqueue = AsyncMock(return_value="task-123")
+            mock_queue.get_status = AsyncMock(return_value=TaskStatus.COMPLETED)
+            mock_queue.close = AsyncMock()
+            mock_redis_cls.return_value = mock_queue
+
+            async def fake_runner(task: Task) -> None:
+                pass
+
+            mock_make_runner.return_value = fake_runner
+
+            await _run_agent_queued(
+                "fix bug", "/tmp/repo", _fake_config(), "gemini", "key",
+                queue_backend="redis",
+                redis_url="redis://custom:6380/1",
+                max_concurrent_runs=5,
+            )
+
+            mock_redis_cls.assert_called_once_with(
+                redis_url="redis://custom:6380/1",
+                max_concurrent_runs=5,
+            )
+            mock_queue.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _create_llm
+# ---------------------------------------------------------------------------
+
+class TestCreateLLM:
+    """_create_llm creates provider by name."""
+
+    def test_gemini_provider(self) -> None:
+        from agent_forge.cli import _create_llm
+
+        with patch("agent_forge.llm.gemini.GeminiProvider") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            result = _create_llm("gemini", "test-key")
+            mock_cls.assert_called_once_with(api_key="test-key")
+            assert result is mock_cls.return_value
+
+    def test_unknown_provider_exits(self) -> None:
+        from agent_forge.cli import _create_llm
+
+        with pytest.raises(SystemExit):
+            _create_llm("unknown", "key")
+
+
+# ---------------------------------------------------------------------------
+# _make_task_runner
+# ---------------------------------------------------------------------------
+
+class TestMakeTaskRunner:
+    """_make_task_runner builds an async callable for Worker."""
+
+    @pytest.mark.asyncio
+    async def test_runner_calls_react_loop(self) -> None:
+        from agent_forge.cli import _make_task_runner
+
+        with (
+            patch("agent_forge.cli._create_llm") as mock_llm_factory,
+            patch("agent_forge.agent.core.react_loop", new_callable=AsyncMock) as mock_react,
+            patch("agent_forge.sandbox.docker.DockerSandbox") as mock_sandbox_cls,
+        ):
+            mock_sandbox = AsyncMock()
+            mock_sandbox_cls.return_value = mock_sandbox
+            mock_llm = AsyncMock()
+            mock_llm_factory.return_value = mock_llm
+
+            event_bus = EventBus()
+            runner = _make_task_runner(_fake_config(), "gemini", "key", event_bus)
+
+            task = Task(
+                id="t-1",
+                task_description="fix login",
+                repo_path="/tmp/repo",
+                config=MagicMock(),
+            )
+
+            await runner(task)
+
+            mock_react.assert_called_once()
+            call_kwargs = mock_react.call_args
+            assert call_kwargs.kwargs["event_bus"] is event_bus
+            mock_sandbox.start.assert_called_once()
+            mock_sandbox.stop.assert_called_once()
+            mock_llm.close.assert_called_once()

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -22,42 +22,28 @@ import agent_forge.orchestration  # noqa: E402
 
 agent_forge.orchestration.__getattr__
 
-# --- Dataclass fields used by external callers ---
-Task.task_description
-Task.repo_path
-Task.config
+# --- Dataclass fields accessed dynamically ---
 Task.priority
 Task.created_at
 
-# --- RedisQueue extended API (used by workers, not yet wired) ---
+# --- RedisQueue extended API (used by Worker._process_task) ---
 from agent_forge.orchestration.redis_queue import RedisQueue
 
 RedisQueue.complete
 RedisQueue.fail
 RedisQueue.size
-RedisQueue.close
 
-# --- Event/EventBus (used by react_loop, not yet wired in CLI — see #80) ---
-from agent_forge.orchestration.events import Event, EventBus, EventType
+# --- Event fields accessed dynamically ---
+from agent_forge.orchestration.events import Event, EventType
 
-Event.event_type
 Event.data
 Event.timestamp
-EventBus.subscribe
-EventBus.emit
-EventType.TASK_STARTED
-EventType.TASK_COMPLETED
-EventType.TASK_FAILED
+
+# --- EventType members used by Worker + react_loop ---
 EventType.TOOL_CALLED
-EventType.TOOL_RESULT
-EventType.ITERATION_START
-EventType.ITERATION_END
-
-# --- Worker (not yet wired in CLI — see #80) ---
-from agent_forge.orchestration.worker import Worker
-
-Worker.start
-Worker.stop
+EventType.TOOL_COMPLETED
+EventType.ITERATION_STARTED
+EventType.ITERATION_COMPLETED
 
 # --- CLI entry point ---
 import agent_forge.cli  # noqa: E402


### PR DESCRIPTION
## Summary

Wire the orchestration layer (EventBus, TaskQueue, Worker) into the CLI `run` command so the system actually uses the infrastructure built in #15, #16, and #18.

### Changes

**CLI (`agent_forge/cli.py`)**
- **Direct mode** (default): creates `EventBus` and passes to `react_loop()` — lifecycle events now emitted
- **Queue mode** (`--queue memory|redis`): full pipeline `TaskQueue.enqueue() → Worker.dequeue() → react_loop()`
- New options: `--queue`, `--redis-url`, `--max-concurrent-runs`
- Extracted `_create_llm` helper and `_make_task_runner` factory

**Vulture whitelist** — removed symbols now actually used (EventBus, Worker.start/stop, etc.)

**Docs** — updated README (usage examples), `docs/architecture.md` (CLI modes, orchestration table), `docs/configuration.md` (CLI flags)

**Workflow** — improved finish-issue step 6 to cover all doc locations + create/update/delete

### Verification

- `make lint` ✅ | `make quality` ✅ | `make test` (293 passed, 90% coverage) ✅

Closes #80