### PR TITLE
fix: enforce hosted auth before validation

### DIFF
--- a/agent_forge/service/app.py
+++ b/agent_forge/service/app.py
@@ -17,6 +17,7 @@ from typing import Any, NoReturn, cast
 from urllib.parse import urlparse
 
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 
 from agent_forge.agent.core import react_loop
 from agent_forge.agent.models import AgentConfig, AgentRun
@@ -956,6 +957,24 @@ def create_app(  # noqa: C901
         if http_request.client is not None:
             return http_request.client.host
         return None
+
+    @app.middleware("http")
+    async def require_hosted_auth(http_request: Request, call_next: Any) -> Any:
+        if not resolved_config.service.auth_enabled:
+            return await call_next(http_request)
+        if not http_request.url.path.startswith("/v1/runs"):
+            return await call_next(http_request)
+
+        try:
+            service._authenticate_headers(
+                dict(http_request.headers),
+                request_origin=_request_origin(http_request),
+                user_agent=http_request.headers.get("user-agent"),
+            )
+        except HTTPException as exc:
+            return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+        return await call_next(http_request)
 
     @app.get(resolved_config.service.healthcheck_path, response_model=HealthResponse)
     async def healthcheck() -> HealthResponse:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       AGENT_FORGE_SERVICE_HOST: "0.0.0.0"
       AGENT_FORGE_SERVICE_PORT: "8000"
       AGENT_FORGE_SERVICE_ROOT_DIR: "/var/lib/agent-forge/service"
+      AGENT_FORGE_SERVICE_AUTH_ENABLED: "true"
+      AGENT_FORGE_SERVICE_CLIENTS_PATH: "/var/lib/agent-forge/service/clients.toml"
       AGENT_FORGE_QUEUE_BACKEND: "memory"
       GEMINI_API_KEY: "${GEMINI_API_KEY:-}"
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"

--- a/docs/hosted-service.md
+++ b/docs/hosted-service.md
@@ -89,6 +89,8 @@ Relevant settings:
 - `service.clients_path`: TOML registry describing external clients and their policy limits
 - `service.allow_local_path_sources`: global safety switch for colocated `local_path` submissions
 - `service.max_source_size_bytes`: upper bound on accepted source material size
+- Authentication is enforced before request validation and run lookup on `/v1/runs*`
+  so anonymous callers receive `401` instead of schema or existence errors.
 
 ### Client Registry
 
@@ -138,6 +140,16 @@ For local queue-backed development:
 ```bash
 docker compose up -d redis
 ```
+
+The checked-in compose deployment also sets:
+
+```bash
+AGENT_FORGE_SERVICE_AUTH_ENABLED=true
+AGENT_FORGE_SERVICE_CLIENTS_PATH=/var/lib/agent-forge/service/clients.toml
+```
+
+If your deployment does not use `docker compose`, set those environment
+variables explicitly or the service will fall back to repo defaults.
 
 ### 4. Run The Hosted Service
 

--- a/tests/unit/test_service_app.py
+++ b/tests/unit/test_service_app.py
@@ -286,6 +286,62 @@ async def test_service_requires_api_key_when_auth_enabled(
 
 
 @pytest.mark.asyncio
+async def test_service_rejects_unauthenticated_requests_before_body_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clients_path = tmp_path / "clients.toml"
+    _write_clients_file(clients_path, allow_local_path=True)
+    monkeypatch.setenv("POA_SERVICE_API_KEY", "test-service-key")
+
+    app = create_app(
+        config=_service_config(
+            tmp_path,
+            auth_enabled=True,
+            clients_path=clients_path,
+            allow_local_path_sources=True,
+        )
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with (
+        app.router.lifespan_context(app),
+        httpx.AsyncClient(transport=transport, base_url="http://testserver") as client,
+    ):
+        response = await client.post("/v1/runs", json={})
+        assert response.status_code == 401
+        assert response.json()["detail"]["error"]["code"] == "unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_service_rejects_unauthenticated_run_lookup_before_run_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clients_path = tmp_path / "clients.toml"
+    _write_clients_file(clients_path, allow_local_path=True)
+    monkeypatch.setenv("POA_SERVICE_API_KEY", "test-service-key")
+
+    app = create_app(
+        config=_service_config(
+            tmp_path,
+            auth_enabled=True,
+            clients_path=clients_path,
+            allow_local_path_sources=True,
+        )
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with (
+        app.router.lifespan_context(app),
+        httpx.AsyncClient(transport=transport, base_url="http://testserver") as client,
+    ):
+        response = await client.get("/v1/runs/nonexistent")
+        assert response.status_code == 401
+        assert response.json()["detail"]["error"]["code"] == "unauthorized"
+
+
+@pytest.mark.asyncio
 async def test_service_denies_local_paths_by_policy(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- enforce hosted auth on /v1/runs* before request validation or run lookup
- enable hosted auth explicitly in the checked-in compose deployment path
- add regression coverage for unauthenticated submit and run-lookup requests

Closes #107