### PR TITLE
feat(#93): add hosted service auth and policy controls

### DIFF
--- a/agent-forge.toml
+++ b/agent-forge.toml
@@ -28,6 +28,11 @@ host = "127.0.0.1"
 port = 8000
 root_dir = "~/.agent-forge/service"
 healthcheck_path = "/healthz"
+auth_enabled = false
+api_key_header = "X-Agent-Forge-API-Key"
+clients_path = "~/.agent-forge/service/clients.toml"
+allow_local_path_sources = false
+max_source_size_bytes = 50_000_000
 
 [providers.gemini]
 api_key_env = "GEMINI_API_KEY"

--- a/agent_forge/config.py
+++ b/agent_forge/config.py
@@ -72,6 +72,11 @@ class ServiceSettings(BaseModel):
     port: int = 8000
     root_dir: str = str(USER_CONFIG_DIR / "service")
     healthcheck_path: str = "/healthz"
+    auth_enabled: bool = False
+    api_key_header: str = "X-Agent-Forge-API-Key"
+    clients_path: str = str(USER_CONFIG_DIR / "service" / "clients.toml")
+    allow_local_path_sources: bool = False
+    max_source_size_bytes: int = 50_000_000
 
 
 class ProviderSettings(BaseModel):

--- a/agent_forge/service/app.py
+++ b/agent_forge/service/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import json
 import os
 import shutil
@@ -12,10 +13,10 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NoReturn, cast
 from urllib.parse import urlparse
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 
 from agent_forge.agent.core import react_loop
 from agent_forge.agent.models import AgentConfig, AgentRun
@@ -41,6 +42,7 @@ from agent_forge.service.models import (
     SeverityLevel,
     TargetRef,
 )
+from agent_forge.service.security import ServiceClientPolicy, load_client_registry
 from agent_forge.tools import create_default_registry
 
 _REPORT_RELATIVE_PATH = Path(".agent-forge/report.json")
@@ -83,6 +85,8 @@ class HostedRunService:
         self._queue = InMemoryQueue()
         self._event_bus = EventBus()
         self._records: dict[str, HostedRunRecord] = {}
+        self._client_policies: dict[str, ServiceClientPolicy] = {}
+        self._audit_log_path = self._service_root / "audit" / "events.jsonl"
         self._worker = Worker(
             queue=self._queue,
             event_bus=self._event_bus,
@@ -93,15 +97,29 @@ class HostedRunService:
     async def start(self) -> None:
         """Start the background worker for hosted runs."""
         self._service_root.mkdir(parents=True, exist_ok=True)
+        clients_path = Path(self._config.service.clients_path).expanduser()
+        self._client_policies = load_client_registry(clients_path)
         await self._worker.start()
 
     async def stop(self) -> None:
         """Stop the background worker for hosted runs."""
         await self._worker.stop()
 
-    async def create_run(self, request: RunRequest) -> RunStatus:
+    async def create_run(
+        self,
+        request: RunRequest,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> RunStatus:
         """Accept a new hosted run request and enqueue it."""
+        client_service_id, client_policy = self._authenticate_headers(headers)
+        self._authorize_submission(
+            request=request,
+            client_service_id=client_service_id,
+            client_policy=client_policy,
+        )
         self._validate_request(request)
+        self._enforce_quotas(client_service_id)
         run_id = f"run_{uuid.uuid4().hex[:16]}"
         workspace_dir = self._materialize_source(run_id, request)
         prompt = self._build_task_prompt(request)
@@ -118,6 +136,13 @@ class HostedRunService:
             created_at=datetime.now(UTC),
         )
         self._records[run_id] = record
+        self._append_audit_event(
+            event="run.accepted",
+            client_service_id=request.client.service_id,
+            run_id=run_id,
+            request_id=request.client.request_id,
+            detail=request.profile.id,
+        )
         await self._queue.enqueue(
             Task(
                 id=run_id,
@@ -128,17 +153,31 @@ class HostedRunService:
         )
         return self._build_status(record, status="accepted")
 
-    async def get_status(self, run_id: str) -> RunStatus:
+    async def get_status(
+        self,
+        run_id: str,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> RunStatus:
         """Return the current lifecycle document for a run."""
+        client_service_id, _ = self._authenticate_headers(headers)
         record = self._records.get(run_id)
         if record is None:
             raise KeyError(run_id)
+        self._authorize_run_access(record, client_service_id=client_service_id)
         queue_status = await self._queue.get_status(run_id)
         return self._build_status(record, status=self._map_status(queue_status))
 
-    def get_report(self, run_id: str) -> ProofOfAuditReport:
+    def get_report(
+        self,
+        run_id: str,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> ProofOfAuditReport:
         """Return the machine report for a completed run."""
+        client_service_id, _ = self._authenticate_headers(headers)
         record = self._require_record(run_id)
+        self._authorize_run_access(record, client_service_id=client_service_id)
         if record.error is not None:
             raise RuntimeError("run_failed")
         if not record.report_path.exists():
@@ -159,9 +198,16 @@ class HostedRunService:
             payload["stats"] = self._compute_stats(payload.get("findings", []))
         return ProofOfAuditReport.model_validate(payload)
 
-    def get_logs(self, run_id: str) -> LogsResponse:
+    def get_logs(
+        self,
+        run_id: str,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> LogsResponse:
         """Return the persisted artifact references for a run."""
+        client_service_id, _ = self._authenticate_headers(headers)
         record = self._require_record(run_id)
+        self._authorize_run_access(record, client_service_id=client_service_id)
         artifacts = {
             "run_dir": str(record.run_dir),
             "run_json": str(record.run_dir / "run.json"),
@@ -171,6 +217,232 @@ class HostedRunService:
             "report_json": str(record.report_path),
         }
         return LogsResponse(run_id=run_id, logs_url=None, inline=None, artifacts=artifacts)
+
+    def _authenticate_headers(
+        self,
+        headers: dict[str, str] | None,
+    ) -> tuple[str | None, ServiceClientPolicy | None]:
+        if not self._config.service.auth_enabled:
+            return None, None
+
+        header_name = self._config.service.api_key_header
+        normalized_headers = {key.lower(): value for key, value in (headers or {}).items()}
+        provided_key = normalized_headers.get(header_name.lower())
+        if not provided_key:
+            self._deny(
+                status_code=401,
+                code="unauthorized",
+                message=f"missing service API key header: {header_name}",
+            )
+
+        for client_service_id, policy in self._client_policies.items():
+            expected_key = os.environ.get(policy.api_key_env, "")
+            if expected_key and hmac.compare_digest(provided_key, expected_key):
+                return client_service_id, policy
+
+        self._deny(
+            status_code=401,
+            code="unauthorized",
+            message="invalid service API key",
+        )
+        raise AssertionError("unreachable")
+
+    def _authorize_submission(
+        self,
+        *,
+        request: RunRequest,
+        client_service_id: str | None,
+        client_policy: ServiceClientPolicy | None,
+    ) -> None:
+        if client_service_id is None or client_policy is None:
+            return
+
+        if request.client.service_id != client_service_id:
+            self._append_audit_event(
+                event="run.denied",
+                client_service_id=client_service_id,
+                request_id=request.client.request_id,
+                detail="client service_id does not match authenticated API key",
+            )
+            self._deny(
+                status_code=403,
+                code="unauthorized",
+                message="request client does not match authenticated service client",
+            )
+
+        if request.profile.id not in client_policy.allowed_profiles:
+            self._append_audit_event(
+                event="run.denied",
+                client_service_id=client_service_id,
+                request_id=request.client.request_id,
+                detail=f"profile not allowed: {request.profile.id}",
+            )
+            self._deny(
+                status_code=403,
+                code="policy_denied",
+                message=f"profile not allowed for client: {request.profile.id}",
+            )
+
+        if request.source.kind not in client_policy.allowed_source_kinds:
+            self._append_audit_event(
+                event="run.denied",
+                client_service_id=client_service_id,
+                request_id=request.client.request_id,
+                detail=f"source kind not allowed: {request.source.kind}",
+            )
+            self._deny(
+                status_code=403,
+                code="policy_denied",
+                message=f"source kind not allowed for client: {request.source.kind}",
+            )
+
+        local_path_allowed = (
+            self._config.service.allow_local_path_sources and client_policy.allow_local_path
+        )
+        if request.source.kind == "local_path" and not local_path_allowed:
+            self._append_audit_event(
+                event="run.denied",
+                client_service_id=client_service_id,
+                request_id=request.client.request_id,
+                detail="local_path sources disabled by service policy",
+            )
+            self._deny(
+                status_code=403,
+                code="policy_denied",
+                message="local_path sources are disabled for hosted clients",
+            )
+
+        source_size_bytes = self._source_size_bytes(request.source.uri)
+        if source_size_bytes > self._config.service.max_source_size_bytes:
+            self._append_audit_event(
+                event="run.denied",
+                client_service_id=client_service_id,
+                request_id=request.client.request_id,
+                detail=f"source exceeds max size: {source_size_bytes}",
+            )
+            self._deny(
+                status_code=403,
+                code="policy_denied",
+                message="source exceeds configured size limit",
+            )
+
+    def _authorize_run_access(
+        self,
+        record: HostedRunRecord,
+        *,
+        client_service_id: str | None,
+    ) -> None:
+        if client_service_id is None:
+            return
+        if record.request.client.service_id == client_service_id:
+            return
+        self._append_audit_event(
+            event="run.denied",
+            client_service_id=client_service_id,
+            run_id=record.run_id,
+            request_id=record.request.client.request_id,
+            detail="attempted to access another client's run",
+        )
+        self._deny(
+            status_code=403,
+            code="policy_denied",
+            message="run does not belong to authenticated client",
+        )
+
+    def _enforce_quotas(self, client_service_id: str | None) -> None:
+        if client_service_id is None:
+            return
+        policy = self._client_policies.get(client_service_id)
+        if policy is None:
+            self._deny(
+                status_code=401,
+                code="unauthorized",
+                message=f"no client policy configured for: {client_service_id}",
+            )
+
+        now = datetime.now(UTC)
+        active_runs = 0
+        daily_runs = 0
+        for record in self._records.values():
+            if record.request.client.service_id != client_service_id:
+                continue
+            if record.completed_at is None:
+                active_runs += 1
+            if (now - record.created_at).total_seconds() <= 86_400:
+                daily_runs += 1
+
+        if active_runs >= policy.max_active_runs:
+            self._append_audit_event(
+                event="run.denied",
+                client_service_id=client_service_id,
+                detail=f"max active runs exceeded: {active_runs}",
+            )
+            self._deny(
+                status_code=429,
+                code="quota_exceeded",
+                message="client has reached the active run limit",
+            )
+
+        if daily_runs >= policy.max_runs_per_day:
+            self._append_audit_event(
+                event="run.denied",
+                client_service_id=client_service_id,
+                detail=f"max daily runs exceeded: {daily_runs}",
+            )
+            self._deny(
+                status_code=429,
+                code="quota_exceeded",
+                message="client has reached the daily run limit",
+            )
+
+    def _source_size_bytes(self, source_uri: str) -> int:
+        path = self._local_path_from_uri(source_uri)
+        if path.is_dir():
+            return sum(
+                child.stat().st_size
+                for child in path.rglob("*")
+                if child.is_file()
+            )
+        return path.stat().st_size
+
+    def _append_audit_event(
+        self,
+        *,
+        event: str,
+        client_service_id: str | None,
+        run_id: str | None = None,
+        request_id: str | None = None,
+        detail: str | None = None,
+    ) -> None:
+        payload = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "event": event,
+            "client_service_id": client_service_id,
+            "run_id": run_id,
+            "request_id": request_id,
+            "detail": detail,
+        }
+        self._audit_log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._audit_log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload) + "\n")
+
+    def _deny(
+        self,
+        *,
+        status_code: int,
+        code: str,
+        message: str,
+    ) -> NoReturn:
+        raise HTTPException(
+            status_code=status_code,
+            detail=ErrorResponse(
+                error=RunError(
+                    code=cast("Any", code),
+                    message=message,
+                    retryable=False,
+                )
+            ).model_dump(),
+        )
 
     def _require_record(self, run_id: str) -> HostedRunRecord:
         record = self._records.get(run_id)
@@ -365,6 +637,13 @@ class HostedRunService:
                     )
                     raise RuntimeError(record.error.message)
                 record.completed_at = datetime.now(UTC)
+                self._append_audit_event(
+                    event="run.completed",
+                    client_service_id=record.request.client.service_id,
+                    run_id=record.run_id,
+                    request_id=record.request.client.request_id,
+                    detail=None,
+                )
             except Exception as exc:
                 if record.error is None:
                     record.error = RunError(
@@ -373,6 +652,13 @@ class HostedRunService:
                         retryable=False,
                     )
                 record.completed_at = datetime.now(UTC)
+                self._append_audit_event(
+                    event="run.failed",
+                    client_service_id=record.request.client.service_id,
+                    run_id=record.run_id,
+                    request_id=record.request.client.request_id,
+                    detail=record.error.message,
+                )
                 raise
             finally:
                 await sandbox.stop()
@@ -496,13 +782,13 @@ def create_app(  # noqa: C901
         )
 
     @app.post("/v1/runs", response_model=RunStatus, status_code=202)
-    async def create_run(request: RunRequest) -> RunStatus:
-        return await service.create_run(request)
+    async def create_run(request: RunRequest, http_request: Request) -> RunStatus:
+        return await service.create_run(request, headers=dict(http_request.headers))
 
     @app.get("/v1/runs/{run_id}", response_model=RunStatus)
-    async def get_run(run_id: str) -> RunStatus:
+    async def get_run(run_id: str, http_request: Request) -> RunStatus:
         try:
-            return await service.get_status(run_id)
+            return await service.get_status(run_id, headers=dict(http_request.headers))
         except KeyError as exc:
             error = ErrorResponse(
                 error=RunError(
@@ -514,9 +800,9 @@ def create_app(  # noqa: C901
             raise HTTPException(status_code=404, detail=error.model_dump()) from exc
 
     @app.get("/v1/runs/{run_id}/report", response_model=ProofOfAuditReport)
-    async def get_report(run_id: str) -> ProofOfAuditReport:
+    async def get_report(run_id: str, http_request: Request) -> ProofOfAuditReport:
         try:
-            return service.get_report(run_id)
+            return service.get_report(run_id, headers=dict(http_request.headers))
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=f"unknown run id: {run_id}") from exc
         except RuntimeError as exc:
@@ -525,9 +811,9 @@ def create_app(  # noqa: C901
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     @app.get("/v1/runs/{run_id}/logs", response_model=LogsResponse)
-    async def get_logs(run_id: str) -> LogsResponse:
+    async def get_logs(run_id: str, http_request: Request) -> LogsResponse:
         try:
-            return service.get_logs(run_id)
+            return service.get_logs(run_id, headers=dict(http_request.headers))
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=f"unknown run id: {run_id}") from exc
 

--- a/agent_forge/service/security.py
+++ b/agent_forge/service/security.py
@@ -1,0 +1,50 @@
+"""Internal authentication and policy models for hosted service mode."""
+
+from __future__ import annotations
+
+import tomllib
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+AllowedSourceKind = Literal["archive_uri", "repository_uri", "git_repository", "local_path"]
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _default_allowed_source_kinds() -> list[AllowedSourceKind]:
+    return ["archive_uri", "repository_uri", "git_repository"]
+
+
+class ServiceClientPolicy(BaseModel):
+    """Configuration for a single hosted-service client."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    api_key_env: str
+    allowed_profiles: list[str] = Field(default_factory=list)
+    allowed_source_kinds: list[AllowedSourceKind] = Field(
+        default_factory=_default_allowed_source_kinds
+    )
+    max_active_runs: int = Field(default=1, ge=1)
+    max_runs_per_day: int = Field(default=25, ge=1)
+    allow_local_path: bool = False
+
+
+class ServiceClientRegistry(BaseModel):
+    """Registry of externally authenticated hosted-service clients."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    clients: dict[str, ServiceClientPolicy] = Field(default_factory=dict)
+
+
+def load_client_registry(path: Path) -> dict[str, ServiceClientPolicy]:
+    """Load client auth and policy configuration from a TOML file."""
+    if not path.is_file():
+        return {}
+
+    with path.open("rb") as handle:
+        raw = tomllib.load(handle)
+    return ServiceClientRegistry.model_validate(raw).clients

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -951,6 +951,26 @@ Hosted deployments read a dedicated `service` config section:
 - `service.port`
 - `service.root_dir`
 - `service.healthcheck_path`
+- `service.auth_enabled`
+- `service.api_key_header`
+- `service.clients_path`
+- `service.allow_local_path_sources`
+- `service.max_source_size_bytes`
+
+When `service.auth_enabled` is enabled, the hosted API requires an API key on
+all `/v1/runs` endpoints. Client identities and execution policy limits are
+loaded from `service.clients_path`, which maps each external `service_id` to:
+
+- an API key environment variable name
+- allowed hosted profiles
+- allowed source kinds
+- max active runs
+- max runs per day
+- whether `local_path` inputs are allowed for that client
+
+Hosted mode also appends JSONL audit events under
+`<service.root_dir>/audit/events.jsonl` for accepted runs, policy denials, and
+run completion or failure.
 
 ### 5.1 Configuration File Schema
 
@@ -982,9 +1002,20 @@ level = "INFO"                   # DEBUG, INFO, WARNING, ERROR
 format = "text"                  # "text" or "json"
 log_file = ""                    # Optional path for JSON log file
 
+[service]
+host = "127.0.0.1"
+port = 8000
+root_dir = "~/.agent-forge/service"
+healthcheck_path = "/healthz"
+auth_enabled = false
+api_key_header = "X-Agent-Forge-API-Key"
+clients_path = "~/.agent-forge/service/clients.toml"
+allow_local_path_sources = false
+max_source_size_bytes = 50_000_000
+
 [providers.gemini]
 api_key_env = "GEMINI_API_KEY"
-default_model = "gemini-2.0-flash"
+default_model = "gemini-3.1-flash-lite-preview"
 
 [providers.openai]
 api_key_env = "OPENAI_API_KEY"
@@ -1030,6 +1061,8 @@ Format: `AGENT_FORGE_{SECTION}_{KEY}` (uppercase, underscored).
 | `AGENT_FORGE_AGENT_MAX_ITERATIONS` | `agent.max_iterations` |
 | `AGENT_FORGE_SANDBOX_MEMORY_LIMIT` | `sandbox.memory_limit` |
 | `AGENT_FORGE_QUEUE_BACKEND`        | `queue.backend`        |
+| `AGENT_FORGE_SERVICE_AUTH_ENABLED` | `service.auth_enabled` |
+| `AGENT_FORGE_SERVICE_PORT`         | `service.port`         |
 | `GEMINI_API_KEY`                   | (direct, not prefixed) |
 | `OPENAI_API_KEY`                   | (direct, not prefixed) |
 | `ANTHROPIC_API_KEY`                | (direct, not prefixed) |

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -122,6 +122,11 @@ class TestEnvOverrides:
         result = _collect_env_overrides()
         assert result == {"service": {"port": 8123}}
 
+    def test_service_auth_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGENT_FORGE_SERVICE_AUTH_ENABLED", "true")
+        result = _collect_env_overrides()
+        assert result == {"service": {"auth_enabled": True}}
+
 
 # ---------------------------------------------------------------------------
 # CLI Override Mapping
@@ -180,6 +185,10 @@ class TestDefaults:
         assert cfg.logging.format == "text"
         assert cfg.service.host == "127.0.0.1"
         assert cfg.service.port == 8000
+        assert cfg.service.auth_enabled is False
+        assert cfg.service.api_key_header == "X-Agent-Forge-API-Key"
+        assert cfg.service.allow_local_path_sources is False
+        assert cfg.service.max_source_size_bytes == 50_000_000
 
     def test_default_providers(self, tmp_path: Path) -> None:
         cfg = load_config(

--- a/tests/unit/test_service_app.py
+++ b/tests/unit/test_service_app.py
@@ -7,10 +7,13 @@ from typing import TYPE_CHECKING
 
 from fastapi.testclient import TestClient
 
+from agent_forge.config import ForgeConfig, ServiceSettings
 from agent_forge.service.app import create_app
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pytest
 
     from agent_forge.orchestration.queue import Task
 
@@ -45,6 +48,55 @@ def _request_payload(source_uri: str) -> dict[str, object]:
             "include_logs": True,
         },
     }
+
+
+def _service_config(
+    tmp_path: Path,
+    *,
+    auth_enabled: bool,
+    clients_path: Path | None = None,
+    allow_local_path_sources: bool = False,
+    max_source_size_bytes: int = 50_000_000,
+) -> ForgeConfig:
+    return ForgeConfig(
+        service=ServiceSettings(
+            root_dir=str(tmp_path / "service-root"),
+            auth_enabled=auth_enabled,
+            clients_path=str(clients_path or (tmp_path / "clients.toml")),
+            allow_local_path_sources=allow_local_path_sources,
+            max_source_size_bytes=max_source_size_bytes,
+        )
+    )
+
+
+def _write_clients_file(
+    path: Path,
+    *,
+    allow_local_path: bool = False,
+    include_secondary_client: bool = False,
+) -> None:
+    secondary = """
+[clients.other-client]
+api_key_env = "OTHER_SERVICE_API_KEY"
+allowed_profiles = ["proof-of-audit-solidity-v1"]
+allowed_source_kinds = ["local_path"]
+max_active_runs = 1
+max_runs_per_day = 5
+allow_local_path = true
+""" if include_secondary_client else ""
+    path.write_text(
+        f"""
+[clients.proof-of-audit-auditor]
+api_key_env = "POA_SERVICE_API_KEY"
+allowed_profiles = ["proof-of-audit-solidity-v1"]
+allowed_source_kinds = ["local_path", "archive_uri"]
+max_active_runs = 1
+max_runs_per_day = 5
+allow_local_path = {"true" if allow_local_path else "false"}
+{secondary}
+""".lstrip(),
+        encoding="utf-8",
+    )
 
 
 def test_service_create_run_and_return_report(tmp_path: Path) -> None:
@@ -206,3 +258,222 @@ def test_service_healthcheck_uses_config_path(tmp_path: Path) -> None:
         response = client.get("/healthz")
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
+
+
+def test_service_requires_api_key_when_auth_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    clients_path = tmp_path / "clients.toml"
+    _write_clients_file(clients_path, allow_local_path=True)
+    monkeypatch.setenv("POA_SERVICE_API_KEY", "test-service-key")
+
+    app = create_app(
+        config=_service_config(
+            tmp_path,
+            auth_enabled=True,
+            clients_path=clients_path,
+            allow_local_path_sources=True,
+        )
+    )
+
+    with TestClient(app) as client:
+        response = client.post("/v1/runs", json=_request_payload(str(repo)))
+        assert response.status_code == 401
+        assert response.json()["detail"]["error"]["code"] == "unauthorized"
+
+
+def test_service_denies_local_paths_by_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    clients_path = tmp_path / "clients.toml"
+    _write_clients_file(clients_path, allow_local_path=False)
+    monkeypatch.setenv("POA_SERVICE_API_KEY", "test-service-key")
+
+    app = create_app(
+        config=_service_config(
+            tmp_path,
+            auth_enabled=True,
+            clients_path=clients_path,
+            allow_local_path_sources=False,
+        )
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/runs",
+            json=_request_payload(str(repo)),
+            headers={"X-Agent-Forge-API-Key": "test-service-key"},
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"]["error"]["code"] == "policy_denied"
+
+
+def test_service_enforces_active_run_quota(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    clients_path = tmp_path / "clients.toml"
+    _write_clients_file(clients_path, allow_local_path=True)
+    monkeypatch.setenv("POA_SERVICE_API_KEY", "test-service-key")
+
+    app = create_app(
+        config=_service_config(
+            tmp_path,
+            auth_enabled=True,
+            clients_path=clients_path,
+            allow_local_path_sources=True,
+        )
+    )
+
+    async def slow_runner(task: Task) -> None:
+        await asyncio.sleep(0.1)
+        record = app.state.service._records[task.id]
+        record.started_at = record.created_at
+        record.completed_at = record.created_at
+        record.report_path.parent.mkdir(parents=True, exist_ok=True)
+        record.report_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "proof-of-audit-report-v1",
+                    "run_id": task.id,
+                    "summary": "ok",
+                    "confidence": "high",
+                    "findings": [],
+                    "stats": {
+                        "finding_count": 0,
+                        "max_severity": None,
+                        "severity_breakdown": {
+                            "critical": 0,
+                            "high": 0,
+                            "medium": 0,
+                            "low": 0,
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    app.state.service._worker._task_runner = slow_runner
+
+    with TestClient(app) as client:
+        headers = {"X-Agent-Forge-API-Key": "test-service-key"}
+        first = client.post("/v1/runs", json=_request_payload(str(repo)), headers=headers)
+        assert first.status_code == 202
+
+        second = client.post("/v1/runs", json=_request_payload(str(repo)), headers=headers)
+        assert second.status_code == 429
+        assert second.json()["detail"]["error"]["code"] == "quota_exceeded"
+
+
+def test_service_prevents_cross_client_run_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    clients_path = tmp_path / "clients.toml"
+    _write_clients_file(clients_path, allow_local_path=True, include_secondary_client=True)
+    monkeypatch.setenv("POA_SERVICE_API_KEY", "test-service-key")
+    monkeypatch.setenv("OTHER_SERVICE_API_KEY", "other-service-key")
+
+    app = create_app(
+        config=_service_config(
+            tmp_path,
+            auth_enabled=True,
+            clients_path=clients_path,
+            allow_local_path_sources=True,
+        )
+    )
+    service = app.state.service
+
+    async def fake_runner(task: Task) -> None:
+        record = service._records[task.id]
+        record.started_at = record.created_at
+        record.completed_at = record.created_at
+        record.report_path.parent.mkdir(parents=True, exist_ok=True)
+        record.report_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "proof-of-audit-report-v1",
+                    "run_id": task.id,
+                    "summary": "ok",
+                    "confidence": "high",
+                    "findings": [],
+                    "stats": {
+                        "finding_count": 0,
+                        "max_severity": None,
+                        "severity_breakdown": {
+                            "critical": 0,
+                            "high": 0,
+                            "medium": 0,
+                            "low": 0,
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    service._worker._task_runner = fake_runner
+
+    with TestClient(app) as client:
+        create_response = client.post(
+            "/v1/runs",
+            json=_request_payload(str(repo)),
+            headers={"X-Agent-Forge-API-Key": "test-service-key"},
+        )
+        assert create_response.status_code == 202
+        run_id = create_response.json()["run_id"]
+
+        status_response = client.get(
+            f"/v1/runs/{run_id}",
+            headers={"X-Agent-Forge-API-Key": "other-service-key"},
+        )
+        assert status_response.status_code == 403
+        assert status_response.json()["detail"]["error"]["code"] == "policy_denied"
+
+
+def test_service_writes_audit_log_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Vault.sol").write_text("contract Vault {}\n", encoding="utf-8")
+    clients_path = tmp_path / "clients.toml"
+    _write_clients_file(clients_path, allow_local_path=True)
+    monkeypatch.setenv("POA_SERVICE_API_KEY", "test-service-key")
+
+    app = create_app(
+        config=_service_config(
+            tmp_path,
+            auth_enabled=True,
+            clients_path=clients_path,
+            allow_local_path_sources=True,
+            max_source_size_bytes=1,
+        )
+    )
+
+    with TestClient(app) as client:
+        denied = client.post(
+            "/v1/runs",
+            json=_request_payload(str(repo)),
+            headers={"X-Agent-Forge-API-Key": "test-service-key"},
+        )
+        assert denied.status_code == 403
+
+    audit_log = tmp_path / "service-root" / "audit" / "events.jsonl"
+    lines = audit_log.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["event"] == "run.denied"
+    assert payload["client_service_id"] == "proof-of-audit-auditor"


### PR DESCRIPTION
## Summary
- require hosted-service API keys from a client registry and enforce client identity on run access
- add per-client profile/source policy checks, active-run and daily-run quotas, and size limits
- append hosted-service audit events and document the new service auth configuration

Closes #93