### PR TITLE
feat: configurable sandbox runtime controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup build-sandbox test test-unit test-integration test-e2e lint format quality run clean update-prices
+.PHONY: setup build-sandbox build-sandbox-node build-sandbox-full test test-unit test-integration test-e2e lint format quality run clean update-prices
 
 update-prices:             ## Refresh vendored model pricing from LiteLLM
 	python scripts/update_prices.py
@@ -8,6 +8,12 @@ setup:                     ## Install dependencies
 
 build-sandbox:             ## Build the sandbox Docker image
 	docker build -t agent-forge-sandbox:latest -f agent_forge/sandbox/Dockerfile .
+
+build-sandbox-node:        ## Build the Node-focused sandbox image
+	docker build -t agent-forge-sandbox:node -f agent_forge/sandbox/Dockerfile.node .
+
+build-sandbox-full:        ## Build the full Python+Node sandbox image
+	docker build -t agent-forge-sandbox:full -f agent_forge/sandbox/Dockerfile.full .
 
 test:                      ## Run all tests (excludes integration + e2e)
 	pytest --cov=agent_forge --cov-report=term-missing -m "not integration and not e2e"

--- a/agent-forge.toml
+++ b/agent-forge.toml
@@ -12,6 +12,7 @@ cpu_limit = 1.0
 memory_limit = "512m"
 timeout_seconds = 300
 network_enabled = false
+writable_cache_mounts = true
 
 [queue]
 backend = "memory"               # "memory" or "redis"

--- a/agent_forge/agent/prompts.py
+++ b/agent_forge/agent/prompts.py
@@ -21,8 +21,13 @@ You can use the following tools to complete the task:
 3. After making changes, verify they work (e.g., run tests or linters).
 4. If you encounter an error, analyze it and try a different approach.
 5. When the task is complete, provide a summary of what you changed and why.
-6. Do NOT attempt to access the internet or external services.
+6. {network_rule}
 7. Stay within the /workspace directory.
+
+## Sandbox
+- Runtime image: {sandbox_image}
+- Network: {network_status}
+- Max shell command timeout: {command_timeout_seconds}s
 
 ## Task
 {task_description}"""
@@ -31,6 +36,10 @@ You can use the following tools to complete the task:
 def build_system_prompt(
     task: str,
     tool_definitions: list[ToolDefinition],
+    *,
+    sandbox_image: str = "agent-forge-sandbox:latest",
+    network_enabled: bool = False,
+    command_timeout_seconds: int = 300,
 ) -> str:
     """Render the system prompt with tool descriptions and task."""
     tool_lines: list[str] = []
@@ -39,7 +48,21 @@ def build_system_prompt(
         params = ", ".join(f"{k}: {v.get('type', 'any')}" for k, v in props.items())
         tool_lines.append(f"- **{td.name}**({params}) — {td.description}")
 
+    if network_enabled:
+        network_rule = (
+            "Network access is enabled in this sandbox. Use it only when required for "
+            "the task, such as installing dependencies or fetching remote resources."
+        )
+        network_status = "enabled"
+    else:
+        network_rule = "Do NOT attempt to access the internet or external services."
+        network_status = "disabled"
+
     return _SYSTEM_PROMPT_TEMPLATE.format(
         tool_descriptions="\n".join(tool_lines),
+        sandbox_image=sandbox_image,
+        network_rule=network_rule,
+        network_status=network_status,
+        command_timeout_seconds=command_timeout_seconds,
         task_description=task,
     )

--- a/agent_forge/cli.py
+++ b/agent_forge/cli.py
@@ -16,6 +16,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from agent_forge.config import USER_CONFIG_DIR, load_config
+from agent_forge.sandbox.base import SandboxConfig
 
 console = Console()
 err_console = Console(stderr=True)
@@ -38,6 +39,18 @@ def main() -> None:
 @click.option("--model", default=None, help="LLM model to use")
 @click.option("--provider", default=None, help="LLM provider (gemini, openai, anthropic)")
 @click.option("--max-iterations", default=None, type=int, help="Max ReAct loop iterations")
+@click.option("--sandbox-image", default=None, help="Sandbox image to run")
+@click.option(
+    "--network/--no-network",
+    default=None,
+    help="Enable or disable network access inside the sandbox",
+)
+@click.option(
+    "--command-timeout",
+    default=None,
+    type=int,
+    help="Per-command sandbox timeout cap in seconds",
+)
 @click.option(
     "--queue",
     "queue_backend",
@@ -74,6 +87,9 @@ def run(
     model: str | None,
     provider: str | None,
     max_iterations: int | None,
+    sandbox_image: str | None,
+    network: bool | None,
+    command_timeout: int | None,
     queue_backend: str | None,
     redis_url: str,
     max_concurrent_runs: int,
@@ -81,24 +97,23 @@ def run(
     report_file: Path | None,
 ) -> None:
     """Run an agent task on a repository."""
-    # Build CLI overrides from provided flags
-    cli_overrides: dict[str, Any] = {}
-    if model is not None:
-        cli_overrides["agent.default_model"] = model
-    if provider is not None:
-        cli_overrides["agent.default_provider"] = provider
-    if max_iterations is not None:
-        cli_overrides["agent.max_iterations"] = max_iterations
-
-    cfg = load_config(cli_overrides=cli_overrides or None)
+    cfg = load_config(
+        cli_overrides=_build_cli_overrides(
+            model=model,
+            provider=provider,
+            max_iterations=max_iterations,
+            sandbox_image=sandbox_image,
+            network=network,
+            command_timeout=command_timeout,
+        )
+    )
 
     # Resolve API key
     provider_name = cfg.agent.default_provider
     provider_cfg = cfg.providers.get(provider_name)
     if provider_cfg is None:
         err_console.print(
-            f"[red]Unknown provider:[/red] '{provider_name}'. "
-            f"Available: {', '.join(cfg.providers)}"
+            f"[red]Unknown provider:[/red] '{provider_name}'. Available: {', '.join(cfg.providers)}"
         )
         sys.exit(1)
 
@@ -118,7 +133,11 @@ def run(
             sys.exit(1)
         asyncio.run(
             _run_agent_queued(
-                task, repo, cfg, provider_name, api_key,
+                task,
+                repo,
+                cfg,
+                provider_name,
+                api_key,
                 queue_backend=queue_backend,
                 redis_url=redis_url,
                 max_concurrent_runs=max_concurrent_runs,
@@ -143,10 +162,12 @@ async def _run_agent(
     """
     from agent_forge.agent.core import react_loop
     from agent_forge.agent.models import AgentConfig, AgentRun
