### PR TITLE
docs(#89): close out hosted service epic

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ graph TD
 - **🔒 Sandboxed Execution** — Every tool invocation runs in an ephemeral Docker container with resource limits — never on the host.
 - **🧠 Gemini 3.1 Ready** — Full support for thought signatures, exponential backoff with jitter, and `Retry-After` header.
 - **🔌 Extensible LLM Layer** — Gemini adapter built, OpenAI and Anthropic interfaces defined for easy addition.
+- **🌐 Hosted Service Mode** — Run Agent Forge as a versioned FastAPI service for external clients with API-key auth, policy controls, and Proof-of-Audit compatibility.
 - **📊 Observability** — Structured JSON logs, trace IDs, token/cost tracking on every run.
 - **💾 Run Persistence** — Every agent run is saved to disk with full conversation history and tool invocations.
 - **🧩 Extensible Tools** — Add new tools by implementing a simple `Tool` ABC and registering them.
@@ -225,9 +226,10 @@ agent_forge/
 | **4** | Web Dashboard & REST API                                          | ⬜ Planned     |
 | **5** | Multi-Agent Collaboration                                         | ⬜ Planned     |
 | **6** | Advanced Isolation & Scaling (microVMs, K8s)                      | ⬜ Planned     |
-| **7** | Platform & Ecosystem (MCP, marketplace, IDE plugins)              | ⬜ Planned     |
+| **7** | Platform & Ecosystem (MCP, marketplace, IDE plugins)              | 🚧 In Progress |
 
 See [spec.md § Roadmap](docs/spec.md#12-roadmap) for detailed milestones.
+Hosted service support for external clients is the first completed Phase 7 milestone.
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1463,6 +1463,7 @@ clean:                     ## Clean up containers and build artifacts
 
 > **Goal:** Agent Forge becomes a platform others can build on.
 
+- [x] Hosted service mode for external clients (versioned run API, headless report contract, deployment model, auth and policy controls, compatibility client, operations guide)
 - [ ] MCP (Model Context Protocol) tool server: expose tools for interop with external agents
 - [ ] Multi-tenant auth + RBAC (team workspaces, API keys, usage quotas)
 - [ ] Custom LLM routing: cost/latency-based model selection per tool call


### PR DESCRIPTION
## Summary
- surface hosted-service mode in the README feature list now that the external-client workflow is shipped
- mark Phase 7 as in progress and call out hosted service support as the first delivered milestone
- record the hosted-service epic as complete in the roadmap section of the technical spec

## Testing
- PATH=/home/koita/dev/ai/agent-forge/.venv/bin:$PATH make lint

Closes #89
