### PR TITLE
feat(#91): add headless report writer mode

### DIFF
--- a/agent_forge/cli.py
+++ b/agent_forge/cli.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import sys
+from pathlib import Path
 from typing import Any
 
 import click
@@ -55,6 +56,18 @@ def main() -> None:
     type=int,
     help="Max concurrent tasks for queue worker (0=unlimited)",
 )
+@click.option(
+    "--output-format",
+    default="text",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    help="Render a human summary or a machine-readable JSON result.",
+)
+@click.option(
+    "--report-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write the machine-readable run result to a JSON file.",
+)
 def run(
     task: str,
     repo: str,
@@ -64,6 +77,8 @@ def run(
     queue_backend: str | None,
     redis_url: str,
     max_concurrent_runs: int,
+    output_format: str,
+    report_file: Path | None,
 ) -> None:
     """Run an agent task on a repository."""
     # Build CLI overrides from provided flags
@@ -96,6 +111,11 @@ def run(
         sys.exit(1)
 
     if queue_backend is not None:
+        if output_format == "json" or report_file is not None:
+            err_console.print(
+                "[red]Machine-readable output is not supported in queue mode yet.[/red]"
+            )
+            sys.exit(1)
         asyncio.run(
             _run_agent_queued(
                 task, repo, cfg, provider_name, api_key,
@@ -105,7 +125,8 @@ def run(
             )
         )
     else:
-        asyncio.run(_run_agent(task, repo, cfg, provider_name, api_key))
+        result = asyncio.run(_run_agent(task, repo, cfg, provider_name, api_key))
+        _emit_run_output(result, output_format=output_format, report_file=report_file)
 
 
 async def _run_agent(
@@ -114,7 +135,7 @@ async def _run_agent(
     cfg: Any,
     provider_name: str,
     api_key: str,
-) -> None:
+) -> Any:
     """Execute the full agent pipeline (direct mode).
 
     Creates an ``EventBus`` so lifecycle events are emitted even in
@@ -152,7 +173,7 @@ async def _run_agent(
             await sandbox.stop()
             await llm.close()
 
-    _display_run_summary(result)
+    return result
 
 
 async def _run_agent_queued(
@@ -310,6 +331,59 @@ def _display_run_summary(run: Any) -> None:
     console.print(Panel(table, title="[bold]Agent Run Complete", border_style=state_color))
 
 
+def _run_output_payload(run: Any) -> dict[str, object]:
+    """Build a stable machine-readable summary for a completed run."""
+    duration_seconds: float | None = None
+    if run.completed_at:
+        duration_seconds = (run.completed_at - run.created_at).total_seconds()
+
+    run_dir = USER_CONFIG_DIR / "runs" / run.id
+    return {
+        "schema_version": "agent-forge-run-result-v1",
+        "run_id": run.id,
+        "state": run.state.value,
+        "task": run.task,
+        "repo_path": run.repo_path,
+        "iterations": run.iterations,
+        "created_at": run.created_at.isoformat(),
+        "completed_at": run.completed_at.isoformat() if run.completed_at else None,
+        "duration_seconds": duration_seconds,
+        "error": run.error,
+        "total_tokens": {
+            "prompt_tokens": run.total_tokens.prompt_tokens,
+            "completion_tokens": run.total_tokens.completion_tokens,
+            "total_tokens": run.total_tokens.total_tokens,
+        },
+        "artifacts": {
+            "run_dir": str(run_dir),
+            "run_json": str(run_dir / "run.json"),
+            "messages_jsonl": str(run_dir / "messages.jsonl"),
+            "events_jsonl": str(run_dir / "events.jsonl"),
+            "summary_json": str(run_dir / "summary.json"),
+        },
+    }
+
+
+def _emit_run_output(
+    run: Any,
+    *,
+    output_format: str,
+    report_file: Path | None,
+) -> None:
+    """Emit either rich text or machine-readable JSON for a run."""
+    payload = _run_output_payload(run)
+
+    if report_file is not None:
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    if output_format == "json":
+        click.echo(json.dumps(payload))
+        return
+
+    _display_run_summary(run)
+
+
 # ---------------------------------------------------------------------------
 # status
 # ---------------------------------------------------------------------------
@@ -317,7 +391,13 @@ def _display_run_summary(run: Any) -> None:
 
 @main.command()
 @click.argument("run_id")
-def status(run_id: str) -> None:
+@click.option(
+    "--output-format",
+    default="text",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    help="Render a human summary or a machine-readable JSON result.",
+)
+def status(run_id: str, output_format: str) -> None:
     """Show the status and summary of a specific run."""
     from agent_forge.agent.persistence import load_run
 
@@ -327,7 +407,7 @@ def status(run_id: str) -> None:
         err_console.print(f"[red]Run not found:[/red] {run_id}")
         sys.exit(1)
 
-    _display_run_summary(agent_run)
+    _emit_run_output(agent_run, output_format=output_format, report_file=None)
 
 
 # ---------------------------------------------------------------------------

--- a/agent_forge/service/app.py
+++ b/agent_forge/service/app.py
@@ -2,26 +2,47 @@
 
 from __future__ import annotations
 
-import asyncio
+import json
+import os
+import shutil
+import tarfile
 import uuid
+import zipfile
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+from urllib.parse import urlparse
 
 from fastapi import FastAPI, HTTPException
 
+from agent_forge.agent.core import react_loop
+from agent_forge.agent.models import AgentConfig, AgentRun
+from agent_forge.cli import _create_llm
+from agent_forge.config import USER_CONFIG_DIR, load_config
 from agent_forge.orchestration.events import EventBus
 from agent_forge.orchestration.queue import InMemoryQueue, Task, TaskStatus
 from agent_forge.orchestration.worker import Worker
+from agent_forge.sandbox.docker import DockerSandbox
 from agent_forge.service.models import (
     ErrorResponse,
+    LogsResponse,
+    ProofOfAuditReport,
+    ReportProvenance,
+    ReportStats,
+    ReportTarget,
     RunArtifactRef,
     RunError,
     RunRequest,
     RunStatus,
+    SeverityBreakdown,
+    SeverityLevel,
+    TargetRef,
 )
+from agent_forge.tools import create_default_registry
+
+_REPORT_RELATIVE_PATH = Path(".agent-forge/report.json")
 
 
 @dataclass
@@ -36,12 +57,23 @@ class HostedRunRecord:
     completed_at: datetime | None = None
     error: RunError | None = None
 
+    @property
+    def report_path(self) -> Path:
+        """Return the expected machine report path for the run."""
+        return self.workspace_dir / _REPORT_RELATIVE_PATH
+
+    @property
+    def run_dir(self) -> Path:
+        """Return the persisted agent run directory."""
+        return USER_CONFIG_DIR / "runs" / self.run_id
+
 
 class HostedRunService:
     """In-process implementation of the versioned hosted run API."""
 
     def __init__(self, *, service_root: Path | None = None) -> None:
-        self._service_root = service_root or Path.cwd() / ".agent-forge-service"
+        self._service_root = service_root or USER_CONFIG_DIR / "service"
+        self._config = load_config()
         self._queue = InMemoryQueue()
         self._event_bus = EventBus()
         self._records: dict[str, HostedRunRecord] = {}
@@ -63,9 +95,16 @@ class HostedRunService:
 
     async def create_run(self, request: RunRequest) -> RunStatus:
         """Accept a new hosted run request and enqueue it."""
+        self._validate_request(request)
         run_id = f"run_{uuid.uuid4().hex[:16]}"
-        workspace_dir = self._service_root / "runs" / run_id
-        workspace_dir.mkdir(parents=True, exist_ok=True)
+        workspace_dir = self._materialize_source(run_id, request)
+        prompt = self._build_task_prompt(request)
+        agent_config = AgentConfig(
+            model=self._config.agent.default_model,
+            max_iterations=request.profile.max_iterations or self._config.agent.max_iterations,
+            max_tokens_per_run=self._config.agent.max_tokens_per_run,
+            temperature=self._config.agent.temperature,
+        )
         record = HostedRunRecord(
             run_id=run_id,
             request=request,
@@ -76,9 +115,9 @@ class HostedRunService:
         await self._queue.enqueue(
             Task(
                 id=run_id,
-                task_description=f"Hosted run for profile {request.profile.id}",
+                task_description=prompt,
                 repo_path=str(workspace_dir),
-                config=None,
+                config=agent_config,
             )
         )
         return self._build_status(record, status="accepted")
@@ -91,14 +130,247 @@ class HostedRunService:
         queue_status = await self._queue.get_status(run_id)
         return self._build_status(record, status=self._map_status(queue_status))
 
+    def get_report(self, run_id: str) -> ProofOfAuditReport:
+        """Return the machine report for a completed run."""
+        record = self._require_record(run_id)
+        if record.error is not None:
+            raise RuntimeError("run_failed")
+        if not record.report_path.exists():
+            raise RuntimeError("run_not_completed")
+        payload = json.loads(record.report_path.read_text(encoding="utf-8"))
+        if "schema_version" not in payload:
+            payload["schema_version"] = "proof-of-audit-report-v1"
+        if "run_id" not in payload:
+            payload["run_id"] = run_id
+        if "target" not in payload:
+            payload["target"] = self._report_target(request=record.request).model_dump()
+        if "provenance" not in payload:
+            payload["provenance"] = ReportProvenance(
+                profile_id=record.request.profile.id,
+                source_digest=record.request.source.source_digest,
+            ).model_dump()
+        if "stats" not in payload:
+            payload["stats"] = self._compute_stats(payload.get("findings", []))
+        return ProofOfAuditReport.model_validate(payload)
+
+    def get_logs(self, run_id: str) -> LogsResponse:
+        """Return the persisted artifact references for a run."""
+        record = self._require_record(run_id)
+        artifacts = {
+            "run_dir": str(record.run_dir),
+            "run_json": str(record.run_dir / "run.json"),
+            "messages_jsonl": str(record.run_dir / "messages.jsonl"),
+            "events_jsonl": str(record.run_dir / "events.jsonl"),
+            "summary_json": str(record.run_dir / "summary.json"),
+            "report_json": str(record.report_path),
+        }
+        return LogsResponse(run_id=run_id, logs_url=None, inline=None, artifacts=artifacts)
+
+    def _require_record(self, run_id: str) -> HostedRunRecord:
+        record = self._records.get(run_id)
+        if record is None:
+            raise KeyError(run_id)
+        return record
+
+    def _validate_request(self, request: RunRequest) -> None:
+        if request.profile.id != "proof-of-audit-solidity-v1":
+            raise HTTPException(
+                status_code=400,
+                detail=ErrorResponse(
+                    error=RunError(
+                        code="unsupported_profile",
+                        message=f"unsupported profile: {request.profile.id}",
+                        retryable=False,
+                    )
+                ).model_dump(),
+            )
+        if request.source.kind not in {"archive_uri", "repository_uri", "local_path"}:
+            raise HTTPException(
+                status_code=400,
+                detail=ErrorResponse(
+                    error=RunError(
+                        code="unsupported_source_kind",
+                        message=f"unsupported source kind: {request.source.kind}",
+                        retryable=False,
+                    )
+                ).model_dump(),
+            )
+
+    def _materialize_source(self, run_id: str, request: RunRequest) -> Path:
+        uri_path = self._local_path_from_uri(request.source.uri)
+        source_root = self._service_root / "sources" / run_id
+        source_root.mkdir(parents=True, exist_ok=True)
+        repo_root = source_root / "repo"
+
+        if uri_path.is_dir():
+            shutil.copytree(uri_path, repo_root)
+            return repo_root
+
+        if uri_path.suffix == ".sol":
+            repo_root.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(uri_path, repo_root / uri_path.name)
+            return repo_root
+
+        if request.source.kind == "archive_uri" or uri_path.suffix == ".zip":
+            repo_root.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(uri_path) as archive:
+                self._extract_zip(archive, repo_root)
+            return self._normalize_repo_root(repo_root)
+
+        if uri_path.suffixes[-2:] == [".tar", ".gz"]:
+            repo_root.mkdir(parents=True, exist_ok=True)
+            with tarfile.open(uri_path, "r:gz") as archive:
+                self._extract_tar_gz(archive, repo_root)
+            return self._normalize_repo_root(repo_root)
+
+        raise HTTPException(
+            status_code=400,
+            detail=ErrorResponse(
+                error=RunError(
+                    code="source_fetch_failed",
+                    message=f"unsupported local source material: {uri_path}",
+                    retryable=False,
+                )
+            ).model_dump(),
+        )
+
+    def _normalize_repo_root(self, root: Path) -> Path:
+        children = [child for child in root.iterdir() if child.name != "__MACOSX"]
+        if len(children) == 1 and children[0].is_dir():
+            return children[0]
+        return root
+
+    def _local_path_from_uri(self, uri: str) -> Path:
+        parsed = urlparse(uri)
+        if parsed.scheme in {"", "file"}:
+            raw_path = parsed.path if parsed.scheme == "file" else uri
+            return Path(raw_path).expanduser().resolve()
+        raise HTTPException(
+            status_code=400,
+            detail=ErrorResponse(
+                error=RunError(
+                    code="source_fetch_failed",
+                    message=(
+                        "only local and file:// URIs are supported in this service "
+                        f"build: {uri}"
+                    ),
+                    retryable=False,
+                )
+            ).model_dump(),
+        )
+
+    def _extract_zip(self, archive: zipfile.ZipFile, destination: Path) -> None:
+        for member in archive.infolist():
+            target_path = self._safe_join(destination, member.filename)
+            if member.is_dir():
+                target_path.mkdir(parents=True, exist_ok=True)
+                continue
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(member) as src, target_path.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+
+    def _extract_tar_gz(self, archive: tarfile.TarFile, destination: Path) -> None:
+        for member in archive.getmembers():
+            target_path = self._safe_join(destination, member.name)
+            if member.isdir():
+                target_path.mkdir(parents=True, exist_ok=True)
+                continue
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                continue
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with extracted, target_path.open("wb") as dst:
+                shutil.copyfileobj(extracted, dst)
+
+    def _safe_join(self, root: Path, relative_path: str) -> Path:
+        target_path = (root / relative_path).resolve()
+        root_path = root.resolve()
+        if root_path == target_path or root_path in target_path.parents:
+            return target_path
+        msg = f"archive entry escapes destination: {relative_path}"
+        raise HTTPException(
+            status_code=400,
+            detail=ErrorResponse(
+                error=RunError(
+                    code="source_fetch_failed",
+                    message=msg,
+                    retryable=False,
+                )
+            ).model_dump(),
+        )
+
+    def _build_task_prompt(self, request: RunRequest) -> str:
+        entry_contract = request.source.entry_contract or "the primary contract"
+        target = request.target.contract_address if request.target else None
+        target_context = f" at deployed address {target}" if target else ""
+        return (
+            "Audit this smart contract repository for three issue classes: "
+            "reentrancy, access control, and unchecked external calls. "
+            f"Focus first on the contract named {entry_contract}{target_context}. "
+            "Do not modify the source code except for writing a valid JSON report to "
+            ".agent-forge/report.json. The report must use schema_version "
+            "\"proof-of-audit-report-v1\" and include the fields run_id, summary, "
+            "confidence, findings, stats, optional benchmark_id, optional target, and "
+            "optional provenance. Each finding must include finding_id, title, severity, "
+            "category, description, impact, recommendation, confidence, and optional "
+            "detector, affected_function, source_path, start_line, end_line, and evidence_uri. "
+            "If no finding is confirmed, write an empty findings array and matching stats."
+        )
+
     def _make_task_runner(self) -> Any:
         async def _runner(task: Task) -> None:
             record = self._records[task.id]
             record.started_at = datetime.now(UTC)
-            # Keep the contract worker generic in v1; later issues plug in
-            # headless execution and artifact writers behind the same surface.
-            await asyncio.sleep(0.01)
-            record.completed_at = datetime.now(UTC)
+            provider_name = self._config.agent.default_provider
+            provider_cfg = self._config.providers.get(provider_name)
+            if provider_cfg is None:
+                record.error = RunError(
+                    code="invalid_request",
+                    message=f"unknown provider: {provider_name}",
+                    retryable=False,
+                )
+                raise RuntimeError(record.error.message)
+            api_key = os.environ.get(provider_cfg.api_key_env, "")
+            if not api_key:
+                record.error = RunError(
+                    code="unauthorized",
+                    message=f"missing provider API key env: {provider_cfg.api_key_env}",
+                    retryable=False,
+                )
+                raise RuntimeError(record.error.message)
+
+            llm = _create_llm(provider_name, api_key)
+            tools = create_default_registry()
+            sandbox = DockerSandbox()
+            agent_run = AgentRun(
+                task=task.task_description,
+                repo_path=task.repo_path,
+                config=task.config,
+                id=task.id,
+            )
+            try:
+                await sandbox.start(repo_path=task.repo_path)
+                await react_loop(agent_run, llm, tools, sandbox, event_bus=self._event_bus)
+                if not record.report_path.exists():
+                    record.error = RunError(
+                        code="report_generation_failed",
+                        message="run completed without writing .agent-forge/report.json",
+                        retryable=False,
+                    )
+                    raise RuntimeError(record.error.message)
+                record.completed_at = datetime.now(UTC)
+            except Exception as exc:
+                if record.error is None:
+                    record.error = RunError(
+                        code="sandbox_execution_failed",
+                        message=str(exc),
+                        retryable=False,
+                    )
+                record.completed_at = datetime.now(UTC)
+                raise
+            finally:
+                await sandbox.stop()
+                await llm.close()
 
         return _runner
 
@@ -155,8 +427,40 @@ class HostedRunService:
         }
         return mapping[queue_status]
 
+    def _report_target(self, *, request: RunRequest) -> ReportTarget:
+        target = request.target or TargetRef()
+        return ReportTarget(
+            submission_kind=target.submission_kind,
+            network=target.network,
+            chain_id=target.chain_id,
+            contract_address=target.contract_address,
+            entry_contract=request.source.entry_contract,
+        )
 
-def create_app(*, service_root: Path | None = None) -> FastAPI:
+    def _compute_stats(self, findings: list[dict[str, Any]]) -> dict[str, Any]:
+        counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        for finding in findings:
+            severity = finding.get("severity")
+            if severity in counts:
+                counts[severity] += 1
+        max_severity: SeverityLevel | None = None
+        for severity in ("critical", "high", "medium", "low"):
+            if counts[severity] > 0:
+                max_severity = cast("SeverityLevel", severity)
+                break
+        return ReportStats(
+            finding_count=len(findings),
+            max_severity=max_severity,
+            severity_breakdown=SeverityBreakdown(
+                critical=counts["critical"],
+                high=counts["high"],
+                medium=counts["medium"],
+                low=counts["low"],
+            ),
+        ).model_dump()
+
+
+def create_app(*, service_root: Path | None = None) -> FastAPI:  # noqa: C901
     """Create the hosted service ASGI app."""
     service = HostedRunService(service_root=service_root)
 
@@ -188,5 +492,23 @@ def create_app(*, service_root: Path | None = None) -> FastAPI:
                 )
             )
             raise HTTPException(status_code=404, detail=error.model_dump()) from exc
+
+    @app.get("/v1/runs/{run_id}/report", response_model=ProofOfAuditReport)
+    async def get_report(run_id: str) -> ProofOfAuditReport:
+        try:
+            return service.get_report(run_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=f"unknown run id: {run_id}") from exc
+        except RuntimeError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    @app.get("/v1/runs/{run_id}/logs", response_model=LogsResponse)
+    async def get_logs(run_id: str) -> LogsResponse:
+        try:
+            return service.get_logs(run_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=f"unknown run id: {run_id}") from exc
 
     return app

--- a/agent_forge/service/models.py
+++ b/agent_forge/service/models.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, ConfigDict, Field
 RunLifecycleStatus = Literal["accepted", "queued", "running", "completed", "failed", "cancelled"]
 SourceKind = Literal["archive_uri", "repository_uri", "git_repository", "local_path"]
 SubmissionKind = Literal["deployed_address", "source_bundle", "repository_url"]
+ConfidenceLevel = Literal["low", "medium", "high"]
+SeverityLevel = Literal["critical", "high", "medium", "low"]
 DeliveryMode = Literal["pull", "callback"]
 ArtifactKind = Literal["report", "logs", "run_metadata"]
 ErrorCode = Literal[
@@ -135,3 +137,93 @@ class ErrorResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     error: RunError
+
+
+class ReportTarget(BaseModel):
+    """Identifies the report target in a downstream-friendly shape."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    submission_kind: str | None = None
+    network: str | None = None
+    chain_id: int | None = None
+    contract_address: str | None = None
+    entry_contract: str | None = None
+
+
+class Finding(BaseModel):
+    """A single machine-readable audit finding."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    finding_id: str
+    title: str
+    severity: SeverityLevel
+    category: str
+    description: str
+    impact: str
+    recommendation: str
+    confidence: ConfidenceLevel
+    detector: str | None = None
+    affected_function: str | None = None
+    source_path: str | None = None
+    start_line: int | None = Field(default=None, ge=1)
+    end_line: int | None = Field(default=None, ge=1)
+    evidence_uri: str | None = None
+
+
+class SeverityBreakdown(BaseModel):
+    """Counts findings by severity."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    critical: int = Field(ge=0)
+    high: int = Field(ge=0)
+    medium: int = Field(ge=0)
+    low: int = Field(ge=0)
+
+
+class ReportStats(BaseModel):
+    """Aggregate summary for a report."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    finding_count: int = Field(ge=0)
+    max_severity: SeverityLevel | None = None
+    severity_breakdown: SeverityBreakdown
+
+
+class ReportProvenance(BaseModel):
+    """Captures which profile and source digest produced the report."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    profile_id: str | None = None
+    source_digest: str | None = None
+
+
+class ProofOfAuditReport(BaseModel):
+    """Stable report schema for Proof-of-Audit-compatible runs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["proof-of-audit-report-v1"]
+    run_id: str
+    summary: str
+    confidence: ConfidenceLevel
+    benchmark_id: str | None = None
+    target: ReportTarget | None = None
+    findings: list[Finding]
+    stats: ReportStats
+    provenance: ReportProvenance | None = None
+
+
+class LogsResponse(BaseModel):
+    """References the persisted artifacts for a completed run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    inline: str | None = None
+    logs_url: str | None = None
+    artifacts: dict[str, str]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -940,6 +940,11 @@ Artifact references are part of the status document rather than being implied:
 - `logs`
 - `run_metadata`
 
+Hosted profiles may also expose a profile-specific report contract behind the
+artifact references. The initial downstream-oriented profile is
+`proof-of-audit-solidity-v1`, which emits `proof-of-audit-report-v1` JSON and
+separates that artifact from the human-oriented CLI summary.
+
 ### 5.1 Configuration File Schema
 
 Agent Forge uses a TOML configuration file (`agent-forge.toml`):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -47,6 +49,73 @@ class TestRunCommand:
         assert result.exit_code != 0
         assert "Unknown provider" in result.output
 
+    def test_run_json_output_and_report_file(self, tmp_path: Path) -> None:
+        """Run can emit a machine-readable result payload."""
+        from datetime import UTC, datetime
+
+        from agent_forge.agent.models import AgentConfig, AgentRun, RunState
+
+        async def fake_run(
+            task: str,
+            repo: str,
+            cfg: object,
+            provider_name: str,
+            api_key: str,
+        ) -> AgentRun:
+            run = AgentRun(task=task, repo_path=repo, config=AgentConfig())
+            run.state = RunState.COMPLETED
+            run.iterations = 2
+            run.completed_at = datetime.now(UTC)
+            return run
+
+        runner = _runner()
+        env = dict(os.environ)
+        env["GEMINI_API_KEY"] = "test-key"
+        report_file = tmp_path / "report.json"
+        with patch("agent_forge.cli._run_agent", side_effect=fake_run), patch(
+            "agent_forge.cli.USER_CONFIG_DIR", tmp_path
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "run",
+                    "--task", "Fix a bug",
+                    "--repo", "/tmp/fake-repo",
+                    "--output-format", "json",
+                    "--report-file", str(report_file),
+                ],
+                env=env,
+            )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["schema_version"] == "agent-forge-run-result-v1"
+        assert payload["state"] == "completed"
+        assert payload["artifacts"]["summary_json"].endswith("/summary.json")
+
+        file_payload = json.loads(report_file.read_text())
+        assert file_payload["run_id"] == payload["run_id"]
+        assert file_payload["task"] == "Fix a bug"
+
+    def test_run_json_output_rejected_for_queue_mode(self) -> None:
+        """Queue mode should fail clearly until machine output is supported there."""
+        runner = _runner()
+        env = dict(os.environ)
+        env["GEMINI_API_KEY"] = "test-key"
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                "--task", "Fix a bug",
+                "--repo", "/tmp/fake-repo",
+                "--queue", "memory",
+                "--output-format", "json",
+            ],
+            env=env,
+        )
+        assert result.exit_code != 0
+        assert "not supported in queue mode yet" in result.output
+
 
 class TestStatusCommand:
     """Tests for the `status` command."""
