### PR TITLE
Add machine-readable CLI run output

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ agent-forge run \
 # Check run status
 agent-forge status <run-id>
 
+# Emit a machine-readable run result and persist it to disk
+agent-forge run \
+  --task "Generate a structured audit report" \
+  --repo ./my-app \
+  --output-format json \
+  --report-file ./artifacts/run-result.json
+
+# Render an existing run as JSON
+agent-forge status <run-id> --output-format json
+
 # List recent runs
 agent-forge list
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,14 +106,19 @@ agent-forge run \
   --provider gemini \
   --model gemini-3.1-flash-lite-preview \
   --max-iterations 25 \
+  --output-format text \            # or "json" for machine output
+  --report-file ./artifacts/run-result.json \  # optional JSON file output
   --queue memory \                  # or "redis" (omit for direct mode)
   --redis-url redis://localhost:6379/0 \   # only with --queue redis
   --max-concurrent-runs 4           # worker concurrency limit
 
-agent-forge status <run-id>
+agent-forge status <run-id> --output-format json
 agent-forge list
 agent-forge config        # Show resolved configuration
 ```
+
+Machine-readable output is only available in direct mode. Queue-backed runs
+still emit human-oriented status until that contract is stabilized.
 
 ## Common Setups
 


### PR DESCRIPTION
## Summary
- add machine-readable JSON output for `agent-forge run`
- add optional `--report-file` output for automation and service wrappers
- add JSON output for `agent-forge status`
- reject queue mode for machine-readable output until that path has a stable contract

## Verification
- .venv/bin/python -m pytest tests/unit/test_cli.py -q --capture=no

Refs #91
Refs akoita/proof-of-audit#241
