### PR TITLE
feat: add bubblewrap sandbox backend

### DIFF
--- a/agent-forge.toml
+++ b/agent-forge.toml
@@ -7,6 +7,7 @@ temperature = 0.0
 system_prompt_path = ""          # Optional custom system prompt file
 
 [sandbox]
+backend = "docker"
 image = "agent-forge-sandbox:latest"
 cpu_limit = 1.0
 memory_limit = "512m"

--- a/agent_forge/agent/prompts.py
+++ b/agent_forge/agent/prompts.py
@@ -25,6 +25,7 @@ You can use the following tools to complete the task:
 7. Stay within the /workspace directory.
 
 ## Sandbox
+- Backend: {sandbox_backend}
 - Runtime image: {sandbox_image}
 - Network: {network_status}
 - Max shell command timeout: {command_timeout_seconds}s
@@ -37,6 +38,7 @@ def build_system_prompt(
     task: str,
     tool_definitions: list[ToolDefinition],
     *,
+    sandbox_backend: str = "docker",
     sandbox_image: str = "agent-forge-sandbox:latest",
     network_enabled: bool = False,
     command_timeout_seconds: int = 300,
@@ -60,6 +62,7 @@ def build_system_prompt(
 
     return _SYSTEM_PROMPT_TEMPLATE.format(
         tool_descriptions="\n".join(tool_lines),
+        sandbox_backend=sandbox_backend,
         sandbox_image=sandbox_image,
         network_rule=network_rule,
         network_status=network_status,

--- a/agent_forge/cli.py
+++ b/agent_forge/cli.py
@@ -41,6 +41,12 @@ def main() -> None:
 @click.option("--max-iterations", default=None, type=int, help="Max ReAct loop iterations")
 @click.option("--sandbox-image", default=None, help="Sandbox image to run")
 @click.option(
+    "--sandbox-backend",
+    default=None,
+    type=click.Choice(["docker", "bwrap", "auto"], case_sensitive=False),
+    help="Sandbox backend to use",
+)
+@click.option(
     "--network/--no-network",
     default=None,
     help="Enable or disable network access inside the sandbox",
@@ -88,6 +94,7 @@ def run(
     provider: str | None,
     max_iterations: int | None,
     sandbox_image: str | None,
+    sandbox_backend: str | None,
     network: bool | None,
     command_timeout: int | None,
     queue_backend: str | None,
@@ -103,6 +110,7 @@ def run(
             provider=provider,
             max_iterations=max_iterations,
             sandbox_image=sandbox_image,
+            sandbox_backend=sandbox_backend,
             network=network,
             command_timeout=command_timeout,
         )
@@ -164,7 +172,7 @@ async def _run_agent(
     from agent_forge.agent.models import AgentConfig, AgentRun
     from agent_forge.agent.prompts import build_system_prompt
     from agent_forge.orchestration.events import EventBus
-    from agent_forge.sandbox.docker import DockerSandbox
+    from agent_forge.sandbox.factory import create_sandbox
     from agent_forge.tools import create_default_registry
 
     sandbox_config = _build_sandbox_config(cfg)
@@ -181,12 +189,13 @@ async def _run_agent(
     agent_config.system_prompt = build_system_prompt(
         task,
         tools.list_definitions(),
+        sandbox_backend=sandbox_config.backend,
         sandbox_image=sandbox_config.image,
         network_enabled=sandbox_config.network_enabled,
         command_timeout_seconds=sandbox_config.timeout_seconds,
     )
     agent_run = AgentRun(task=task, repo_path=repo, config=agent_config)
-    sandbox = DockerSandbox()
+    sandbox = create_sandbox(sandbox_config)
 
     with console.status("[bold green]Agent running...", spinner="dots"):
         try:
@@ -315,7 +324,7 @@ def _make_task_runner(
     from agent_forge.agent.core import react_loop
     from agent_forge.agent.models import AgentRun
     from agent_forge.agent.prompts import build_system_prompt
-    from agent_forge.sandbox.docker import DockerSandbox
+    from agent_forge.sandbox.factory import create_sandbox
     from agent_forge.tools import create_default_registry
 
     sandbox_config = _build_sandbox_config(_cfg)
@@ -325,6 +334,7 @@ def _make_task_runner(
         task.config.system_prompt = build_system_prompt(
             task.task_description,
             tools.list_definitions(),
+            sandbox_backend=sandbox_config.backend,
             sandbox_image=sandbox_config.image,
             network_enabled=sandbox_config.network_enabled,
             command_timeout_seconds=sandbox_config.timeout_seconds,
@@ -335,7 +345,7 @@ def _make_task_runner(
             config=task.config,
         )
         llm = _create_llm(provider_name, api_key)
-        sandbox = DockerSandbox()
+        sandbox = create_sandbox(sandbox_config)
 
         try:
             await sandbox.start(repo_path=task.repo_path, config=sandbox_config)
@@ -356,6 +366,7 @@ def _make_task_runner(
 def _build_sandbox_config(cfg: Any) -> SandboxConfig:
     """Convert resolved app config into a sandbox runtime config."""
     return SandboxConfig(
+        backend=cfg.sandbox.backend,
         image=cfg.sandbox.image,
         cpu_limit=cfg.sandbox.cpu_limit,
         memory_limit=cfg.sandbox.memory_limit,
@@ -371,6 +382,7 @@ def _build_cli_overrides(
     provider: str | None,
     max_iterations: int | None,
     sandbox_image: str | None,
+    sandbox_backend: str | None,
     network: bool | None,
     command_timeout: int | None,
 ) -> dict[str, Any] | None:
@@ -384,6 +396,8 @@ def _build_cli_overrides(
         cli_overrides["agent.max_iterations"] = max_iterations
     if sandbox_image is not None:
         cli_overrides["sandbox.image"] = sandbox_image
+    if sandbox_backend is not None:
+        cli_overrides["sandbox.backend"] = sandbox_backend
     if network is not None:
         cli_overrides["sandbox.network_enabled"] = network
     if command_timeout is not None:

--- a/agent_forge/config.py
+++ b/agent_forge/config.py
@@ -40,8 +40,9 @@ class AgentSettings(BaseModel):
 
 
 class SandboxSettings(BaseModel):
-    """Settings for the Docker sandbox runtime."""
+    """Settings for the sandbox runtime."""
 
+    backend: str = "docker"
     image: str = DEFAULT_SANDBOX_IMAGE
     cpu_limit: float = 1.0
     memory_limit: str = "512m"

--- a/agent_forge/sandbox/__init__.py
+++ b/agent_forge/sandbox/__init__.py
@@ -1,12 +1,16 @@
 """Sandbox runtime for isolated tool execution."""
 
 from agent_forge.sandbox.base import ExecResult, Sandbox, SandboxConfig, SandboxState
+from agent_forge.sandbox.bwrap import BwrapSandbox
 from agent_forge.sandbox.docker import DockerSandbox
+from agent_forge.sandbox.factory import create_sandbox
 
 __all__ = [
+    "BwrapSandbox",
     "DockerSandbox",
     "ExecResult",
     "Sandbox",
     "SandboxConfig",
     "SandboxState",
+    "create_sandbox",
 ]

--- a/agent_forge/sandbox/base.py
+++ b/agent_forge/sandbox/base.py
@@ -23,6 +23,7 @@ class SandboxState(Enum):
 class SandboxConfig:
     """Configuration for a sandbox container."""
 
+    backend: str = "docker"
     image: str = "agent-forge-sandbox:latest"
     workspace_path: str = "/workspace"
     cpu_limit: float = 1.0

--- a/agent_forge/sandbox/bwrap.py
+++ b/agent_forge/sandbox/bwrap.py
@@ -1,0 +1,199 @@
+"""Bubblewrap-based sandbox implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import platform
+import shlex
+import shutil
+from pathlib import Path
+from typing import Final
+
+from agent_forge.llm.errors import SandboxStartupError
+from agent_forge.observability import get_logger
+from agent_forge.sandbox.base import ExecResult, Sandbox, SandboxConfig, SandboxState
+
+logger = get_logger("sandbox")
+
+_READ_ONLY_DIRS: Final[tuple[str, ...]] = (
+    "/bin",
+    "/etc",
+    "/lib",
+    "/lib64",
+    "/opt",
+    "/sbin",
+    "/usr",
+)
+
+
+class BwrapSandbox(Sandbox):
+    """Bubblewrap-backed sandbox for fast, daemonless isolation on Linux.
+
+    The sandbox keeps only configuration state between calls. Each ``exec``
+    launches a fresh ``bwrap`` process over the same workspace mount.
+    """
+
+    def __init__(self) -> None:
+        self._config = SandboxConfig(backend="bwrap")
+        self._state = SandboxState.IDLE
+        self._repo_path: str | None = None
+        self._bwrap_path = shutil.which("bwrap")
+
+    @property
+    def state(self) -> SandboxState:
+        """Current lifecycle state."""
+        return self._state
+
+    @property
+    def timeout_cap_seconds(self) -> int:
+        """Effective command timeout cap exposed to tools."""
+        return self._config.timeout_seconds
+
+    async def start(self, repo_path: str, config: SandboxConfig | None = None) -> None:
+        """Validate availability and cache the sandbox configuration."""
+        if self._state == SandboxState.RUNNING:
+            msg = "Sandbox is already running"
+            raise RuntimeError(msg)
+
+        if platform.system() != "Linux":
+            msg = "bubblewrap sandbox is only available on Linux"
+            raise SandboxStartupError(msg)
+        if self._bwrap_path is None:
+            msg = "bubblewrap sandbox requires the 'bwrap' executable"
+            raise SandboxStartupError(msg)
+
+        cfg = config or SandboxConfig(backend="bwrap")
+        self._config = cfg
+        self._repo_path = str(Path(repo_path).resolve())
+        self._state = SandboxState.RUNNING
+        logger.info("sandbox_started", backend="bwrap", repo_path=self._repo_path)
+
+    async def exec(
+        self,
+        command: str,
+        *,
+        timeout_seconds: int = 30,
+    ) -> ExecResult:
+        """Execute a command inside a fresh bubblewrap process."""
+        self._ensure_running()
+        argv = self._build_bwrap_argv(command)
+        process = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        try:
+            stdout_raw, stderr_raw = await asyncio.wait_for(
+                process.communicate(),
+                timeout=timeout_seconds,
+            )
+        except TimeoutError:
+            process.kill()
+            await process.communicate()
+            return ExecResult(
+                exit_code=124,
+                stdout="",
+                stderr=f"Command timed out after {timeout_seconds}s",
+            )
+
+        return ExecResult(
+            exit_code=process.returncode or 0,
+            stdout=(stdout_raw or b"").decode("utf-8", errors="replace"),
+            stderr=(stderr_raw or b"").decode("utf-8", errors="replace"),
+        )
+
+    async def read_file(self, path: str) -> str:
+        """Read a file from the sandbox filesystem."""
+        result = await self.exec(f"cat {shlex.quote(path)}")
+        if result.exit_code != 0:
+            msg = f"File not found in sandbox: {path}"
+            raise FileNotFoundError(msg)
+        return result.stdout
+
+    async def write_file(self, path: str, content: str) -> None:
+        """Write content to a file inside the sandbox."""
+        quoted_path = shlex.quote(path)
+        parent = os.path.dirname(path)
+        if parent:
+            mkdir_result = await self.exec(f"mkdir -p {shlex.quote(parent)}")
+            if mkdir_result.exit_code != 0:
+                msg = f"Failed to create parent directory: {parent} — {mkdir_result.stderr}"
+                raise OSError(msg)
+
+        escaped = shlex.quote(content)
+        result = await self.exec(f"printf %s {escaped} > {quoted_path}")
+        if result.exit_code != 0:
+            msg = f"Failed to write file: {path} — {result.stderr}"
+            raise OSError(msg)
+
+    async def stop(self) -> None:
+        """Reset the logical sandbox state."""
+        self._repo_path = None
+        self._state = SandboxState.STOPPED
+        logger.info("sandbox_stopped", backend="bwrap")
+
+    async def is_alive(self) -> bool:
+        """Check if the sandbox has been started and not yet stopped."""
+        return self._state == SandboxState.RUNNING and self._repo_path is not None
+
+    def _build_bwrap_argv(self, command: str) -> list[str]:
+        assert self._repo_path is not None  # noqa: S101
+        assert self._bwrap_path is not None  # noqa: S101
+
+        argv = [
+            self._bwrap_path,
+            "--die-with-parent",
+            "--new-session",
+            "--unshare-pid",
+            "--proc",
+            "/proc",
+            "--dev",
+            "/dev",
+            "--tmpfs",
+            "/tmp",  # noqa: S108
+        ]
+        if not self._config.network_enabled:
+            argv.append("--unshare-net")
+        if self._config.network_enabled and self._config.writable_cache_mounts:
+            argv.extend(["--tmpfs", "/cache"])
+
+        for host_path in _READ_ONLY_DIRS:
+            if Path(host_path).exists():
+                argv.extend(["--ro-bind", host_path, host_path])
+
+        argv.extend(
+            [
+                "--bind",
+                self._repo_path,
+                self._config.workspace_path,
+                "--chdir",
+                self._config.workspace_path,
+            ]
+        )
+
+        for key, value in self._build_env_vars().items():
+            argv.extend(["--setenv", key, value])
+
+        shell_path = "/bin/bash" if Path("/bin/bash").exists() else "/bin/sh"
+        argv.extend([shell_path, "-lc", command])
+        return argv
+
+    def _build_env_vars(self) -> dict[str, str]:
+        env_vars = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+        env_vars.update(self._config.env_vars)
+        if self._config.network_enabled and self._config.writable_cache_mounts:
+            env_vars.setdefault("HOME", "/cache/home")
+            env_vars.setdefault("XDG_CACHE_HOME", "/cache/xdg")
+            env_vars.setdefault("PIP_CACHE_DIR", "/cache/pip")
+            env_vars.setdefault("NPM_CONFIG_CACHE", "/cache/npm")
+            env_vars.setdefault("YARN_CACHE_FOLDER", "/cache/yarn")
+            env_vars.setdefault("PNPM_HOME", "/cache/pnpm-home")
+            env_vars.setdefault("PNPM_STORE_DIR", "/cache/pnpm-store")
+        return env_vars
+
+    def _ensure_running(self) -> None:
+        if self._state != SandboxState.RUNNING or self._repo_path is None:
+            msg = "Sandbox is not running. Call start() first."
+            raise RuntimeError(msg)

--- a/agent_forge/sandbox/factory.py
+++ b/agent_forge/sandbox/factory.py
@@ -1,0 +1,61 @@
+"""Sandbox backend selection helpers."""
+
+from __future__ import annotations
+
+import platform
+import shutil
+from typing import Final
+
+import docker
+
+from agent_forge.llm.errors import SandboxStartupError
+from agent_forge.sandbox.base import Sandbox, SandboxConfig
+from agent_forge.sandbox.bwrap import BwrapSandbox
+from agent_forge.sandbox.docker import DockerSandbox
+
+_VALID_BACKENDS: Final[set[str]] = {"auto", "bwrap", "docker"}
+
+
+def create_sandbox(config: SandboxConfig | None = None) -> Sandbox:
+    """Create the configured sandbox backend.
+
+    ``auto`` prefers Docker when the daemon is reachable and otherwise falls
+    back to bubblewrap on Linux.
+    """
+
+    cfg = config or SandboxConfig()
+    backend = cfg.backend
+    if backend not in _VALID_BACKENDS:
+        msg = f"Unknown sandbox backend: {backend}"
+        raise SandboxStartupError(msg)
+
+    if backend == "docker":
+        return DockerSandbox()
+    if backend == "bwrap":
+        return BwrapSandbox()
+    if _docker_available():
+        return DockerSandbox()
+    if _bwrap_available():
+        return BwrapSandbox()
+    msg = "No supported sandbox backend is available (tried Docker, then bubblewrap)"
+    raise SandboxStartupError(msg)
+
+
+def _docker_available() -> bool:
+    """Return True when the Docker daemon is reachable."""
+    try:
+        client = docker.from_env()
+        try:
+            client.ping()
+        finally:
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+def _bwrap_available() -> bool:
+    """Return True when bubblewrap is installed on Linux."""
+    return platform.system() == "Linux" and shutil.which("bwrap") is not None

--- a/agent_forge/service/app.py
+++ b/agent_forge/service/app.py
@@ -26,7 +26,8 @@ from agent_forge.config import USER_CONFIG_DIR, ForgeConfig, load_config
 from agent_forge.orchestration.events import EventBus
 from agent_forge.orchestration.queue import InMemoryQueue, Task, TaskStatus
 from agent_forge.orchestration.worker import Worker
-from agent_forge.sandbox.docker import DockerSandbox
+from agent_forge.sandbox.base import SandboxConfig
+from agent_forge.sandbox.factory import create_sandbox
 from agent_forge.service.models import (
     ErrorResponse,
     HealthResponse,
@@ -376,10 +377,7 @@ class HostedRunService:
             self._deny(
                 status_code=403,
                 code="policy_denied",
-                message=(
-                    "report schema not allowed for client: "
-                    f"{request.profile.report_schema}"
-                ),
+                message=(f"report schema not allowed for client: {request.profile.report_schema}"),
                 request_origin=request_origin,
                 user_agent=user_agent,
             )
@@ -554,11 +552,7 @@ class HostedRunService:
     def _source_size_bytes(self, source_uri: str) -> int:
         path = self._local_path_from_uri(source_uri)
         if path.is_dir():
-            return sum(
-                child.stat().st_size
-                for child in path.rglob("*")
-                if child.is_file()
-            )
+            return sum(child.stat().st_size for child in path.rglob("*") if child.is_file())
         return path.stat().st_size
 
     def _append_audit_event(
@@ -698,8 +692,7 @@ class HostedRunService:
                 error=RunError(
                     code="source_fetch_failed",
                     message=(
-                        "only local and file:// URIs are supported in this service "
-                        f"build: {uri}"
+                        f"only local and file:// URIs are supported in this service build: {uri}"
                     ),
                     retryable=False,
                 )
@@ -756,7 +749,7 @@ class HostedRunService:
             f"Focus first on the contract named {entry_contract}{target_context}. "
             "Do not modify the source code except for writing a valid JSON report to "
             ".agent-forge/report.json. The report must use schema_version "
-            "\"proof-of-audit-report-v1\" and include the fields run_id, summary, "
+            '"proof-of-audit-report-v1" and include the fields run_id, summary, '
             "confidence, findings, stats, optional benchmark_id, optional target, and "
             "optional provenance. Each finding must include finding_id, title, severity, "
             "category, description, impact, recommendation, confidence, and optional "
@@ -788,7 +781,16 @@ class HostedRunService:
 
             llm = _create_llm(provider_name, api_key)
             tools = create_default_registry()
-            sandbox = DockerSandbox()
+            sandbox_config = SandboxConfig(
+                backend=self._config.sandbox.backend,
+                image=self._config.sandbox.image,
+                cpu_limit=self._config.sandbox.cpu_limit,
+                memory_limit=self._config.sandbox.memory_limit,
+                timeout_seconds=self._config.sandbox.timeout_seconds,
+                network_enabled=self._config.sandbox.network_enabled,
+                writable_cache_mounts=self._config.sandbox.writable_cache_mounts,
+            )
+            sandbox = create_sandbox(sandbox_config)
             agent_run = AgentRun(
                 task=task.task_description,
                 repo_path=task.repo_path,
@@ -796,7 +798,7 @@ class HostedRunService:
                 id=task.id,
             )
             try:
-                await sandbox.start(repo_path=task.repo_path)
+                await sandbox.start(repo_path=task.repo_path, config=sandbox_config)
                 await react_loop(agent_run, llm, tools, sandbox, event_bus=self._event_bus)
                 if not record.report_path.exists():
                     record.error = RunError(
@@ -859,9 +861,8 @@ class HostedRunService:
         )
 
     def _artifact_refs(self, record: HostedRunRecord) -> list[RunArtifactRef]:
-        include_logs = (
-            record.request.artifacts is None
-            or bool(record.request.artifacts.include_logs)
+        include_logs = record.request.artifacts is None or bool(
+            record.request.artifacts.include_logs
         )
         artifacts = [
             RunArtifactRef(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ temperature = 0.0
 system_prompt_path = ""
 
 [sandbox]
+backend = "docker"
 image = "agent-forge-sandbox:latest"
 cpu_limit = 1.0
 memory_limit = "512m"
@@ -90,6 +91,7 @@ Examples:
 ```bash
 export AGENT_FORGE_AGENT_MAX_ITERATIONS=10
 export AGENT_FORGE_SANDBOX_MEMORY_LIMIT=1g
+export AGENT_FORGE_SANDBOX_BACKEND=auto
 export AGENT_FORGE_SANDBOX_IMAGE=agent-forge-sandbox:full
 export AGENT_FORGE_LOGGING_LEVEL=DEBUG
 export AGENT_FORGE_SERVICE_AUTH_ENABLED=true
@@ -110,6 +112,7 @@ agent-forge run \
   --provider gemini \
   --model gemini-3.1-flash-lite-preview \
   --max-iterations 25 \
+  --sandbox-backend auto \
   --sandbox-image agent-forge-sandbox:full \
   --network \
   --command-timeout 480 \
@@ -154,6 +157,7 @@ agent-forge run --task "Add input validation" --repo ./my-app
 
 ```toml
 [sandbox]
+backend = "auto"
 image = "agent-forge-sandbox:full"
 memory_limit = "1g"
 timeout_seconds = 600
@@ -174,6 +178,12 @@ Build them with:
 ./scripts/build-sandbox.sh node
 ./scripts/build-sandbox.sh full
 ```
+
+### Sandbox Backends
+
+- `docker`: use the Docker daemon-backed sandbox
+- `bwrap`: use Linux bubblewrap directly
+- `auto`: prefer Docker and fall back to bubblewrap when Docker is unavailable
 ```
 
 ## Inspecting Config

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -416,12 +416,14 @@ from dataclasses import dataclass
 
 @dataclass
 class SandboxConfig:
+    backend: str = "docker"                      # "docker" | "bwrap" | "auto"
     image: str = "agent-forge-sandbox:latest"    # Pre-built image with common tools
     workspace_path: str = "/workspace"           # Mount point inside container
     cpu_limit: float = 1.0                       # CPU cores
     memory_limit: str = "512m"                   # Memory limit
     timeout_seconds: int = 300                   # Max container lifetime
     network_enabled: bool = False                # Network access (default: isolated)
+    writable_cache_mounts: bool = True           # Mount writable cache tmpfs
     env_vars: dict[str, str] = field(default_factory=dict)
 
 class Sandbox(ABC):
@@ -527,10 +529,11 @@ Sandbox capabilities are configured through `SandboxConfig` and CLI flags. Each 
 
 | Capability          | Default           | Opt-in via                           | Use case                          |
 | ------------------- | ----------------- | ------------------------------------ | --------------------------------- |
+| **Backend**         | Docker            | `backend="..."` / `--sandbox-backend`| Bubblewrap fallback, CI, fast startup |
 | **Network access**  | ❌ Disabled       | `network_enabled=True` / `--network` | Install dependencies, fetch APIs  |
 | **Custom runtime**  | Python 3.12       | `image="..."` / `--sandbox-image`    | Node.js, Go, Rust, multi-runtime  |
-| **Writable paths**  | `/workspace` only | Future: `--writable-paths`           | Cache dirs (`~/.npm`, `~/.cache`) |
-| **Command timeout** | 120s              | Future: `--command-timeout`          | Long builds, `npm install`        |
+| **Writable paths**  | `/workspace` only | `writable_cache_mounts=True`         | Cache dirs (`~/.npm`, `~/.cache`) |
+| **Command timeout** | 300s              | `timeout_seconds=...` / `--command-timeout` | Long builds, `npm install` |
 | **Tmpfs size**      | 64 MB (noexec)    | Future: `--tmpfs-size`               | Larger temporary storage          |
 
 > **Design decision:** We start restricted and let operators widen permissions, rather than starting open and asking them to lock down. This ensures that forgetting to configure is safe, not dangerous.

--- a/tests/integration/test_bwrap_sandbox_integration.py
+++ b/tests/integration/test_bwrap_sandbox_integration.py
@@ -1,0 +1,40 @@
+"""Integration tests for tools executing in a real bubblewrap sandbox."""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agent_forge.sandbox.base import SandboxConfig
+from agent_forge.sandbox.bwrap import BwrapSandbox
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def sandbox() -> BwrapSandbox:
+    if platform.system() != "Linux" or shutil.which("bwrap") is None:
+        pytest.skip("bubblewrap is not available")
+
+    repo = Path(tempfile.mkdtemp())
+    (repo / "hello.py").write_text("print('hello world')\n", encoding="utf-8")
+
+    sb = BwrapSandbox()
+    await sb.start(str(repo), SandboxConfig(backend="bwrap", timeout_seconds=60))
+    yield sb
+    await sb.stop()
+
+
+class TestBwrapSandboxIntegration:
+    @pytest.mark.asyncio
+    async def test_read_and_write(self, sandbox: BwrapSandbox) -> None:
+        content = await sandbox.read_file("/workspace/hello.py")
+        assert "hello world" in content
+
+        await sandbox.write_file("/workspace/new.txt", "ok\n")
+        new_content = await sandbox.read_file("/workspace/new.txt")
+        assert new_content == "ok\n"

--- a/tests/unit/test_agent_core.py
+++ b/tests/unit/test_agent_core.py
@@ -330,6 +330,7 @@ class TestBuildSystemPrompt:
         assert "read_file" in prompt
         assert "Fix the bug" in prompt
         assert "/workspace" in prompt
+        assert "Backend: docker" in prompt
         assert "Runtime image: agent-forge-sandbox:latest" in prompt
         assert "Network: disabled" in prompt
 
@@ -342,10 +343,12 @@ class TestBuildSystemPrompt:
         prompt = build_system_prompt(
             task="Install dependencies",
             tool_definitions=[],
+            sandbox_backend="bwrap",
             sandbox_image="agent-forge-sandbox:node",
             network_enabled=True,
             command_timeout_seconds=480,
         )
+        assert "Backend: bwrap" in prompt
         assert "Network: enabled" in prompt
         assert "installing dependencies" in prompt
         assert "agent-forge-sandbox:node" in prompt

--- a/tests/unit/test_bwrap_sandbox.py
+++ b/tests/unit/test_bwrap_sandbox.py
@@ -1,0 +1,161 @@
+"""Unit tests for the bubblewrap sandbox backend."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_forge.llm.errors import SandboxStartupError
+from agent_forge.sandbox.base import SandboxConfig, SandboxState
+from agent_forge.sandbox.bwrap import BwrapSandbox
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestBwrapSandboxLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_requires_linux(self) -> None:
+        with (
+            patch("agent_forge.sandbox.bwrap.platform.system", return_value="Darwin"),
+            patch("agent_forge.sandbox.bwrap.shutil.which", return_value="/usr/bin/bwrap"),
+        ):
+            sandbox = BwrapSandbox()
+            with pytest.raises(SandboxStartupError, match="only available on Linux"):
+                await sandbox.start("/tmp/repo")
+
+    @pytest.mark.asyncio
+    async def test_start_requires_bwrap_binary(self) -> None:
+        with (
+            patch("agent_forge.sandbox.bwrap.platform.system", return_value="Linux"),
+            patch("agent_forge.sandbox.bwrap.shutil.which", return_value=None),
+        ):
+            sandbox = BwrapSandbox()
+            with pytest.raises(SandboxStartupError, match="requires the 'bwrap' executable"):
+                await sandbox.start("/tmp/repo")
+
+    @pytest.mark.asyncio
+    async def test_start_sets_running_state(self) -> None:
+        with (
+            patch("agent_forge.sandbox.bwrap.platform.system", return_value="Linux"),
+            patch("agent_forge.sandbox.bwrap.shutil.which", return_value="/usr/bin/bwrap"),
+        ):
+            sandbox = BwrapSandbox()
+            await sandbox.start("/tmp/repo")
+            assert sandbox.state == SandboxState.RUNNING
+            assert await sandbox.is_alive() is True
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_stopped_state(self) -> None:
+        with (
+            patch("agent_forge.sandbox.bwrap.platform.system", return_value="Linux"),
+            patch("agent_forge.sandbox.bwrap.shutil.which", return_value="/usr/bin/bwrap"),
+        ):
+            sandbox = BwrapSandbox()
+            await sandbox.start("/tmp/repo")
+            await sandbox.stop()
+            assert sandbox.state == SandboxState.STOPPED
+
+
+class TestBwrapSandboxExec:
+    @pytest.mark.asyncio
+    async def test_exec_builds_isolated_command(self, tmp_path: Path) -> None:
+        process = AsyncMock()
+        process.communicate.return_value = (b"hello\n", b"")
+        process.kill = MagicMock()
+        process.returncode = 0
+
+        with (
+            patch("agent_forge.sandbox.bwrap.platform.system", return_value="Linux"),
+            patch("agent_forge.sandbox.bwrap.shutil.which", return_value="/usr/bin/bwrap"),
+            patch(
+                "agent_forge.sandbox.bwrap.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=process,
+            ) as mock_exec,
+        ):
+            sandbox = BwrapSandbox()
+            await sandbox.start(
+                str(tmp_path),
+                SandboxConfig(
+                    backend="bwrap",
+                    network_enabled=True,
+                    writable_cache_mounts=True,
+                ),
+            )
+
+            result = await sandbox.exec("echo hello", timeout_seconds=45)
+
+        assert result.exit_code == 0
+        assert result.stdout == "hello\n"
+        argv = mock_exec.await_args.args
+        assert "--unshare-pid" in argv
+        assert "--die-with-parent" in argv
+        assert "--new-session" in argv
+        assert "--bind" in argv
+        assert "/cache" in argv
+        assert "echo hello" in argv
+
+    @pytest.mark.asyncio
+    async def test_exec_unshares_network_when_disabled(self, tmp_path: Path) -> None:
+        process = AsyncMock()
+        process.communicate.return_value = (b"ok\n", b"")
+        process.kill = MagicMock()
+        process.returncode = 0
+
+        with (
+            patch("agent_forge.sandbox.bwrap.platform.system", return_value="Linux"),
+            patch("agent_forge.sandbox.bwrap.shutil.which", return_value="/usr/bin/bwrap"),
+            patch(
+                "agent_forge.sandbox.bwrap.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=process,
+            ) as mock_exec,
+        ):
+            sandbox = BwrapSandbox()
+            await sandbox.start(
+                str(tmp_path),
+                SandboxConfig(backend="bwrap", network_enabled=False),
+            )
+            await sandbox.exec("echo ok")
+
+        argv = mock_exec.await_args.args
+        assert "--unshare-net" in argv
+
+    @pytest.mark.asyncio
+    async def test_exec_timeout_kills_process(self, tmp_path: Path) -> None:
+        process = AsyncMock()
+        process.kill = MagicMock()
+        process.communicate = AsyncMock(side_effect=[TimeoutError, (b"", b"")])
+
+        with (
+            patch("agent_forge.sandbox.bwrap.platform.system", return_value="Linux"),
+            patch("agent_forge.sandbox.bwrap.shutil.which", return_value="/usr/bin/bwrap"),
+            patch(
+                "agent_forge.sandbox.bwrap.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=process,
+            ),
+        ):
+            sandbox = BwrapSandbox()
+            await sandbox.start(str(tmp_path))
+            result = await sandbox.exec("sleep 10", timeout_seconds=1)
+
+        assert result.exit_code == 124
+        process.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_read_file_not_found(self, tmp_path: Path) -> None:
+        with (
+            patch("agent_forge.sandbox.bwrap.platform.system", return_value="Linux"),
+            patch("agent_forge.sandbox.bwrap.shutil.which", return_value="/usr/bin/bwrap"),
+        ):
+            sandbox = BwrapSandbox()
+            await sandbox.start(str(tmp_path))
+            sandbox.exec = AsyncMock(
+                return_value=MagicMock(exit_code=1, stdout="", stderr="missing")
+            )
+            with pytest.raises(FileNotFoundError):
+                await sandbox.read_file("/workspace/missing.txt")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -152,6 +152,8 @@ class TestRunCommand:
                     "/tmp/fake-repo",
                     "--sandbox-image",
                     "agent-forge-sandbox:node",
+                    "--sandbox-backend",
+                    "bwrap",
                     "--network",
                     "--command-timeout",
                     "480",
@@ -163,6 +165,7 @@ class TestRunCommand:
         mock_load_config.assert_called_once_with(
             cli_overrides={
                 "sandbox.image": "agent-forge-sandbox:node",
+                "sandbox.backend": "bwrap",
                 "sandbox.network_enabled": True,
                 "sandbox.timeout_seconds": 480,
             }

--- a/tests/unit/test_cli_orchestration.py
+++ b/tests/unit/test_cli_orchestration.py
@@ -30,6 +30,7 @@ def _fake_config() -> MagicMock:
     cfg.agent.max_iterations = 10
     cfg.agent.max_tokens_per_run = 100_000
     cfg.agent.temperature = 0.0
+    cfg.sandbox.backend = "docker"
     cfg.sandbox.image = "agent-forge-sandbox:latest"
     cfg.sandbox.cpu_limit = 1.0
     cfg.sandbox.memory_limit = "512m"
@@ -69,9 +70,9 @@ class TestDirectModeEventBus:
             patch("agent_forge.cli._create_llm") as mock_llm_factory,
             patch("agent_forge.tools.create_default_registry") as mock_tools,
             patch("agent_forge.agent.core.react_loop", new_callable=AsyncMock) as mock_react,
-            patch("agent_forge.sandbox.docker.DockerSandbox") as mock_sandbox_cls,
+            patch("agent_forge.sandbox.factory.create_sandbox") as mock_create_sandbox,
         ):
-            mock_sandbox_cls.return_value = AsyncMock()
+            mock_create_sandbox.return_value = AsyncMock()
             mock_llm_factory.return_value = AsyncMock()
             mock_tools.return_value = MagicMock()
             mock_react.return_value = _mock_react_result()
@@ -92,9 +93,9 @@ class TestDirectModeEventBus:
             patch("agent_forge.cli._create_llm") as mock_llm_factory,
             patch("agent_forge.tools.create_default_registry") as mock_tools,
             patch("agent_forge.agent.core.react_loop", new_callable=AsyncMock) as mock_react,
-            patch("agent_forge.sandbox.docker.DockerSandbox") as mock_sandbox_cls,
+            patch("agent_forge.sandbox.factory.create_sandbox") as mock_create_sandbox,
         ):
-            mock_sandbox_cls.return_value = AsyncMock()
+            mock_create_sandbox.return_value = AsyncMock()
             mock_llm_factory.return_value = AsyncMock()
             mock_tools.return_value = MagicMock()
             mock_react.return_value = _mock_react_result()
@@ -246,6 +247,7 @@ class TestSandboxConfigWiring:
         from agent_forge.cli import _build_sandbox_config
 
         cfg = _fake_config()
+        cfg.sandbox.backend = "auto"
         cfg.sandbox.image = "agent-forge-sandbox:full"
         cfg.sandbox.cpu_limit = 2.0
         cfg.sandbox.memory_limit = "2g"
@@ -256,6 +258,7 @@ class TestSandboxConfigWiring:
         sandbox_config = _build_sandbox_config(cfg)
 
         assert sandbox_config == SandboxConfig(
+            backend="auto",
             image="agent-forge-sandbox:full",
             cpu_limit=2.0,
             memory_limit="2g",
@@ -486,10 +489,10 @@ class TestMakeTaskRunner:
         with (
             patch("agent_forge.cli._create_llm") as mock_llm_factory,
             patch("agent_forge.agent.core.react_loop", new_callable=AsyncMock) as mock_react,
-            patch("agent_forge.sandbox.docker.DockerSandbox") as mock_sandbox_cls,
+            patch("agent_forge.sandbox.factory.create_sandbox") as mock_create_sandbox,
         ):
             mock_sandbox = AsyncMock()
-            mock_sandbox_cls.return_value = mock_sandbox
+            mock_create_sandbox.return_value = mock_sandbox
             mock_llm = AsyncMock()
             mock_llm_factory.return_value = mock_llm
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -92,6 +92,11 @@ class TestEnvOverrides:
         result = _collect_env_overrides()
         assert result == {"sandbox": {"memory_limit": "1g"}}
 
+    def test_sandbox_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGENT_FORGE_SANDBOX_BACKEND", "bwrap")
+        result = _collect_env_overrides()
+        assert result == {"sandbox": {"backend": "bwrap"}}
+
     def test_bool_coercion(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("AGENT_FORGE_SANDBOX_NETWORK_ENABLED", "true")
         result = _collect_env_overrides()
@@ -180,6 +185,7 @@ class TestDefaults:
         assert cfg.agent.default_provider == "gemini"
         assert cfg.agent.default_model == "gemini-3.1-flash-lite-preview"
         assert cfg.agent.temperature == 0.0
+        assert cfg.sandbox.backend == "docker"
         assert cfg.sandbox.image == "agent-forge-sandbox:latest"
         assert cfg.sandbox.memory_limit == "512m"
         assert cfg.sandbox.timeout_seconds == 300

--- a/tests/unit/test_sandbox_factory.py
+++ b/tests/unit/test_sandbox_factory.py
@@ -1,0 +1,47 @@
+"""Unit tests for sandbox backend selection."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agent_forge.llm.errors import SandboxStartupError
+from agent_forge.sandbox.base import SandboxConfig
+from agent_forge.sandbox.bwrap import BwrapSandbox
+from agent_forge.sandbox.docker import DockerSandbox
+from agent_forge.sandbox.factory import create_sandbox
+
+
+class TestCreateSandbox:
+    def test_docker_backend(self) -> None:
+        sandbox = create_sandbox(SandboxConfig(backend="docker"))
+        assert isinstance(sandbox, DockerSandbox)
+
+    def test_bwrap_backend(self) -> None:
+        sandbox = create_sandbox(SandboxConfig(backend="bwrap"))
+        assert isinstance(sandbox, BwrapSandbox)
+
+    def test_auto_prefers_docker(self) -> None:
+        with (
+            patch("agent_forge.sandbox.factory._docker_available", return_value=True),
+            patch("agent_forge.sandbox.factory._bwrap_available", return_value=True),
+        ):
+            sandbox = create_sandbox(SandboxConfig(backend="auto"))
+        assert isinstance(sandbox, DockerSandbox)
+
+    def test_auto_falls_back_to_bwrap(self) -> None:
+        with (
+            patch("agent_forge.sandbox.factory._docker_available", return_value=False),
+            patch("agent_forge.sandbox.factory._bwrap_available", return_value=True),
+        ):
+            sandbox = create_sandbox(SandboxConfig(backend="auto"))
+        assert isinstance(sandbox, BwrapSandbox)
+
+    def test_auto_raises_when_no_backend_available(self) -> None:
+        with (
+            patch("agent_forge.sandbox.factory._docker_available", return_value=False),
+            patch("agent_forge.sandbox.factory._bwrap_available", return_value=False),
+            pytest.raises(SandboxStartupError, match="No supported sandbox backend"),
+        ):
+            create_sandbox(SandboxConfig(backend="auto"))


### PR DESCRIPTION
## Summary
- add a Linux bubblewrap sandbox backend and a backend factory with docker/auto fallback selection
- wire CLI and hosted service sandbox creation through the factory and expose sandbox backend config
- add unit and integration coverage plus spec/config docs for bubblewrap support

Fixes #104

## Testing
- `ruff check agent_forge tests`
- `python -m pytest tests/unit/test_bwrap_sandbox.py tests/unit/test_sandbox_factory.py tests/unit/test_config.py tests/unit/test_cli.py -k 'not serve_invokes_uvicorn' tests/unit/test_cli_orchestration.py tests/unit/test_agent_core.py tests/unit/test_sandbox.py tests/integration/test_bwrap_sandbox_integration.py -v`

## Notes
- `tests/unit/test_cli.py::TestServeCommand::test_serve_invokes_uvicorn` is unchanged and still depends on `uvicorn` being installed in the local environment.