@@ -76,6 +145,31 @@ class TestStatusCommand:
             result = runner.invoke(main, ["status", run.id])
 
         assert result.exit_code == 0
+
+    def test_status_existing_run_json(self, tmp_path: Path) -> None:
+        """Status can emit a machine-readable result payload."""
+        from datetime import UTC, datetime
+
+        from agent_forge.agent.models import AgentConfig, AgentRun, RunState
+        from agent_forge.agent.persistence import save_run
+
+        run = AgentRun(task="Test task", repo_path="/tmp/repo", config=AgentConfig())
+        run.state = RunState.COMPLETED
+        run.iterations = 5
+        run.completed_at = datetime.now(UTC)
+        save_run(run, base_dir=tmp_path)
+
+        runner = _runner()
+        with patch("agent_forge.agent.persistence._default_runs_dir", return_value=tmp_path), patch(
+            "agent_forge.cli.USER_CONFIG_DIR", tmp_path.parent
+        ):
+            result = runner.invoke(main, ["status", run.id, "--output-format", "json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["schema_version"] == "agent-forge-run-result-v1"
+        assert payload["run_id"] == run.id
+        assert payload["state"] == "completed"
 
 
 class TestListCommand:

--- a/tests/unit/test_service_app.py
+++ b/tests/unit/test_service_app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import zipfile
 from typing import TYPE_CHECKING
 
 from fastapi.testclient import TestClient
@@ -45,31 +47,80 @@ def _request_payload(source_uri: str) -> dict[str, object]:
     }
 
 
-def test_service_create_run_and_return_status_contract(tmp_path: Path) -> None:
+def test_service_create_run_and_return_report(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Vault.sol").write_text("contract Vault {}\n", encoding="utf-8")
+
     app = create_app(service_root=tmp_path / "service-root")
     service = app.state.service
 
     async def fake_runner(task: Task) -> None:
         record = service._records[task.id]
         record.started_at = record.created_at
-        await asyncio.sleep(0.01)
+        record.report_path.parent.mkdir(parents=True, exist_ok=True)
+        record.report_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "proof-of-audit-report-v1",
+                    "run_id": task.id,
+                    "summary": "Potential issue found",
+                    "confidence": "medium",
+                    "findings": [],
+                    "stats": {
+                        "finding_count": 0,
+                        "max_severity": None,
+                        "severity_breakdown": {
+                            "critical": 0,
+                            "high": 0,
+                            "medium": 0,
+                            "low": 0,
+                        },
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
         record.completed_at = record.created_at
+        run_dir = record.run_dir
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "run.json").write_text(
+            json.dumps(
+                {
+                    "id": task.id,
+                    "task": "audit",
+                    "repo_path": str(record.workspace_dir),
+                    "state": "completed",
+                    "iterations": 1,
+                    "total_tokens": {
+                        "prompt_tokens": 0,
+                        "completion_tokens": 0,
+                        "total_tokens": 0,
+                    },
+                    "config": {
+                        "max_iterations": 3,
+                        "max_tokens_per_run": 200000,
+                        "model": "gemini-3.1-flash-lite-preview",
+                        "provider": "gemini",
+                        "temperature": 0.0,
+                        "system_prompt": None,
+                    },
+                    "created_at": record.created_at.isoformat(),
+                    "completed_at": record.completed_at.isoformat(),
+                    "error": None,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
     service._worker._task_runner = fake_runner
 
     with TestClient(app) as client:
-        response = client.post("/v1/runs", json=_request_payload(str(tmp_path / "repo")))
+        response = client.post("/v1/runs", json=_request_payload(str(repo)))
         assert response.status_code == 202
-        accepted = response.json()
-        assert accepted["schema_version"] == "agent-forge-run-v1"
-        assert accepted["status"] == "accepted"
-        assert accepted["status_url"].startswith("/v1/runs/run_")
-        assert {artifact["kind"] for artifact in accepted["artifacts"]} == {
-            "report",
-            "run_metadata",
-            "logs",
-        }
-        run_id = accepted["run_id"]
+        run_id = response.json()["run_id"]
 
         for _ in range(40):
             status_response = client.get(f"/v1/runs/{run_id}")
@@ -80,9 +131,46 @@ def test_service_create_run_and_return_status_contract(tmp_path: Path) -> None:
         else:
             raise AssertionError("run did not complete")
 
-        completed = status_response.json()
-        assert completed["profile"]["id"] == "proof-of-audit-solidity-v1"
-        assert completed["artifacts"][0]["available"] is True
+        report_response = client.get(f"/v1/runs/{run_id}/report")
+        assert report_response.status_code == 200
+        assert report_response.json()["schema_version"] == "proof-of-audit-report-v1"
+
+        logs_response = client.get(f"/v1/runs/{run_id}/logs")
+        assert logs_response.status_code == 200
+        report_json = logs_response.json()["artifacts"]["report_json"]
+        assert report_json.endswith("/.agent-forge/report.json")
+
+
+def test_service_materializes_zip_sources(tmp_path: Path) -> None:
+    archive_path = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("wrapped/src/Vault.sol", "contract Vault {}\n")
+
+    app = create_app(service_root=tmp_path / "service-root")
+    service = app.state.service
+
+    async def fake_runner(task: Task) -> None:
+        record = service._records[task.id]
+        record.started_at = record.created_at
+        record.completed_at = record.created_at
+
+    service._worker._task_runner = fake_runner
+
+    payload = _request_payload(str(archive_path))
+    payload["source"] = {
+        "kind": "archive_uri",
+        "uri": str(archive_path),
+        "archive_format": "zip",
+        "entry_contract": "Vault",
+        "source_digest": "sha256:test",
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/v1/runs", json=payload)
+        assert response.status_code == 202
+        run_id = response.json()["run_id"]
+        record = service._records[run_id]
+        assert (record.workspace_dir / "src" / "Vault.sol").exists()
 
 
 def test_service_rejects_unknown_run_id(tmp_path: Path) -> None:
@@ -95,23 +183,17 @@ def test_service_rejects_unknown_run_id(tmp_path: Path) -> None:
         assert detail["error"]["code"] == "invalid_request"
 
 
-def test_service_request_contract_rejects_unknown_fields(tmp_path: Path) -> None:
+def test_service_rejects_unsupported_profile(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
     app = create_app(service_root=tmp_path / "service-root")
-    payload = _request_payload(str(tmp_path / "repo"))
-    payload["unexpected"] = "value"
+
+    payload = _request_payload(str(repo))
+    payload["profile"] = {
+        "id": "generic-coding-agent-v1",
+        "report_schema": "proof-of-audit-report-v1",
+    }
 
     with TestClient(app) as client:
         response = client.post("/v1/runs", json=payload)
-        assert response.status_code == 422
-
-
-def test_service_can_omit_logs_artifact(tmp_path: Path) -> None:
-    app = create_app(service_root=tmp_path / "service-root")
-    payload = _request_payload(str(tmp_path / "repo"))
-    payload["artifacts"] = {"result_delivery": "pull", "include_logs": False}
-
-    with TestClient(app) as client:
-        response = client.post("/v1/runs", json=payload)
-        assert response.status_code == 202
-        kinds = {artifact["kind"] for artifact in response.json()["artifacts"]}
-        assert kinds == {"report", "run_metadata"}
+        assert response.status_code == 400


### PR DESCRIPTION
## Summary
- turn the hosted run worker into a headless profile runner that materializes sources and expects a machine report artifact
- expose `report` and `logs` retrieval endpoints with a stable `proof-of-audit-report-v1` contract
- add machine-readable CLI output for direct runs so terminal UI and downstream artifacts stay separate

Closes #91