### PR TITLE
feat(#92): package hosted service deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.venv
+__pycache__/
+*.pyc
+htmlcov
+tests

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md LICENSE ./
+COPY agent-forge.toml ./agent-forge.toml
+COPY agent_forge ./agent_forge
+
+RUN pip install --no-cache-dir ".[redis]"
+
+EXPOSE 8000
+
+CMD ["sh", "-lc", "agent-forge serve --host ${AGENT_FORGE_SERVICE_HOST:-0.0.0.0} --port ${AGENT_FORGE_SERVICE_PORT:-8000}"]

--- a/agent-forge.toml
+++ b/agent-forge.toml
@@ -23,6 +23,12 @@ level = "INFO"                   # DEBUG, INFO, WARNING, ERROR
 format = "text"                  # "text" or "json"
 log_file = ""                    # Optional path for JSON log file
 
+[service]
+host = "127.0.0.1"
+port = 8000
+root_dir = "~/.agent-forge/service"
+healthcheck_path = "/healthz"
+
 [providers.gemini]
 api_key_env = "GEMINI_API_KEY"
 default_model = "gemini-3.1-flash-lite-preview"

--- a/agent_forge/cli.py
+++ b/agent_forge/cli.py
@@ -488,5 +488,39 @@ def config() -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# serve
+# ---------------------------------------------------------------------------
+
+
+@main.command()
+@click.option("--host", default=None, help="Bind host override.")
+@click.option("--port", default=None, type=int, help="Bind port override.")
+@click.option(
+    "--service-root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the hosted service root directory.",
+)
+def serve(host: str | None, port: int | None, service_root: Path | None) -> None:
+    """Run the hosted FastAPI service."""
+    import uvicorn
+
+    cli_overrides: dict[str, Any] = {}
+    if host is not None:
+        cli_overrides["service.host"] = host
+    if port is not None:
+        cli_overrides["service.port"] = port
+    if service_root is not None:
+        cli_overrides["service.root_dir"] = str(service_root)
+
+    cfg = load_config(cli_overrides=cli_overrides or None)
+
+    from agent_forge.service import create_app
+
+    app = create_app(service_root=Path(cfg.service.root_dir).expanduser(), config=cfg)
+    uvicorn.run(app, host=cfg.service.host, port=cfg.service.port)
+
+
 if __name__ == "__main__":
     main()

--- a/agent_forge/config.py
+++ b/agent_forge/config.py
@@ -65,6 +65,15 @@ class LoggingSettings(BaseModel):
     log_file: str = ""
 
 
+class ServiceSettings(BaseModel):
+    """Settings for the hosted service runtime."""
+
+    host: str = "127.0.0.1"
+    port: int = 8000
+    root_dir: str = str(USER_CONFIG_DIR / "service")
+    healthcheck_path: str = "/healthz"
+
+
 class ProviderSettings(BaseModel):
     """Settings for a single LLM provider."""
 
@@ -79,6 +88,7 @@ class ForgeConfig(BaseModel):
     sandbox: SandboxSettings = Field(default_factory=SandboxSettings)
     queue: QueueSettings = Field(default_factory=QueueSettings)
     logging: LoggingSettings = Field(default_factory=LoggingSettings)
+    service: ServiceSettings = Field(default_factory=ServiceSettings)
     providers: dict[str, ProviderSettings] = Field(
         default_factory=lambda: {
             "gemini": ProviderSettings(
@@ -145,6 +155,7 @@ _SECTION_MODELS: dict[str, type[BaseModel]] = {
     "sandbox": SandboxSettings,
     "queue": QueueSettings,
     "logging": LoggingSettings,
+    "service": ServiceSettings,
 }
 
 

--- a/agent_forge/service/app.py
+++ b/agent_forge/service/app.py
@@ -20,13 +20,14 @@ from fastapi import FastAPI, HTTPException
 from agent_forge.agent.core import react_loop
 from agent_forge.agent.models import AgentConfig, AgentRun
 from agent_forge.cli import _create_llm
-from agent_forge.config import USER_CONFIG_DIR, load_config
+from agent_forge.config import USER_CONFIG_DIR, ForgeConfig, load_config
 from agent_forge.orchestration.events import EventBus
 from agent_forge.orchestration.queue import InMemoryQueue, Task, TaskStatus
 from agent_forge.orchestration.worker import Worker
 from agent_forge.sandbox.docker import DockerSandbox
 from agent_forge.service.models import (
     ErrorResponse,
+    HealthResponse,
     LogsResponse,
     ProofOfAuditReport,
     ReportProvenance,
@@ -71,9 +72,14 @@ class HostedRunRecord:
 class HostedRunService:
     """In-process implementation of the versioned hosted run API."""
 
-    def __init__(self, *, service_root: Path | None = None) -> None:
-        self._service_root = service_root or USER_CONFIG_DIR / "service"
-        self._config = load_config()
+    def __init__(
+        self,
+        *,
+        service_root: Path | None = None,
+        config: ForgeConfig | None = None,
+    ) -> None:
+        self._config = config or load_config()
+        self._service_root = service_root or Path(self._config.service.root_dir).expanduser()
         self._queue = InMemoryQueue()
         self._event_bus = EventBus()
         self._records: dict[str, HostedRunRecord] = {}
@@ -460,9 +466,14 @@ class HostedRunService:
         ).model_dump()
 
 
-def create_app(*, service_root: Path | None = None) -> FastAPI:  # noqa: C901
+def create_app(  # noqa: C901
+    *,
+    service_root: Path | None = None,
+    config: ForgeConfig | None = None,
+) -> FastAPI:
     """Create the hosted service ASGI app."""
-    service = HostedRunService(service_root=service_root)
+    resolved_config = config or load_config()
+    service = HostedRunService(service_root=service_root, config=resolved_config)
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> Any:
@@ -474,6 +485,15 @@ def create_app(*, service_root: Path | None = None) -> FastAPI:  # noqa: C901
 
     app = FastAPI(title="agent-forge hosted service", version="0.1.0", lifespan=lifespan)
     app.state.service = service
+
+    @app.get(resolved_config.service.healthcheck_path, response_model=HealthResponse)
+    async def healthcheck() -> HealthResponse:
+        return HealthResponse(
+            status="ok",
+            service_root=str(service._service_root),
+            queue_backend=resolved_config.queue.backend,
+            sandbox_image=resolved_config.sandbox.image,
+        )
 
     @app.post("/v1/runs", response_model=RunStatus, status_code=202)
     async def create_run(request: RunRequest) -> RunStatus:

--- a/agent_forge/service/models.py
+++ b/agent_forge/service/models.py
@@ -227,3 +227,14 @@ class LogsResponse(BaseModel):
     inline: str | None = None
     logs_url: str | None = None
     artifacts: dict[str, str]
+
+
+class HealthResponse(BaseModel):
+    """Readiness information for a hosted deployment."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"]
+    service_root: str
+    queue_backend: str
+    sandbox_image: str

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,32 @@
 version: "3.9"
 
 services:
+  agent-forge-service:
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+    ports:
+      - "8000:8000"
+    environment:
+      AGENT_FORGE_SERVICE_HOST: "0.0.0.0"
+      AGENT_FORGE_SERVICE_PORT: "8000"
+      AGENT_FORGE_SERVICE_ROOT_DIR: "/var/lib/agent-forge/service"
+      AGENT_FORGE_QUEUE_BACKEND: "memory"
+      GEMINI_API_KEY: "${GEMINI_API_KEY:-}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - agent_forge_data:/var/lib/agent-forge
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   redis:
     image: redis:7-alpine
     ports:
@@ -14,4 +40,5 @@ services:
       retries: 5
 
 volumes:
+  agent_forge_data:
   redis_data:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -945,6 +945,13 @@ artifact references. The initial downstream-oriented profile is
 `proof-of-audit-solidity-v1`, which emits `proof-of-audit-report-v1` JSON and
 separates that artifact from the human-oriented CLI summary.
 
+Hosted deployments read a dedicated `service` config section:
+
+- `service.host`
+- `service.port`
+- `service.root_dir`
+- `service.healthcheck_path`
+
 ### 5.1 Configuration File Schema
 
 Agent Forge uses a TOML configuration file (`agent-forge.toml`):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pydantic>=2.0",
     "rich>=13.0",
     "structlog>=24.0",
+    "uvicorn>=0.34",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -222,6 +222,21 @@ class TestConfigCommand:
         assert "max_iterations" in result.output
 
 
+class TestServeCommand:
+    """Tests for the hosted service entrypoint."""
+
+    def test_serve_invokes_uvicorn(self) -> None:
+        runner = _runner()
+        with patch("uvicorn.run") as uvicorn_run:
+            result = runner.invoke(main, ["serve", "--host", "127.0.0.1", "--port", "8123"])
+
+        assert result.exit_code == 0
+        uvicorn_run.assert_called_once()
+        call = uvicorn_run.call_args
+        assert call.kwargs["host"] == "127.0.0.1"
+        assert call.kwargs["port"] == 8123
+
+
 class TestMainGroup:
     """Tests for the CLI group itself."""
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -117,6 +117,11 @@ class TestEnvOverrides:
         result = _collect_env_overrides()
         assert result == {"queue": {"backend": "redis"}}
 
+    def test_service_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGENT_FORGE_SERVICE_PORT", "8123")
+        result = _collect_env_overrides()
+        assert result == {"service": {"port": 8123}}
+
 
 # ---------------------------------------------------------------------------
 # CLI Override Mapping
@@ -173,6 +178,8 @@ class TestDefaults:
         assert cfg.queue.max_concurrent_runs == 4
         assert cfg.logging.level == "INFO"
         assert cfg.logging.format == "text"
+        assert cfg.service.host == "127.0.0.1"
+        assert cfg.service.port == 8000
 
     def test_default_providers(self, tmp_path: Path) -> None:
         cfg = load_config(
@@ -258,6 +265,14 @@ class TestPrecedence:
             user_path=user_toml,
         )
         assert cfg.agent.max_iterations == 3  # CLI wins over all
+
+    def test_service_cli_overrides(self, tmp_path: Path) -> None:
+        cfg = load_config(
+            cli_overrides={"service.port": 9000},
+            project_path=tmp_path / "x.toml",
+            user_path=tmp_path / "y.toml",
+        )
+        assert cfg.service.port == 9000
 
     def test_partial_overrides_preserve_other_fields(self, tmp_path: Path) -> None:
         project_toml = tmp_path / "agent-forge.toml"

--- a/tests/unit/test_service_app.py
+++ b/tests/unit/test_service_app.py
@@ -197,3 +197,12 @@ def test_service_rejects_unsupported_profile(tmp_path: Path) -> None:
     with TestClient(app) as client:
         response = client.post("/v1/runs", json=payload)
         assert response.status_code == 400
+
+
+def test_service_healthcheck_uses_config_path(tmp_path: Path) -> None:
+    app = create_app(service_root=tmp_path / "service-root")
+
+    with TestClient(app) as client:
+        response = client.get("/healthz")
+        assert response.status_code == 200
+        assert response.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- add hosted service runtime configuration and `agent-forge serve`
- package the service with a dedicated Dockerfile and compose deployment
- expose readiness health checks and persistence defaults for long-running service mode

Closes #92