### PR TITLE
ci: set up Release Drafter for structured release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,103 @@
+# Release Drafter configuration
+# Auto-categorizes PRs into structured release notes based on labels.
+# See: https://github.com/release-drafter/release-drafter
+
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+template: |
+  ## 🎯 What's New in v$RESOLVED_VERSION
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "enhancement"
+      - "feature"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "bug"
+      - "fix"
+  - title: "🧪 Testing"
+    labels:
+      - "testing"
+      - "test"
+  - title: "📖 Documentation"
+    labels:
+      - "documentation"
+  - title: "🔧 Infrastructure & CI"
+    labels:
+      - "ci"
+      - "infrastructure"
+      - "devops"
+  - title: "🔒 Security"
+    labels:
+      - "security"
+  - title: "🏗️ Refactoring"
+    labels:
+      - "refactor"
+  - title: "📦 Dependencies"
+    labels:
+      - "dependencies"
+
+  # If a PR has no matching label, put it here
+  - title: "🔀 Other Changes"
+    labels:
+      - "*"
+
+# Exclude these labels from release notes entirely
+exclude-labels:
+  - "skip-changelog"
+  - "duplicate"
+  - "wontfix"
+
+# Auto-label PRs based on file paths and branch names
+autolabeler:
+  - label: "documentation"
+    files:
+      - "docs/**"
+      - "*.md"
+    branch:
+      - "/docs?/"
+  - label: "testing"
+    files:
+      - "tests/**"
+    branch:
+      - "/test/"
+  - label: "ci"
+    files:
+      - ".github/**"
+      - "Makefile"
+  - label: "enhancement"
+    branch:
+      - "/feat/"
+      - "/feature/"
+  - label: "bug"
+    branch:
+      - "/fix/"
+      - "/bugfix/"
+
+# Version resolution — bumps based on labels
+version-resolver:
+  major:
+    labels:
+      - "breaking"
+  minor:
+    labels:
+      - "enhancement"
+      - "feature"
+  patch:
+    labels:
+      - "bug"
+      - "fix"
+      - "documentation"
+      - "testing"
+      - "ci"
+  default: patch
+
+# PR title formatting in release notes
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&@'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-release-draft:
+    name: Draft Release Notes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,19 @@ permissions:
 
 jobs:
   release:
-    name: Create Release
+    name: Publish Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Create GitHub Release
+      # Publish the existing draft created by Release Drafter.
+      # If no draft exists, creates a release with auto-generated notes.
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
           draft: false
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Set up [Release Drafter](https://github.com/release-drafter/release-drafter) for automated structured release notes.

### How it works

1. **On every PR merge to main** → Release Drafter auto-updates a draft release with categorized notes
2. **On tag push (`v*`)** → The draft is published as a GitHub Release

### Categories

PRs are grouped by labels:
| Category | Labels |
|----------|--------|
| 🚀 Features | `enhancement`, `feature` |
| 🐛 Bug Fixes | `bug`, `fix` |
| 🧪 Testing | `testing`, `test` |
| 📖 Documentation | `documentation` |
| 🔧 Infrastructure & CI | `ci`, `infrastructure` |
| 🔒 Security | `security` |

### Auto-labeling

PRs are auto-labeled based on:
- **File paths**: `docs/**` → `documentation`, `tests/**` → `testing`, `.github/**` → `ci`
- **Branch names**: `feat/*` → `enhancement`, `fix/*` → `bug`

### Version resolution

Suggested version bump based on labels: `enhancement` → minor, `bug` → patch, `breaking` → major

### Files

| File | Purpose |
|------|---------|
| `.github/release-drafter.yml` | Config (categories, auto-labeler, version resolver) |
| `.github/workflows/release-drafter.yml` | Workflow (runs on push to main + PR events) |
| `.github/workflows/release.yml` | Updated: publishes draft on tag push |