### PR TITLE
feat(#94): add proof-of-audit compatibility harness

### DIFF
--- a/agent_forge/service/__init__.py
+++ b/agent_forge/service/__init__.py
@@ -1,5 +1,15 @@
 """Hosted service package for agent-forge."""
 
 from agent_forge.service.app import create_app
+from agent_forge.service.client import (
+    HostedServiceClientError,
+    ProofOfAuditHostedClient,
+    build_proof_of_audit_request,
+)
 
-__all__ = ["create_app"]
+__all__ = [
+    "HostedServiceClientError",
+    "ProofOfAuditHostedClient",
+    "build_proof_of_audit_request",
+    "create_app",
+]

--- a/agent_forge/service/client.py
+++ b/agent_forge/service/client.py
@@ -1,0 +1,181 @@
+"""Client helpers for externally consuming the hosted agent-forge service."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import NoReturn, TypeVar
+
+import httpx
+
+from agent_forge.service.models import (
+    ArtifactPolicy,
+    ClientRef,
+    ErrorResponse,
+    ProfileRef,
+    ProofOfAuditReport,
+    RunRequest,
+    RunStatus,
+    SourceKind,
+    SourceRef,
+    TargetRef,
+)
+
+ModelT = TypeVar("ModelT", RunStatus, ProofOfAuditReport)
+
+
+class HostedServiceClientError(RuntimeError):
+    """Raised when the hosted service rejects or fails a client request."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        message: str,
+        code: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+
+
+def build_proof_of_audit_request(
+    *,
+    request_id: str,
+    service_id: str,
+    source_uri: str,
+    source_kind: SourceKind,
+    entry_contract: str,
+    contract_address: str,
+    network: str,
+    chain_id: int,
+    source_digest: str | None = None,
+) -> RunRequest:
+    """Build the hosted run payload expected by Proof-of-Audit-style clients."""
+    return RunRequest(
+        schema_version="agent-forge-run-request-v1",
+        client=ClientRef(
+            name="proof-of-audit",
+            request_id=request_id,
+            service_id=service_id,
+        ),
+        profile=ProfileRef(
+            id="proof-of-audit-solidity-v1",
+            report_schema="proof-of-audit-report-v1",
+        ),
+        source=SourceRef(
+            kind=source_kind,
+            uri=source_uri,
+            entry_contract=entry_contract,
+            source_digest=source_digest,
+        ),
+        target=TargetRef(
+            submission_kind="deployed_address",
+            network=network,
+            chain_id=chain_id,
+            contract_address=contract_address,
+        ),
+        artifacts=ArtifactPolicy(result_delivery="pull", include_logs=True),
+    )
+
+
+class ProofOfAuditHostedClient:
+    """Async compatibility client for Proof-of-Audit-style hosted runs."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._owns_client = http_client is None
+        self._client = http_client or httpx.AsyncClient(base_url=base_url)
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client if owned by this instance."""
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def submit_run(self, request: RunRequest) -> RunStatus:
+        """Submit a hosted Proof-of-Audit run request."""
+        response = await self._client.post(
+            "/v1/runs",
+            json=request.model_dump(mode="json"),
+            headers=self._headers(),
+        )
+        return self._parse_response(response, RunStatus)
+
+    async def get_status(self, run_id: str) -> RunStatus:
+        """Fetch the current lifecycle state for a hosted run."""
+        response = await self._client.get(
+            f"/v1/runs/{run_id}",
+            headers=self._headers(),
+        )
+        return self._parse_response(response, RunStatus)
+
+    async def get_report(self, run_id: str) -> ProofOfAuditReport:
+        """Fetch the machine-readable report for a completed run."""
+        response = await self._client.get(
+            f"/v1/runs/{run_id}/report",
+            headers=self._headers(),
+        )
+        return self._parse_response(response, ProofOfAuditReport)
+
+    async def wait_for_report(
+        self,
+        run_id: str,
+        *,
+        poll_interval_seconds: float = 0.05,
+        max_polls: int = 100,
+    ) -> ProofOfAuditReport:
+        """Poll run status until a final report is available or the run fails."""
+        for _ in range(max_polls):
+            status = await self.get_status(run_id)
+            if status.status == "completed":
+                return await self.get_report(run_id)
+            if status.status == "failed":
+                error = status.error
+                raise HostedServiceClientError(
+                    status_code=409,
+                    code=error.code if error is not None else None,
+                    message=(
+                        error.message
+                        if error is not None
+                        else "hosted service run failed without an error payload"
+                    ),
+                )
+            await asyncio.sleep(poll_interval_seconds)
+
+        msg = f"timed out waiting for hosted run: {run_id}"
+        raise TimeoutError(msg)
+
+    def _headers(self) -> dict[str, str]:
+        return {"X-Agent-Forge-API-Key": self._api_key}
+
+    def _parse_response(self, response: httpx.Response, model: type[ModelT]) -> ModelT:
+        if response.is_success:
+            return model.model_validate(response.json())
+        self._raise_service_error(response)
+        raise AssertionError("unreachable")
+
+    def _raise_service_error(self, response: httpx.Response) -> NoReturn:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {"detail": response.text}
+
+        detail = payload.get("detail", payload)
+        if isinstance(detail, dict) and "error" in detail:
+            error = ErrorResponse.model_validate(detail).error
+            raise HostedServiceClientError(
+                status_code=response.status_code,
+                code=error.code,
+                message=error.message,
+            )
+
+        raise HostedServiceClientError(
+            status_code=response.status_code,
+            code=None,
+            message=str(detail),
+        )

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -972,6 +972,11 @@ Hosted mode also appends JSONL audit events under
 `<service.root_dir>/audit/events.jsonl` for accepted runs, policy denials, and
 run completion or failure.
 
+The hosted API also ships with a Proof-of-Audit compatibility harness in
+`agent_forge.service.client`, including a client helper that submits the
+versioned request contract, polls `/v1/runs/{run_id}`, retrieves the stable
+report artifact, and preserves machine-readable failure codes for regressions.
+
 ### 5.1 Configuration File Schema
 
 Agent Forge uses a TOML configuration file (`agent-forge.toml`):

--- a/tests/unit/test_service_client.py
+++ b/tests/unit/test_service_client.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from agent_forge.config import ForgeConfig, ServiceSettings
+from agent_forge.service import (
+    HostedServiceClientError,
+    ProofOfAuditHostedClient,
+    build_proof_of_audit_request,
+    create_app,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from agent_forge.orchestration.queue import Task
+
+
+def _service_config(
+    tmp_path: Path,
+    *,
+    clients_path: Path,
+    allow_local_path_sources: bool = True,
+) -> ForgeConfig:
+    return ForgeConfig(
+        service=ServiceSettings(
+            root_dir=str(tmp_path / "service-root"),
+            auth_enabled=True,
+            clients_path=str(clients_path),
+            allow_local_path_sources=allow_local_path_sources,
+        )
+    )
+
+
+def _write_clients_file(path: Path) -> None:
+    path.write_text(
+        """
+[clients.proof-of-audit-auditor]
+api_key_env = "POA_SERVICE_API_KEY"
+allowed_profiles = ["proof-of-audit-solidity-v1"]
+allowed_source_kinds = ["local_path", "archive_uri"]
+max_active_runs = 1
+max_runs_per_day = 5
+allow_local_path = true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_proof_of_audit_client_completes_hosted_flow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Vault.sol").write_text("contract Vault {}\n", encoding="utf-8")
+    clients_path = tmp_path / "clients.toml"
+    _write_clients_file(clients_path)
+    monkeypatch.setenv("POA_SERVICE_API_KEY", "test-service-key")
+
+    app = create_app(config=_service_config(tmp_path, clients_path=clients_path))
+    service = app.state.service
+
+    async def fake_runner(task: Task) -> None:
+        record = service._records[task.id]
+        record.started_at = record.created_at
+        record.completed_at = record.created_at
+        record.report_path.parent.mkdir(parents=True, exist_ok=True)
+        record.report_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "proof-of-audit-report-v1",
+                    "run_id": task.id,
+                    "summary": "Potential reentrancy issue detected",
+                    "confidence": "high",
+                    "target": {
+                        "submission_kind": "deployed_address",
+                        "network": "base-sepolia",
+                        "chain_id": 84532,
+                        "contract_address": "0xabc",
+                        "entry_contract": "Vault",
+                    },
+                    "findings": [
+                        {
+                            "finding_id": "POA-1",
+                            "title": "Reentrancy on withdraw",
+                            "severity": "high",
+                            "category": "reentrancy",
+                            "description": "External call before balance update.",
+                            "impact": "Attacker can drain funds.",
+                            "recommendation": "Use checks-effects-interactions.",
+                            "confidence": "high",
+                        }
+                    ],
+                    "stats": {
+                        "finding_count": 1,
+                        "max_severity": "high",
+                        "severity_breakdown": {
+                            "critical": 0,
+                            "high": 1,
+                            "medium": 0,
+                            "low": 0,
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    service._worker._task_runner = fake_runner
+
+    request = build_proof_of_audit_request(
+        request_id="audit-123",
+        service_id="proof-of-audit-auditor",
+        source_uri=str(repo),
+        source_kind="local_path",
+        entry_contract="Vault",
+        contract_address="0xabc",
+        network="base-sepolia",
+        chain_id=84532,
+        source_digest="sha256:test",
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with (
+        app.router.lifespan_context(app),
+        httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as http_client,
+    ):
+        client = ProofOfAuditHostedClient(
+            base_url="http://testserver",
+            api_key="test-service-key",
+            http_client=http_client,
+        )
+        submitted = await client.submit_run(request)
+        report = await client.wait_for_report(submitted.run_id)
+
+    assert submitted.status in {"accepted", "queued", "running", "completed"}
+    assert report.schema_version == "proof-of-audit-report-v1"
+    assert report.target is not None
+    assert report.target.network == "base-sepolia"
+    assert report.stats.finding_count == 1
+    assert report.findings[0].category == "reentrancy"
+
+
+@pytest.mark.asyncio
+async def test_proof_of_audit_client_maps_auth_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Vault.sol").write_text("contract Vault {}\n", encoding="utf-8")
+    clients_path = tmp_path / "clients.toml"
+    _write_clients_file(clients_path)
+    monkeypatch.setenv("POA_SERVICE_API_KEY", "expected-key")
+
+    app = create_app(config=_service_config(tmp_path, clients_path=clients_path))
+    request = build_proof_of_audit_request(
+        request_id="audit-123",
+        service_id="proof-of-audit-auditor",
+        source_uri=str(repo),
+        source_kind="local_path",
+        entry_contract="Vault",
+        contract_address="0xabc",
+        network="base-sepolia",
+        chain_id=84532,
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with (
+        app.router.lifespan_context(app),
+        httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as http_client,
+    ):
+        client = ProofOfAuditHostedClient(
+            base_url="http://testserver",
+            api_key="wrong-key",
+            http_client=http_client,
+        )
+        with pytest.raises(HostedServiceClientError) as exc_info:
+            await client.submit_run(request)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.code == "unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_proof_of_audit_client_maps_failed_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Vault.sol").write_text("contract Vault {}\n", encoding="utf-8")
+    clients_path = tmp_path / "clients.toml"
+    _write_clients_file(clients_path)
+    monkeypatch.setenv("POA_SERVICE_API_KEY", "test-service-key")
+
+    app = create_app(config=_service_config(tmp_path, clients_path=clients_path))
+    service = app.state.service
+
+    async def failing_runner(task: Task) -> None:
+        record = service._records[task.id]
+        record.started_at = record.created_at
+        record.completed_at = record.created_at
+        msg = "sandbox rejected the analysis request"
+        record.error = {
+            "code": "sandbox_execution_failed",
+            "message": msg,
+            "retryable": False,
+        }
+        raise RuntimeError(msg)
+
+    service._worker._task_runner = failing_runner
+
+    request = build_proof_of_audit_request(
+        request_id="audit-123",
+        service_id="proof-of-audit-auditor",
+        source_uri=str(repo),
+        source_kind="local_path",
+        entry_contract="Vault",
+        contract_address="0xabc",
+        network="base-sepolia",
+        chain_id=84532,
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with (
+        app.router.lifespan_context(app),
+        httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as http_client,
+    ):
+        client = ProofOfAuditHostedClient(
+            base_url="http://testserver",
+            api_key="test-service-key",
+            http_client=http_client,
+        )
+        submitted = await client.submit_run(request)
+        with pytest.raises(HostedServiceClientError) as exc_info:
+            await client.wait_for_report(submitted.run_id, poll_interval_seconds=0.01)
+
+    assert exc_info.value.code == "sandbox_execution_failed"


### PR DESCRIPTION
## Summary
- add an async hosted-service client for Proof-of-Audit-style consumers
- cover submission, polling, report retrieval, and failure mapping with compatibility tests
- document the compatibility harness entry point in the hosted-service spec

Closes #94