+    from agent_forge.agent.prompts import build_system_prompt
     from agent_forge.orchestration.events import EventBus
     from agent_forge.sandbox.docker import DockerSandbox
     from agent_forge.tools import create_default_registry
 
+    sandbox_config = _build_sandbox_config(cfg)
     agent_config = AgentConfig(
         model=cfg.agent.default_model,
         max_iterations=cfg.agent.max_iterations,
@@ -154,17 +175,28 @@ async def _run_agent(
         temperature=cfg.agent.temperature,
     )
 
-    agent_run = AgentRun(task=task, repo_path=repo, config=agent_config)
     event_bus = EventBus()
     llm = _create_llm(provider_name, api_key)
     tools = create_default_registry()
+    agent_config.system_prompt = build_system_prompt(
+        task,
+        tools.list_definitions(),
+        sandbox_image=sandbox_config.image,
+        network_enabled=sandbox_config.network_enabled,
+        command_timeout_seconds=sandbox_config.timeout_seconds,
+    )
+    agent_run = AgentRun(task=task, repo_path=repo, config=agent_config)
     sandbox = DockerSandbox()
 
     with console.status("[bold green]Agent running...", spinner="dots"):
         try:
-            await sandbox.start(repo_path=repo)
+            await sandbox.start(repo_path=repo, config=sandbox_config)
             result = await react_loop(
-                agent_run, llm, tools, sandbox, event_bus=event_bus,
+                agent_run,
+                llm,
+                tools,
+                sandbox,
+                event_bus=event_bus,
             )
         except Exception as exc:  # noqa: BLE001 — top-level catch-all for CLI
             err_console.print(f"[red]Agent failed:[/red] {exc}")
@@ -264,14 +296,16 @@ def _create_llm(provider_name: str, api_key: str) -> Any:
     if provider_name == "gemini":
         return GeminiProvider(api_key=api_key)
     err_console.print(
-        f"[red]Provider '{provider_name}' not yet implemented.[/red] "
-        "Only 'gemini' is available."
+        f"[red]Provider '{provider_name}' not yet implemented.[/red] Only 'gemini' is available."
     )
     sys.exit(1)
 
 
 def _make_task_runner(
-    _cfg: Any, provider_name: str, api_key: str, event_bus: Any,
+    _cfg: Any,
+    provider_name: str,
+    api_key: str,
+    event_bus: Any,
 ) -> Any:
     """Build an async callable that the Worker invokes for each task.
 
@@ -280,29 +314,81 @@ def _make_task_runner(
     """
     from agent_forge.agent.core import react_loop
     from agent_forge.agent.models import AgentRun
+    from agent_forge.agent.prompts import build_system_prompt
     from agent_forge.sandbox.docker import DockerSandbox
     from agent_forge.tools import create_default_registry
 
+    sandbox_config = _build_sandbox_config(_cfg)
+
     async def _runner(task: Any) -> None:
+        tools = create_default_registry()
+        task.config.system_prompt = build_system_prompt(
+            task.task_description,
+            tools.list_definitions(),
+            sandbox_image=sandbox_config.image,
+            network_enabled=sandbox_config.network_enabled,
+            command_timeout_seconds=sandbox_config.timeout_seconds,
+        )
         agent_run = AgentRun(
             task=task.task_description,
             repo_path=task.repo_path,
             config=task.config,
         )
         llm = _create_llm(provider_name, api_key)
-        tools = create_default_registry()
         sandbox = DockerSandbox()
 
         try:
-            await sandbox.start(repo_path=task.repo_path)
+            await sandbox.start(repo_path=task.repo_path, config=sandbox_config)
             await react_loop(
-                agent_run, llm, tools, sandbox, event_bus=event_bus,
+                agent_run,
+                llm,
+                tools,
+                sandbox,
+                event_bus=event_bus,
             )
         finally:
             await sandbox.stop()
             await llm.close()
 
     return _runner
+
+
+def _build_sandbox_config(cfg: Any) -> SandboxConfig:
+    """Convert resolved app config into a sandbox runtime config."""
+    return SandboxConfig(
+        image=cfg.sandbox.image,
+        cpu_limit=cfg.sandbox.cpu_limit,
+        memory_limit=cfg.sandbox.memory_limit,
+        timeout_seconds=cfg.sandbox.timeout_seconds,
+        network_enabled=cfg.sandbox.network_enabled,
+        writable_cache_mounts=cfg.sandbox.writable_cache_mounts,
+    )
+
+
+def _build_cli_overrides(
+    *,
+    model: str | None,
+    provider: str | None,
+    max_iterations: int | None,
+    sandbox_image: str | None,
+    network: bool | None,
+    command_timeout: int | None,
+) -> dict[str, Any] | None:
+    """Collect non-empty CLI overrides into config dotted keys."""
+    cli_overrides: dict[str, Any] = {}
+    if model is not None:
+        cli_overrides["agent.default_model"] = model
+    if provider is not None:
+        cli_overrides["agent.default_provider"] = provider
+    if max_iterations is not None:
+        cli_overrides["agent.max_iterations"] = max_iterations
+    if sandbox_image is not None:
+        cli_overrides["sandbox.image"] = sandbox_image
+    if network is not None:
+        cli_overrides["sandbox.network_enabled"] = network
+    if command_timeout is not None:
+        cli_overrides["sandbox.timeout_seconds"] = command_timeout
+    return cli_overrides or None
 
 
 def _display_run_summary(run: Any) -> None:

--- a/agent_forge/config.py
+++ b/agent_forge/config.py
@@ -47,6 +47,7 @@ class SandboxSettings(BaseModel):
     memory_limit: str = "512m"
     timeout_seconds: int = 300
     network_enabled: bool = False
+    writable_cache_mounts: bool = True
 
 
 class QueueSettings(BaseModel):

--- a/agent_forge/sandbox/Dockerfile.full
+++ b/agent_forge/sandbox/Dockerfile.full
@@ -1,0 +1,33 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    jq \
+    ripgrep \
+    tree \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g pnpm yarn \
+    && pip install --no-cache-dir \
+        mypy \
+        pytest \
+        ruff
+
+WORKDIR /workspace
+
+RUN useradd -m -s /bin/bash agent && chown agent:agent /workspace
+USER agent

--- a/agent_forge/sandbox/Dockerfile.node
+++ b/agent_forge/sandbox/Dockerfile.node
@@ -1,0 +1,20 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    curl \
+    git \
+    jq \
+    python3 \
+    python3-pip \
+    ripgrep \
+    tree \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g pnpm yarn
+
+WORKDIR /workspace
+
+RUN useradd -m -s /bin/bash agent && chown agent:agent /workspace
+USER agent

--- a/agent_forge/sandbox/base.py
+++ b/agent_forge/sandbox/base.py
@@ -29,6 +29,7 @@ class SandboxConfig:
     memory_limit: str = "512m"
     timeout_seconds: int = 300
     network_enabled: bool = False
+    writable_cache_mounts: bool = False
     env_vars: dict[str, str] = field(default_factory=dict)
 
 

--- a/agent_forge/sandbox/docker.py
+++ b/agent_forge/sandbox/docker.py
@@ -52,6 +52,11 @@ class DockerSandbox(Sandbox):
         """Current lifecycle state."""
         return self._state
 
+    @property
+    def timeout_cap_seconds(self) -> int:
+        """Effective command timeout cap exposed to tools."""
+        return self._config.timeout_seconds
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -70,7 +75,16 @@ class DockerSandbox(Sandbox):
         self._config = cfg
 
         security_opts: list[str] = ["no-new-privileges"]
-        tmpfs: dict[str, str] = {"/tmp": "rw,noexec,nosuid,size=64m"}  # noqa: S108
+        tmpfs = self._build_tmpfs(cfg)
+        environment = dict(cfg.env_vars)
+        if cfg.network_enabled and cfg.writable_cache_mounts:
+            environment.setdefault("HOME", "/cache/home")
+            environment.setdefault("XDG_CACHE_HOME", "/cache/xdg")
+            environment.setdefault("PIP_CACHE_DIR", "/cache/pip")
+            environment.setdefault("NPM_CONFIG_CACHE", "/cache/npm")
+            environment.setdefault("YARN_CACHE_FOLDER", "/cache/yarn")
+            environment.setdefault("PNPM_HOME", "/cache/pnpm-home")
+            environment.setdefault("PNPM_STORE_DIR", "/cache/pnpm-store")
 
         # Parse memory limit to bytes for Docker SDK
         mem_limit = cfg.memory_limit
@@ -86,7 +100,7 @@ class DockerSandbox(Sandbox):
             "tmpfs": tmpfs,
             "nano_cpus": int(cfg.cpu_limit * 1e9),
             "mem_limit": mem_limit,
-            "environment": cfg.env_vars,
+            "environment": environment,
             "volumes": {
                 repo_path: {
                     "bind": cfg.workspace_path,
@@ -132,8 +146,7 @@ class DockerSandbox(Sandbox):
 
         self._state = SandboxState.STOPPED
         msg = (
-            f"Failed to start sandbox container after "
-            f"{_START_MAX_RETRIES + 1} attempts: {last_exc}"
+            f"Failed to start sandbox container after {_START_MAX_RETRIES + 1} attempts: {last_exc}"
         )
         raise SandboxStartupError(msg) from last_exc
 
@@ -249,3 +262,19 @@ class DockerSandbox(Sandbox):
         if self._state != SandboxState.RUNNING or self._container is None:
             msg = "Sandbox is not running. Call start() first."
             raise RuntimeError(msg)
+
+    def _build_tmpfs(self, cfg: SandboxConfig) -> dict[str, str]:
+        """Build tmpfs mounts for scratch space and optional package caches."""
+        tmpfs = {
+            "/tmp": self._tmpfs_options(size="128m", executable=False),  # noqa: S108
+        }
+        if cfg.network_enabled and cfg.writable_cache_mounts:
+            tmpfs["/cache"] = self._tmpfs_options(size="1g", executable=True)
+        return tmpfs
+
+    def _tmpfs_options(self, *, size: str, executable: bool) -> str:
+        exec_flag = "exec" if executable else "noexec"
+        return (
+            f"rw,{exec_flag},nosuid,nodev,size={size},"
+            f"uid={self._host_uid},gid={self._host_gid},mode=1777"
+        )

--- a/agent_forge/tools/run_shell.py
+++ b/agent_forge/tools/run_shell.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from agent_forge.sandbox.base import Sandbox
 
 _MAX_OUTPUT_BYTES = 50 * 1024  # 50 KB
-_MAX_TIMEOUT = 120  # hard cap
+_MAX_TIMEOUT = 600  # hard cap
 
 # Dangerous command patterns
 _BLOCKLIST: list[re.Pattern[str]] = [
@@ -46,7 +46,9 @@ class RunShellTool(Tool):
                 },
                 "timeout_seconds": {
                     "type": "integer",
-                    "description": "Timeout in seconds (default: 30, max: 120)",
+                    "description": (
+                        "Timeout in seconds (default: 30, max: sandbox policy, hard cap: 600)"
+                    ),
                     "default": 30,
                 },
             },
@@ -56,7 +58,10 @@ class RunShellTool(Tool):
     async def execute(self, arguments: dict[str, Any], sandbox: Sandbox) -> ToolResult:
         """Run a shell command with timeout and output truncation."""
         command = arguments.get("command", "")
-        timeout = min(arguments.get("timeout_seconds", 30), _MAX_TIMEOUT)
+        timeout_cap = getattr(sandbox, "timeout_cap_seconds", _MAX_TIMEOUT)
+        if not isinstance(timeout_cap, int) or timeout_cap <= 0:
+            timeout_cap = _MAX_TIMEOUT
+        timeout = min(arguments.get("timeout_seconds", 30), timeout_cap, _MAX_TIMEOUT)
 
         if not command:
             return ToolResult(output="", error="Missing required argument: command", exit_code=1)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ cpu_limit = 1.0
 memory_limit = "512m"
 timeout_seconds = 300
 network_enabled = false
+writable_cache_mounts = true
 
 [queue]
 backend = "memory"              # "memory" or "redis"
@@ -89,6 +90,7 @@ Examples:
 ```bash
 export AGENT_FORGE_AGENT_MAX_ITERATIONS=10
 export AGENT_FORGE_SANDBOX_MEMORY_LIMIT=1g
+export AGENT_FORGE_SANDBOX_IMAGE=agent-forge-sandbox:full
 export AGENT_FORGE_LOGGING_LEVEL=DEBUG
 export AGENT_FORGE_SERVICE_AUTH_ENABLED=true
 export AGENT_FORGE_SERVICE_PORT=8000
@@ -108,6 +110,9 @@ agent-forge run \
   --provider gemini \
   --model gemini-3.1-flash-lite-preview \
   --max-iterations 25 \
+  --sandbox-image agent-forge-sandbox:full \
+  --network \
+  --command-timeout 480 \
   --output-format text \            # or "json" for machine output
   --report-file ./artifacts/run-result.json \  # optional JSON file output
   --queue memory \                  # or "redis" (omit for direct mode)
@@ -149,10 +154,26 @@ agent-forge run --task "Add input validation" --repo ./my-app
 
 ```toml
 [sandbox]
+image = "agent-forge-sandbox:full"
 memory_limit = "1g"
 timeout_seconds = 600
 network_enabled = true   # Allow network access (e.g. pip install)
 cpu_limit = 2.0
+writable_cache_mounts = true  # Mount /cache for npm/pip/pnpm/yarn caches
+
+### Sandbox Images
+
+- `agent-forge-sandbox:latest`: Python-focused base image
+- `agent-forge-sandbox:node`: Node-focused image with `node`, `npm`, `pnpm`, and `yarn`
+- `agent-forge-sandbox:full`: Python + Node image for mixed-language repos
+
+Build them with:
+
+```bash
+./scripts/build-sandbox.sh python
+./scripts/build-sandbox.sh node
+./scripts/build-sandbox.sh full
+```
 ```
 
 ## Inspecting Config

--- a/scripts/build-sandbox.sh
+++ b/scripts/build-sandbox.sh
@@ -5,10 +5,32 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
-echo "Building sandbox image..."
+variant="${1:-python}"
+
+case "$variant" in
+  python)
+    dockerfile="$PROJECT_ROOT/agent_forge/sandbox/Dockerfile"
+    image_tag="agent-forge-sandbox:latest"
+    ;;
+  node)
+    dockerfile="$PROJECT_ROOT/agent_forge/sandbox/Dockerfile.node"
+    image_tag="agent-forge-sandbox:node"
+    ;;
+  full)
+    dockerfile="$PROJECT_ROOT/agent_forge/sandbox/Dockerfile.full"
+    image_tag="agent-forge-sandbox:full"
+    ;;
+  *)
+    echo "Unknown sandbox variant: $variant" >&2
+    echo "Usage: $0 [python|node|full]" >&2
+    exit 1
+    ;;
+esac
+
+echo "Building sandbox image $image_tag..."
 docker build \
-    -t agent-forge-sandbox:latest \
-    -f "$PROJECT_ROOT/agent_forge/sandbox/Dockerfile" \
+    -t "$image_tag" \
+    -f "$dockerfile" \
     "$PROJECT_ROOT"
 
-echo "✅ Sandbox image built: agent-forge-sandbox:latest"
+echo "✅ Sandbox image built: $image_tag"

--- a/tests/unit/test_agent_core.py
+++ b/tests/unit/test_agent_core.py
@@ -330,11 +330,26 @@ class TestBuildSystemPrompt:
         assert "read_file" in prompt
         assert "Fix the bug" in prompt
         assert "/workspace" in prompt
+        assert "Runtime image: agent-forge-sandbox:latest" in prompt
+        assert "Network: disabled" in prompt
 
     def test_empty_tools(self) -> None:
         prompt = build_system_prompt(task="Do something", tool_definitions=[])
         assert "Agent Forge" in prompt
         assert "Do something" in prompt
+
+    def test_network_enabled_prompt(self) -> None:
+        prompt = build_system_prompt(
+            task="Install dependencies",
+            tool_definitions=[],
+            sandbox_image="agent-forge-sandbox:node",
+            network_enabled=True,
+            command_timeout_seconds=480,
+        )
+        assert "Network: enabled" in prompt
+        assert "installing dependencies" in prompt
+        assert "agent-forge-sandbox:node" in prompt
+        assert "480s" in prompt
 
 
 class TestTokenUsageAdd:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -41,9 +41,12 @@ class TestRunCommand:
             main,
             [
                 "run",
-                "--task", "Fix a bug",
-                "--repo", "/tmp/fake-repo",
-                "--provider", "nonexistent",
+                "--task",
+                "Fix a bug",
+                "--repo",
+                "/tmp/fake-repo",
+                "--provider",
+                "nonexistent",
             ],
         )
         assert result.exit_code != 0
@@ -72,17 +75,22 @@ class TestRunCommand:
         env = dict(os.environ)
         env["GEMINI_API_KEY"] = "test-key"
         report_file = tmp_path / "report.json"
-        with patch("agent_forge.cli._run_agent", side_effect=fake_run), patch(
-            "agent_forge.cli.USER_CONFIG_DIR", tmp_path
+        with (
+            patch("agent_forge.cli._run_agent", side_effect=fake_run),
+            patch("agent_forge.cli.USER_CONFIG_DIR", tmp_path),
         ):
             result = runner.invoke(
                 main,
                 [
                     "run",
-                    "--task", "Fix a bug",
-                    "--repo", "/tmp/fake-repo",
-                    "--output-format", "json",
-                    "--report-file", str(report_file),
+                    "--task",
+                    "Fix a bug",
+                    "--repo",
+                    "/tmp/fake-repo",
+                    "--output-format",
+                    "json",
+                    "--report-file",
+                    str(report_file),
                 ],
                 env=env,
             )
@@ -106,15 +114,61 @@ class TestRunCommand:
             main,
             [
                 "run",
-                "--task", "Fix a bug",
-                "--repo", "/tmp/fake-repo",
-                "--queue", "memory",
-                "--output-format", "json",
+                "--task",
+                "Fix a bug",
+                "--repo",
+                "/tmp/fake-repo",
+                "--queue",
+                "memory",
+                "--output-format",
+                "json",
             ],
             env=env,
         )
         assert result.exit_code != 0
         assert "not supported in queue mode yet" in result.output
+
+    def test_run_sandbox_flags_override_config(self) -> None:
+        """CLI sandbox flags should reach load_config as sandbox overrides."""
+        runner = _runner()
+        env = dict(os.environ)
+        env["GEMINI_API_KEY"] = "test-key"
+        fake_cfg = MagicMock()
+        fake_cfg.agent.default_provider = "gemini"
+        fake_cfg.providers = {"gemini": MagicMock(api_key_env="GEMINI_API_KEY")}
+
+        with (
+            patch("agent_forge.cli.load_config", return_value=fake_cfg) as mock_load_config,
+            patch("agent_forge.cli._run_agent") as mock_run_agent,
+            patch("agent_forge.cli._emit_run_output") as mock_emit,
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "run",
+                    "--task",
+                    "Fix a bug",
+                    "--repo",
+                    "/tmp/fake-repo",
+                    "--sandbox-image",
+                    "agent-forge-sandbox:node",
+                    "--network",
+                    "--command-timeout",
+                    "480",
+                ],
+                env=env,
+            )
+
+        assert result.exit_code == 0
+        mock_load_config.assert_called_once_with(
+            cli_overrides={
+                "sandbox.image": "agent-forge-sandbox:node",
+                "sandbox.network_enabled": True,
+                "sandbox.timeout_seconds": 480,
+            }
+        )
+        mock_run_agent.assert_called_once()
+        mock_emit.assert_called_once()
 
 
 class TestStatusCommand:
@@ -160,8 +214,9 @@ class TestStatusCommand:
         save_run(run, base_dir=tmp_path)
 
         runner = _runner()
-        with patch("agent_forge.agent.persistence._default_runs_dir", return_value=tmp_path), patch(
-            "agent_forge.cli.USER_CONFIG_DIR", tmp_path.parent
+        with (
+            patch("agent_forge.agent.persistence._default_runs_dir", return_value=tmp_path),
+            patch("agent_forge.cli.USER_CONFIG_DIR", tmp_path.parent),
         ):
             result = runner.invoke(main, ["status", run.id, "--output-format", "json"])
 

--- a/tests/unit/test_cli_orchestration.py
+++ b/tests/unit/test_cli_orchestration.py
@@ -16,6 +16,7 @@ import pytest
 
 from agent_forge.orchestration.events import EventBus
 from agent_forge.orchestration.queue import Task, TaskStatus
+from agent_forge.sandbox.base import SandboxConfig
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -29,6 +30,12 @@ def _fake_config() -> MagicMock:
     cfg.agent.max_iterations = 10
     cfg.agent.max_tokens_per_run = 100_000
     cfg.agent.temperature = 0.0
+    cfg.sandbox.image = "agent-forge-sandbox:latest"
+    cfg.sandbox.cpu_limit = 1.0
+    cfg.sandbox.memory_limit = "512m"
+    cfg.sandbox.timeout_seconds = 300
+    cfg.sandbox.network_enabled = False
+    cfg.sandbox.writable_cache_mounts = True
     return cfg
 
 
@@ -129,13 +136,18 @@ class TestMemoryQueueMode:
                 return_value="task-abc",
             ),
         ):
+
             async def fake_runner(task: Task) -> None:
                 pass
 
             mock_make_runner.return_value = fake_runner
 
             await _run_agent_queued(
-                "fix bug", "/tmp/repo", _fake_config(), "gemini", "key",
+                "fix bug",
+                "/tmp/repo",
+                _fake_config(),
+                "gemini",
+                "key",
                 queue_backend="memory",
                 redis_url="redis://localhost",
                 max_concurrent_runs=0,
@@ -168,6 +180,7 @@ class TestMemoryQueueMode:
                 side_effect=lambda _t: f"task-{len(enqueue_calls)}",
             ),
         ):
+
             async def fake_runner(task: Task) -> None:
                 pass
 
@@ -176,7 +189,11 @@ class TestMemoryQueueMode:
             # Run 3 tasks sequentially (each call to _run_agent_queued is one task)
             for i in range(3):
                 await _run_agent_queued(
-                    f"task {i}", "/tmp/repo", _fake_config(), "gemini", "key",
+                    f"task {i}",
+                    "/tmp/repo",
+                    _fake_config(),
+                    "gemini",
+                    "key",
                     queue_backend="memory",
                     redis_url="redis://localhost",
                     max_concurrent_runs=0,
@@ -205,6 +222,7 @@ class TestMemoryQueueMode:
                 return_value="task-1",
             ),
         ):
+
             async def fake_runner(task: Task) -> None:
                 pass
 
@@ -212,11 +230,39 @@ class TestMemoryQueueMode:
 
             # Should not crash with non-zero concurrency
             await _run_agent_queued(
-                "task", "/tmp/repo", _fake_config(), "gemini", "key",
+                "task",
+                "/tmp/repo",
+                _fake_config(),
+                "gemini",
+                "key",
                 queue_backend="memory",
                 redis_url="redis://localhost",
                 max_concurrent_runs=8,
             )
+
+
+class TestSandboxConfigWiring:
+    def test_build_sandbox_config(self) -> None:
+        from agent_forge.cli import _build_sandbox_config
+
+        cfg = _fake_config()
+        cfg.sandbox.image = "agent-forge-sandbox:full"
+        cfg.sandbox.cpu_limit = 2.0
+        cfg.sandbox.memory_limit = "2g"
+        cfg.sandbox.timeout_seconds = 480
+        cfg.sandbox.network_enabled = True
+        cfg.sandbox.writable_cache_mounts = True
+
+        sandbox_config = _build_sandbox_config(cfg)
+
+        assert sandbox_config == SandboxConfig(
+            image="agent-forge-sandbox:full",
+            cpu_limit=2.0,
+            memory_limit="2g",
+            timeout_seconds=480,
+            network_enabled=True,
+            writable_cache_mounts=True,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -250,7 +296,11 @@ class TestRedisQueueMode:
             mock_make_runner.return_value = fake_runner
 
             await _run_agent_queued(
-                "fix bug", "/tmp/repo", _fake_config(), "gemini", "key",
+                "fix bug",
+                "/tmp/repo",
+                _fake_config(),
+                "gemini",
+                "key",
                 queue_backend="redis",
                 redis_url="redis://custom:6380/1",
                 max_concurrent_runs=5,
@@ -286,7 +336,11 @@ class TestRedisQueueMode:
 
             for i in range(3):
                 await _run_agent_queued(
-                    f"task {i}", "/tmp/repo", _fake_config(), "gemini", "key",
+                    f"task {i}",
+                    "/tmp/repo",
+                    _fake_config(),
+                    "gemini",
+                    "key",
                     queue_backend="redis",
                     redis_url="redis://localhost:6379/0",
                     max_concurrent_runs=2,
@@ -327,6 +381,7 @@ class TestQueueModeCleanup:
                 return_value="task-fail",
             ),
         ):
+
             async def fake_runner(task: Task) -> None:
                 pass
 
@@ -334,7 +389,11 @@ class TestQueueModeCleanup:
 
             with pytest.raises(SystemExit):
                 await _run_agent_queued(
-                    "broken task", "/tmp/repo", _fake_config(), "gemini", "key",
+                    "broken task",
+                    "/tmp/repo",
+                    _fake_config(),
+                    "gemini",
+                    "key",
                     queue_backend="memory",
                     redis_url="redis://localhost",
                     max_concurrent_runs=0,
@@ -373,7 +432,11 @@ class TestQueueModeCleanup:
 
             with pytest.raises(SystemExit):
                 await _run_agent_queued(
-                    "task", "/tmp/repo", _fake_config(), "gemini", "key",
+                    "task",
+                    "/tmp/repo",
+                    _fake_config(),
+                    "gemini",
+                    "key",
                     queue_backend="redis",
                     redis_url="redis://localhost",
                     max_concurrent_runs=0,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -127,6 +127,11 @@ class TestEnvOverrides:
         result = _collect_env_overrides()
         assert result == {"service": {"auth_enabled": True}}
 
+    def test_sandbox_cache_mounts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGENT_FORGE_SANDBOX_WRITABLE_CACHE_MOUNTS", "false")
+        result = _collect_env_overrides()
+        assert result == {"sandbox": {"writable_cache_mounts": False}}
+
 
 # ---------------------------------------------------------------------------
 # CLI Override Mapping
@@ -179,6 +184,7 @@ class TestDefaults:
         assert cfg.sandbox.memory_limit == "512m"
         assert cfg.sandbox.timeout_seconds == 300
         assert cfg.sandbox.network_enabled is False
+        assert cfg.sandbox.writable_cache_mounts is True
         assert cfg.queue.backend == "memory"
         assert cfg.queue.max_concurrent_runs == 4
         assert cfg.logging.level == "INFO"

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -63,6 +63,7 @@ class TestSandboxLifecycle:
             assert call_kwargs["read_only"] is True
             assert call_kwargs["pids_limit"] == 256
             assert "/tmp" in call_kwargs["tmpfs"]
+            assert "noexec" in call_kwargs["tmpfs"]["/tmp"]
             assert call_kwargs["network_mode"] == "none"
             assert call_kwargs["user"] == f"{os.getuid()}:{os.getgid()}"
 
@@ -82,6 +83,29 @@ class TestSandboxLifecycle:
             assert call_kwargs["nano_cpus"] == 2_000_000_000
             assert call_kwargs["mem_limit"] == "1g"
             assert "network_mode" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_start_network_cache_mounts(self, mock_docker_client: MagicMock) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            config = SandboxConfig(network_enabled=True, writable_cache_mounts=True)
+            await sandbox.start("/tmp/repo", config=config)
+
+            call_kwargs = mock_docker_client.containers.run.call_args[1]
+            assert "/cache" in call_kwargs["tmpfs"]
+            assert "exec" in call_kwargs["tmpfs"]["/cache"]
+            assert call_kwargs["environment"]["HOME"] == "/cache/home"
+            assert call_kwargs["environment"]["NPM_CONFIG_CACHE"] == "/cache/npm"
+
+    @pytest.mark.asyncio
+    async def test_timeout_cap_exposed(self, mock_docker_client: MagicMock) -> None:
+        with patch("agent_forge.sandbox.docker.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_docker_client
+            sandbox = DockerSandbox()
+            await sandbox.start("/tmp/repo", config=SandboxConfig(timeout_seconds=420))
+
+            assert sandbox.timeout_cap_seconds == 420
 
     @pytest.mark.asyncio
     async def test_start_already_running(self, mock_docker_client: MagicMock) -> None:
@@ -150,7 +174,9 @@ class TestSandboxExec:
             # No chown during start anymore; just our command
             assert container.exec_run.call_count == 1
             container.exec_run.assert_called_with(
-                ["bash", "-c", "echo hello"], demux=True, user=f"{os.getuid()}:{os.getgid()}",
+                ["bash", "-c", "echo hello"],
+                demux=True,
+                user=f"{os.getuid()}:{os.getgid()}",
             )
 
     @pytest.mark.asyncio

--- a/tests/unit/test_tools_extra.py
+++ b/tests/unit/test_tools_extra.py
@@ -86,8 +86,19 @@ class TestRunShell:
         tool = RunShellTool()
         await tool.execute({"command": "sleep 1", "timeout_seconds": 999}, sandbox)
 
-        # Timeout should be capped at 120
-        sandbox.exec.assert_called_once_with("sleep 1", timeout_seconds=120)
+        # Timeout should be capped at the tool hard ceiling.
+        sandbox.exec.assert_called_once_with("sleep 1", timeout_seconds=600)
+
+    @pytest.mark.asyncio
+    async def test_timeout_capped_by_sandbox_policy(self) -> None:
+        sandbox = AsyncMock()
+        sandbox.timeout_cap_seconds = 45
+        sandbox.exec.return_value = ExecResult(exit_code=0, stdout="ok", stderr="")
+
+        tool = RunShellTool()
+        await tool.execute({"command": "sleep 1", "timeout_seconds": 120}, sandbox)
+
+        sandbox.exec.assert_called_once_with("sleep 1", timeout_seconds=45)
 
     @pytest.mark.asyncio
     async def test_output_truncation(self) -> None:


### PR DESCRIPTION
## Summary
- add configurable sandbox CLI and config wiring for image, network access, and command timeout
- add writable cache tmpfs mounts and sandbox-aware prompt/timeout behavior
- add Node and full runtime sandbox Dockerfiles plus docs and tests

Fixes #86

## Testing
- `ruff check agent_forge tests`
- `python -m pytest tests/unit/test_config.py tests/unit/test_sandbox.py tests/unit/test_tools_extra.py tests/unit/test_cli.py -k 'not serve_invokes_uvicorn' tests/unit/test_cli_orchestration.py tests/unit/test_agent_core.py`

## Notes
- `tests/unit/test_cli.py::TestServeCommand::test_serve_invokes_uvicorn` is unchanged and still depends on `uvicorn` being installed in the local environment.