### PR TITLE
feat(#90): define hosted service API contract

### DIFF
--- a/agent_forge/service/__init__.py
+++ b/agent_forge/service/__init__.py
@@ -1,0 +1,5 @@
+"""Hosted service package for agent-forge."""
+
+from agent_forge.service.app import create_app
+
+__all__ = ["create_app"]

--- a/agent_forge/service/app.py
+++ b/agent_forge/service/app.py
@@ -1,0 +1,192 @@
+"""FastAPI app for the hosted agent-forge service contract."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+from agent_forge.orchestration.events import EventBus
+from agent_forge.orchestration.queue import InMemoryQueue, Task, TaskStatus
+from agent_forge.orchestration.worker import Worker
+from agent_forge.service.models import (
+    ErrorResponse,
+    RunArtifactRef,
+    RunError,
+    RunRequest,
+    RunStatus,
+)
+
+
+@dataclass
+class HostedRunRecord:
+    """Persistent in-memory record for a hosted run."""
+
+    run_id: str
+    request: RunRequest
+    workspace_dir: Path
+    created_at: datetime
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    error: RunError | None = None
+
+
+class HostedRunService:
+    """In-process implementation of the versioned hosted run API."""
+
+    def __init__(self, *, service_root: Path | None = None) -> None:
+        self._service_root = service_root or Path.cwd() / ".agent-forge-service"
+        self._queue = InMemoryQueue()
+        self._event_bus = EventBus()
+        self._records: dict[str, HostedRunRecord] = {}
+        self._worker = Worker(
+            queue=self._queue,
+            event_bus=self._event_bus,
+            task_runner=self._make_task_runner(),
+            poll_interval=0.05,
+        )
+
+    async def start(self) -> None:
+        """Start the background worker for hosted runs."""
+        self._service_root.mkdir(parents=True, exist_ok=True)
+        await self._worker.start()
+
+    async def stop(self) -> None:
+        """Stop the background worker for hosted runs."""
+        await self._worker.stop()
+
+    async def create_run(self, request: RunRequest) -> RunStatus:
+        """Accept a new hosted run request and enqueue it."""
+        run_id = f"run_{uuid.uuid4().hex[:16]}"
+        workspace_dir = self._service_root / "runs" / run_id
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        record = HostedRunRecord(
+            run_id=run_id,
+            request=request,
+            workspace_dir=workspace_dir,
+            created_at=datetime.now(UTC),
+        )
+        self._records[run_id] = record
+        await self._queue.enqueue(
+            Task(
+                id=run_id,
+                task_description=f"Hosted run for profile {request.profile.id}",
+                repo_path=str(workspace_dir),
+                config=None,
+            )
+        )
+        return self._build_status(record, status="accepted")
+
+    async def get_status(self, run_id: str) -> RunStatus:
+        """Return the current lifecycle document for a run."""
+        record = self._records.get(run_id)
+        if record is None:
+            raise KeyError(run_id)
+        queue_status = await self._queue.get_status(run_id)
+        return self._build_status(record, status=self._map_status(queue_status))
+
+    def _make_task_runner(self) -> Any:
+        async def _runner(task: Task) -> None:
+            record = self._records[task.id]
+            record.started_at = datetime.now(UTC)
+            # Keep the contract worker generic in v1; later issues plug in
+            # headless execution and artifact writers behind the same surface.
+            await asyncio.sleep(0.01)
+            record.completed_at = datetime.now(UTC)
+
+        return _runner
+
+    def _build_status(self, record: HostedRunRecord, *, status: str) -> RunStatus:
+        return RunStatus(
+            run_id=record.run_id,
+            status=status,  # type: ignore[arg-type]
+            created_at=record.created_at.isoformat(),
+            started_at=record.started_at.isoformat() if record.started_at else None,
+            completed_at=record.completed_at.isoformat() if record.completed_at else None,
+            client=record.request.client,
+            profile=record.request.profile,
+            status_url=f"/v1/runs/{record.run_id}",
+            artifacts=self._artifact_refs(record),
+            error=record.error,
+        )
+
+    def _artifact_refs(self, record: HostedRunRecord) -> list[RunArtifactRef]:
+        include_logs = (
+            record.request.artifacts is None
+            or bool(record.request.artifacts.include_logs)
+        )
+        artifacts = [
+            RunArtifactRef(
+                kind="report",
+                url=f"/v1/runs/{record.run_id}/report",
+                available=record.completed_at is not None and record.error is None,
+                content_type="application/json",
+            ),
+            RunArtifactRef(
+                kind="run_metadata",
+                url=f"/v1/runs/{record.run_id}/metadata",
+                available=True,
+                content_type="application/json",
+            ),
+        ]
+        if include_logs:
+            artifacts.append(
+                RunArtifactRef(
+                    kind="logs",
+                    url=f"/v1/runs/{record.run_id}/logs",
+                    available=record.completed_at is not None,
+                    content_type="application/json",
+                )
+            )
+        return artifacts
+
+    def _map_status(self, queue_status: TaskStatus) -> str:
+        mapping = {
+            TaskStatus.QUEUED: "queued",
+            TaskStatus.PROCESSING: "running",
+            TaskStatus.COMPLETED: "completed",
+            TaskStatus.FAILED: "failed",
+        }
+        return mapping[queue_status]
+
+
+def create_app(*, service_root: Path | None = None) -> FastAPI:
+    """Create the hosted service ASGI app."""
+    service = HostedRunService(service_root=service_root)
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> Any:
+        await service.start()
+        try:
+            yield
+        finally:
+            await service.stop()
+
+    app = FastAPI(title="agent-forge hosted service", version="0.1.0", lifespan=lifespan)
+    app.state.service = service
+
+    @app.post("/v1/runs", response_model=RunStatus, status_code=202)
+    async def create_run(request: RunRequest) -> RunStatus:
+        return await service.create_run(request)
+
+    @app.get("/v1/runs/{run_id}", response_model=RunStatus)
+    async def get_run(run_id: str) -> RunStatus:
+        try:
+            return await service.get_status(run_id)
+        except KeyError as exc:
+            error = ErrorResponse(
+                error=RunError(
+                    code="invalid_request",
+                    message=f"unknown run id: {run_id}",
+                    retryable=False,
+                )
+            )
+            raise HTTPException(status_code=404, detail=error.model_dump()) from exc
+
+    return app

--- a/agent_forge/service/models.py
+++ b/agent_forge/service/models.py
@@ -1,0 +1,137 @@
+"""Pydantic models for the hosted agent-forge service contract."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+RunLifecycleStatus = Literal["accepted", "queued", "running", "completed", "failed", "cancelled"]
+SourceKind = Literal["archive_uri", "repository_uri", "git_repository", "local_path"]
+SubmissionKind = Literal["deployed_address", "source_bundle", "repository_url"]
+DeliveryMode = Literal["pull", "callback"]
+ArtifactKind = Literal["report", "logs", "run_metadata"]
+ErrorCode = Literal[
+    "invalid_request",
+    "unsupported_profile",
+    "unsupported_source_kind",
+    "source_fetch_failed",
+    "sandbox_start_failed",
+    "sandbox_execution_failed",
+    "report_generation_failed",
+    "policy_denied",
+    "unauthorized",
+    "quota_exceeded",
+]
+
+
+class ClientRef(BaseModel):
+    """Identifies the external caller that submitted the run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    request_id: str
+    service_id: str | None = None
+
+
+class ProfileRef(BaseModel):
+    """Describes the policy or template to apply for a run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    report_schema: str
+    max_iterations: int | None = Field(default=None, ge=1)
+
+
+class SourceRef(BaseModel):
+    """Reference to the source material the service should analyze."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: SourceKind
+    uri: str
+    archive_format: Literal["zip", "tar.gz"] | None = None
+    entry_contract: str | None = None
+    source_digest: str | None = None
+
+
+class TargetRef(BaseModel):
+    """Optional metadata describing the target deployment."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    submission_kind: SubmissionKind | None = None
+    network: str | None = None
+    chain_id: int | None = None
+    contract_address: str | None = None
+
+
+class ArtifactPolicy(BaseModel):
+    """Controls how result artifacts should be delivered."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    result_delivery: DeliveryMode | None = None
+    include_logs: bool | None = None
+
+
+class RunRequest(BaseModel):
+    """Versioned submission payload for hosted runs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["agent-forge-run-request-v1"]
+    client: ClientRef
+    profile: ProfileRef
+    source: SourceRef
+    target: TargetRef | None = None
+    artifacts: ArtifactPolicy | None = None
+
+
+class RunArtifactRef(BaseModel):
+    """Reference to a machine-consumable artifact emitted by the run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: ArtifactKind
+    url: str
+    available: bool
+    content_type: str
+
+
+class RunError(BaseModel):
+    """Structured error payload for rejected or failed runs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: ErrorCode
+    message: str
+    retryable: bool
+
+
+class RunStatus(BaseModel):
+    """Versioned status document returned by the service."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["agent-forge-run-v1"] = "agent-forge-run-v1"
+    run_id: str
+    status: RunLifecycleStatus
+    created_at: str
+    started_at: str | None = None
+    completed_at: str | None = None
+    client: ClientRef | None = None
+    profile: ProfileRef | None = None
+    status_url: str | None = None
+    artifacts: list[RunArtifactRef] = Field(default_factory=list)
+    error: RunError | None = None
+
+
+class ErrorResponse(BaseModel):
+    """Envelope returned for machine-readable failures."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    error: RunError

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -898,6 +898,48 @@ At the end of each run, produce a summary printed to console:
 
 ## 5. Data Models & Schemas
 
+### 5.1 Hosted Service Run API
+
+Hosted mode exposes a versioned machine API for external clients. The first
+contract version is intentionally polling-based and centered on a single run
+resource:
+
+- `POST /v1/runs` accepts a `RunRequest` document with `client`, `profile`,
+  `source`, optional `target`, and optional artifact delivery preferences.
+- `GET /v1/runs/{run_id}` returns a `RunStatus` document that includes the run
+  lifecycle state, client/profile echo fields, and stable artifact references.
+- All request and response models are versioned with explicit
+  `schema_version` fields so hosted clients do not have to infer compatibility
+  from CLI behavior.
+
+The v1 request supports these source payload patterns:
+
+- `local_path` for already-resolved source paths in a colocated environment
+- `archive_uri` for source bundles such as `.zip` and `.tar.gz`
+- `repository_uri` or `git_repository` for externally-resolved repository inputs
+
+The v1 status model standardizes lifecycle states as:
+
+- `accepted`
+- `queued`
+- `running`
+- `completed`
+- `failed`
+- `cancelled`
+
+The v1 error envelope standardizes machine-readable failures such as:
+
+- validation failures (`invalid_request`)
+- source acquisition failures (`source_fetch_failed`)
+- sandbox/runtime failures (`sandbox_start_failed`, `sandbox_execution_failed`)
+- policy failures (`policy_denied`, `unauthorized`, `quota_exceeded`)
+
+Artifact references are part of the status document rather than being implied:
+
+- `report`
+- `logs`
+- `run_metadata`
+
 ### 5.1 Configuration File Schema
 
 Agent Forge uses a TOML configuration file (`agent-forge.toml`):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 
 dependencies = [
     "click>=8.0",
+    "fastapi>=0.115",
     "httpx>=0.27",
     "docker>=7.0",
     "pydantic>=2.0",

--- a/tests/unit/test_service_app.py
+++ b/tests/unit/test_service_app.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from fastapi.testclient import TestClient
+
+from agent_forge.service.app import create_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from agent_forge.orchestration.queue import Task
+
+
+def _request_payload(source_uri: str) -> dict[str, object]:
+    return {
+        "schema_version": "agent-forge-run-request-v1",
+        "client": {
+            "name": "proof-of-audit",
+            "request_id": "audit-123",
+            "service_id": "proof-of-audit-auditor",
+        },
+        "profile": {
+            "id": "proof-of-audit-solidity-v1",
+            "report_schema": "proof-of-audit-report-v1",
+            "max_iterations": 3,
+        },
+        "source": {
+            "kind": "local_path",
+            "uri": source_uri,
+            "entry_contract": "Vault",
+            "source_digest": "sha256:test",
+        },
+        "target": {
+            "submission_kind": "deployed_address",
+            "network": "base-sepolia",
+            "chain_id": 84532,
+            "contract_address": "0xabc",
+        },
+        "artifacts": {
+            "result_delivery": "pull",
+            "include_logs": True,
+        },
+    }
+
+
+def test_service_create_run_and_return_status_contract(tmp_path: Path) -> None:
+    app = create_app(service_root=tmp_path / "service-root")
+    service = app.state.service
+
+    async def fake_runner(task: Task) -> None:
+        record = service._records[task.id]
+        record.started_at = record.created_at
+        await asyncio.sleep(0.01)
+        record.completed_at = record.created_at
+
+    service._worker._task_runner = fake_runner
+
+    with TestClient(app) as client:
+        response = client.post("/v1/runs", json=_request_payload(str(tmp_path / "repo")))
+        assert response.status_code == 202
+        accepted = response.json()
+        assert accepted["schema_version"] == "agent-forge-run-v1"
+        assert accepted["status"] == "accepted"
+        assert accepted["status_url"].startswith("/v1/runs/run_")
+        assert {artifact["kind"] for artifact in accepted["artifacts"]} == {
+            "report",
+            "run_metadata",
+            "logs",
+        }
+        run_id = accepted["run_id"]
+
+        for _ in range(40):
+            status_response = client.get(f"/v1/runs/{run_id}")
+            assert status_response.status_code == 200
+            if status_response.json()["status"] == "completed":
+                break
+            asyncio.run(asyncio.sleep(0.01))
+        else:
+            raise AssertionError("run did not complete")
+
+        completed = status_response.json()
+        assert completed["profile"]["id"] == "proof-of-audit-solidity-v1"
+        assert completed["artifacts"][0]["available"] is True
+
+
+def test_service_rejects_unknown_run_id(tmp_path: Path) -> None:
+    app = create_app(service_root=tmp_path / "service-root")
+
+    with TestClient(app) as client:
+        response = client.get("/v1/runs/run_missing")
+        assert response.status_code == 404
+        detail = response.json()["detail"]
+        assert detail["error"]["code"] == "invalid_request"
+
+
+def test_service_request_contract_rejects_unknown_fields(tmp_path: Path) -> None:
+    app = create_app(service_root=tmp_path / "service-root")
+    payload = _request_payload(str(tmp_path / "repo"))
+    payload["unexpected"] = "value"
+
+    with TestClient(app) as client:
+        response = client.post("/v1/runs", json=payload)
+        assert response.status_code == 422
+
+
+def test_service_can_omit_logs_artifact(tmp_path: Path) -> None:
+    app = create_app(service_root=tmp_path / "service-root")
+    payload = _request_payload(str(tmp_path / "repo"))
+    payload["artifacts"] = {"result_delivery": "pull", "include_logs": False}
+
+    with TestClient(app) as client:
+        response = client.post("/v1/runs", json=payload)
+        assert response.status_code == 202
+        kinds = {artifact["kind"] for artifact in response.json()["artifacts"]}
+        assert kinds == {"report", "run_metadata"}


### PR DESCRIPTION
## Summary
- add a versioned hosted service package with `POST /v1/runs` and `GET /v1/runs/{run_id}`
- define machine-readable request, status, error, and artifact-reference models for external clients
- document the hosted run API contract in the technical spec and cover it with unit tests

Closes #90