### PR TITLE
[codex] Load external tool plugins

### DIFF
--- a/agent_forge/tools/__init__.py
+++ b/agent_forge/tools/__init__.py
@@ -1,5 +1,8 @@
 """Tool system — base classes and built-in tools."""
 
+from collections.abc import Callable, Iterable
+from importlib.metadata import EntryPoint
+
 from agent_forge.tools.base import Tool, ToolRegistry, ToolResult, validate_path
 from agent_forge.tools.create_pr import CreatePRTool
 from agent_forge.tools.edit_file import EditFileTool
@@ -7,12 +10,20 @@ from agent_forge.tools.git_commit import GitCommitTool
 from agent_forge.tools.git_create_branch import GitCreateBranchTool
 from agent_forge.tools.git_diff import GitDiffTool
 from agent_forge.tools.list_directory import ListDirectoryTool
+from agent_forge.tools.plugins import (
+    TOOL_PLUGIN_GROUP,
+    ToolPluginError,
+    discover_tool_plugins,
+    load_plugin_tools,
+    register_plugin_tools,
+)
 from agent_forge.tools.read_file import ReadFileTool
 from agent_forge.tools.run_shell import RunShellTool
 from agent_forge.tools.search_codebase import SearchCodebaseTool
 from agent_forge.tools.write_file import WriteFileTool
 
 __all__ = [
+    "TOOL_PLUGIN_GROUP",
     "CreatePRTool",
     "EditFileTool",
     "GitCommitTool",
@@ -23,16 +34,24 @@ __all__ = [
     "RunShellTool",
     "SearchCodebaseTool",
     "Tool",
+    "ToolPluginError",
     "ToolRegistry",
     "ToolResult",
     "WriteFileTool",
     "create_default_registry",
+    "discover_tool_plugins",
+    "load_plugin_tools",
+    "register_plugin_tools",
     "validate_path",
 ]
 
 
-def create_default_registry() -> ToolRegistry:
-    """Create a ToolRegistry with all built-in tools registered."""
+def create_default_registry(
+    *,
+    load_plugins: bool = True,
+    entry_points_factory: Callable[[], Iterable[EntryPoint]] | None = None,
+) -> ToolRegistry:
+    """Create a ToolRegistry with built-ins and optional external plugins."""
     registry = ToolRegistry()
     registry.register(ReadFileTool())
     registry.register(WriteFileTool())
@@ -44,4 +63,6 @@ def create_default_registry() -> ToolRegistry:
     registry.register(GitCommitTool())
     registry.register(GitCreateBranchTool())
     registry.register(CreatePRTool())
+    if load_plugins:
+        register_plugin_tools(registry, entry_points_factory=entry_points_factory)
     return registry

--- a/agent_forge/tools/plugins.py
+++ b/agent_forge/tools/plugins.py
@@ -1,0 +1,84 @@
+"""Plugin discovery and loading for external tool packages."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from importlib.metadata import EntryPoint, entry_points
+from inspect import isclass
+from typing import cast
+
+from agent_forge.tools.base import Tool, ToolRegistry
+
+TOOL_PLUGIN_GROUP = "agent_forge.tools"
+
+
+class ToolPluginError(ValueError):
+    """Raised when a declared tool plugin cannot be loaded safely."""
+
+
+EntryPointIterable = Iterable[EntryPoint]
+EntryPointsFactory = Callable[[], EntryPointIterable]
+
+
+def _default_entry_points() -> EntryPointIterable:
+    """Return configured tool plugin entry points."""
+    return entry_points(group=TOOL_PLUGIN_GROUP)
+
+
+def discover_tool_plugins(
+    *,
+    entry_points_factory: EntryPointsFactory | None = None,
+) -> list[EntryPoint]:
+    """Discover configured tool plugins from Python entry points."""
+    factory = entry_points_factory or _default_entry_points
+    return sorted(factory(), key=lambda entry_point: entry_point.name)
+
+
+def _instantiate_plugin(entry_point: EntryPoint) -> Tool:
+    """Load one entry point and coerce it into a Tool instance."""
+    try:
+        loaded = entry_point.load()
+    except Exception as exc:
+        msg = f"Failed to load tool plugin '{entry_point.name}': {exc}"
+        raise ToolPluginError(msg) from exc
+
+    if isinstance(loaded, Tool):
+        return loaded
+
+    if isclass(loaded) and issubclass(cast("type[object]", loaded), Tool):
+        tool_class = cast("type[Tool]", loaded)
+        try:
+            return tool_class()
+        except Exception as exc:
+            msg = (
+                f"Failed to instantiate tool plugin '{entry_point.name}' "
+                f"from '{entry_point.value}': {exc}"
+            )
+            raise ToolPluginError(msg) from exc
+
+    msg = (
+        f"Invalid tool plugin '{entry_point.name}' from '{entry_point.value}': "
+        "entry point must resolve to a Tool instance or Tool subclass"
+    )
+    raise ToolPluginError(msg)
+
+
+def load_plugin_tools(
+    *,
+    entry_points_factory: EntryPointsFactory | None = None,
+) -> list[Tool]:
+    """Load all configured external tool plugins."""
+    return [
+        _instantiate_plugin(entry_point)
+        for entry_point in discover_tool_plugins(entry_points_factory=entry_points_factory)
+    ]
+
+
+def register_plugin_tools(
+    registry: ToolRegistry,
+    *,
+    entry_points_factory: EntryPointsFactory | None = None,
+) -> None:
+    """Register all configured external tool plugins on a registry."""
+    for tool in load_plugin_tools(entry_points_factory=entry_points_factory):
+        registry.register(tool)

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -83,6 +83,52 @@ async def test_my_tool_basic():
 - `description` should be clear — the LLM reads it to decide when to use the tool
 - Always return a `ToolResult` (never raise from `execute`)
 
+## Shipping a Tool Plugin
+
+Agent Forge can load external tool plugins automatically from Python entry
+points in the `agent_forge.tools` group.
+
+### 1. Package the Tool
+
+Create a normal Python package that depends on `agent-forge` and expose either:
+
+- a `Tool` subclass with a zero-argument constructor, or
+- a pre-instantiated `Tool` object
+
+### 2. Declare the Entry Point
+
+```toml
+[project.entry-points."agent_forge.tools"]
+my_tool = "my_package.tool:MyTool"
+```
+
+### 3. Install the Plugin
+
+```bash
+pip install my-package
+```
+
+or during development:
+
+```bash
+pip install -e ./path/to/plugin
+```
+
+After installation, `create_default_registry()` loads the plugin automatically
+for the CLI and hosted service.
+
+### Plugin Validation Rules
+
+- entry points must resolve to a `Tool` instance or a `Tool` subclass
+- subclasses must be instantiable without constructor arguments
+- plugin tool names must remain unique across built-ins and other plugins
+- plugin load failures are raised immediately with the entry point name/value
+
+### Example Package
+
+See [`examples/echo-tool-plugin`](/home/koita/dev/ai/agent-forge/examples/echo-tool-plugin)
+for a minimal working plugin package.
+
 ---
 
 ## Adding a New LLM Provider

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1435,7 +1435,7 @@ clean:                     ## Clean up containers and build artifacts
 > **Goal:** The agent understands git workflows and users can extend it with custom tools.
 
 - [x] Git-aware tools: `git_diff`, `git_commit`, `git_create_branch`, `create_pr`
-- [ ] Plugin system: load custom tools from external Python packages
+- [x] Plugin system: load custom tools from external Python packages
 - [ ] Tool dependency resolution (e.g., a tool that requires another tool's output)
 - [ ] Custom system prompt templates (per-project `.agent-forge/prompts/`)
 - [ ] Agent memory: persist learnings across runs (file-based initially)

--- a/examples/echo-tool-plugin/README.md
+++ b/examples/echo-tool-plugin/README.md
@@ -1,0 +1,13 @@
+# Echo Tool Plugin Example
+
+This example package shows how to ship an external Agent Forge tool via Python
+entry points.
+
+Install it in editable mode from the repo root:
+
+```bash
+pip install -e ./examples/echo-tool-plugin
+```
+
+Once installed, Agent Forge will discover the plugin automatically through the
+`agent_forge.tools` entry point group.

--- a/examples/echo-tool-plugin/pyproject.toml
+++ b/examples/echo-tool-plugin/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agent-forge-echo-tool-plugin"
+version = "0.1.0"
+description = "Example external Agent Forge tool plugin"
+requires-python = ">=3.11"
+
+[project.entry-points."agent_forge.tools"]
+echo_tool = "agent_forge_echo_plugin:EchoTool"

--- a/examples/echo-tool-plugin/src/agent_forge_echo_plugin/__init__.py
+++ b/examples/echo-tool-plugin/src/agent_forge_echo_plugin/__init__.py
@@ -1,0 +1,3 @@
+from agent_forge_echo_plugin.tool import EchoTool
+
+__all__ = ["EchoTool"]

--- a/examples/echo-tool-plugin/src/agent_forge_echo_plugin/tool.py
+++ b/examples/echo-tool-plugin/src/agent_forge_echo_plugin/tool.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+from agent_forge.tools.base import Tool, ToolResult
+
+
+class EchoTool(Tool):
+    @property
+    def name(self) -> str:
+        return "echo_tool"
+
+    @property
+    def description(self) -> str:
+        return "Echo a short string to demonstrate external plugin loading"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "Message to echo back",
+                }
+            },
+            "required": ["message"],
+        }
+
+    async def execute(self, arguments: dict[str, Any], sandbox: Any) -> ToolResult:
+        return ToolResult(output=str(arguments.get("message", "")))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,4 +77,4 @@ def mock_llm() -> LLMProvider:
 @pytest.fixture
 def tool_registry() -> ToolRegistry:
     """A fully populated tool registry with all built-in tools."""
-    return create_default_registry()
+    return create_default_registry(load_plugins=False)

--- a/tests/e2e/test_agent_e2e.py
+++ b/tests/e2e/test_agent_e2e.py
@@ -90,7 +90,7 @@ def llm(api_key: str) -> GeminiProvider:
 @pytest.fixture
 def tools() -> ToolRegistry:
     """Create the default tool registry."""
-    return create_default_registry()
+    return create_default_registry(load_plugins=False)
 
 
 @pytest.fixture
@@ -337,4 +337,3 @@ class TestAgentPersistence:
         assert loaded.total_tokens.total_tokens == result.total_tokens.total_tokens
         assert len(loaded.messages) == len(result.messages)
         assert len(loaded.tool_invocations) == len(result.tool_invocations)
-

--- a/tests/unit/test_tool_plugins.py
+++ b/tests/unit/test_tool_plugins.py
@@ -1,0 +1,145 @@
+"""Unit tests for external tool plugin discovery and registration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from agent_forge.tools import ToolPluginError, create_default_registry, discover_tool_plugins
+from agent_forge.tools.base import Tool, ToolRegistry, ToolResult
+from agent_forge.tools.plugins import load_plugin_tools, register_plugin_tools
+
+
+class ExamplePluginTool(Tool):
+    @property
+    def name(self) -> str:
+        return "example_plugin"
+
+    @property
+    def description(self) -> str:
+        return "Example plugin tool"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "value": {"type": "string"},
+            },
+        }
+
+    async def execute(self, arguments: dict[str, Any], sandbox: Any) -> ToolResult:
+        return ToolResult(output=str(arguments.get("value", "")))
+
+
+@dataclass
+class FakeEntryPoint:
+    name: str
+    value: str
+    loaded: object
+
+    def load(self) -> object:
+        if isinstance(self.loaded, Exception):
+            raise self.loaded
+        return self.loaded
+
+
+class TestToolPluginDiscovery:
+    def test_discover_sorts_entry_points(self) -> None:
+        discovered = discover_tool_plugins(
+            entry_points_factory=lambda: [
+                FakeEntryPoint("zeta", "pkg:ZetaTool", ExamplePluginTool),
+                FakeEntryPoint("alpha", "pkg:AlphaTool", ExamplePluginTool),
+            ]
+        )
+
+        assert [entry_point.name for entry_point in discovered] == ["alpha", "zeta"]
+
+
+class TestToolPluginLoading:
+    def test_loads_tool_subclass(self) -> None:
+        tools = load_plugin_tools(
+            entry_points_factory=lambda: [
+                FakeEntryPoint("example", "pkg:ExamplePluginTool", ExamplePluginTool)
+            ]
+        )
+
+        assert len(tools) == 1
+        assert isinstance(tools[0], ExamplePluginTool)
+
+    def test_loads_tool_instance(self) -> None:
+        tools = load_plugin_tools(
+            entry_points_factory=lambda: [
+                FakeEntryPoint("example", "pkg:tool", ExamplePluginTool())
+            ]
+        )
+
+        assert len(tools) == 1
+        assert tools[0].name == "example_plugin"
+
+    def test_rejects_invalid_plugin_type(self) -> None:
+        with pytest.raises(ToolPluginError, match="Tool instance or Tool subclass"):
+            load_plugin_tools(
+                entry_points_factory=lambda: [FakeEntryPoint("bad", "pkg:not_tool", object())]
+            )
+
+    def test_surfaces_plugin_load_error(self) -> None:
+        with pytest.raises(ToolPluginError, match="Failed to load tool plugin 'bad'"):
+            load_plugin_tools(
+                entry_points_factory=lambda: [
+                    FakeEntryPoint("bad", "pkg:broken", RuntimeError("boom"))
+                ]
+            )
+
+    def test_surfaces_instantiation_error(self) -> None:
+        class BrokenTool(ExamplePluginTool):
+            def __init__(self) -> None:
+                msg = "bad init"
+                raise RuntimeError(msg)
+
+        with pytest.raises(ToolPluginError, match="Failed to instantiate tool plugin 'broken'"):
+            load_plugin_tools(
+                entry_points_factory=lambda: [
+                    FakeEntryPoint("broken", "pkg:BrokenTool", BrokenTool)
+                ]
+            )
+
+
+class TestToolPluginRegistration:
+    def test_register_plugin_tools(self) -> None:
+        registry = ToolRegistry()
+        register_plugin_tools(
+            registry,
+            entry_points_factory=lambda: [
+                FakeEntryPoint("example", "pkg:ExamplePluginTool", ExamplePluginTool)
+            ],
+        )
+
+        assert registry.get("example_plugin").name == "example_plugin"
+
+    def test_default_registry_can_include_plugins(self) -> None:
+        registry = create_default_registry(
+            entry_points_factory=lambda: [
+                FakeEntryPoint("example", "pkg:ExamplePluginTool", ExamplePluginTool)
+            ]
+        )
+
+        assert registry.get("example_plugin").name == "example_plugin"
+        assert len(registry) == 11
+
+    def test_duplicate_plugin_name_is_rejected(self) -> None:
+        class DuplicateReadFileTool(ExamplePluginTool):
+            @property
+            def name(self) -> str:
+                return "read_file"
+
+        registry = create_default_registry(load_plugins=False)
+        with pytest.raises(ValueError, match="already registered"):
+            register_plugin_tools(
+                registry,
+                entry_points_factory=lambda: [
+                    FakeEntryPoint("read_file", "pkg:DuplicateReadFileTool", DuplicateReadFileTool)
+                ]
+            )

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -94,7 +94,7 @@ class TestToolRegistry:
             registry.get("nonexistent")
 
     def test_list_definitions(self) -> None:
-        registry = create_default_registry()
+        registry = create_default_registry(load_plugins=False)
         defs = registry.list_definitions()
         names = {d.name for d in defs}
         assert names == {

--- a/tests/unit/test_tools_extra.py
+++ b/tests/unit/test_tools_extra.py
@@ -335,7 +335,7 @@ class TestEditFile:
 
 class TestDefaultRegistry:
     def test_all_tools_registered(self) -> None:
-        registry = create_default_registry()
+        registry = create_default_registry(load_plugins=False)
         names = {d.name for d in registry.list_definitions()}
         assert names == {
             "create_pr",


### PR DESCRIPTION
## Summary
- discover external tools from the `agent_forge.tools` Python entry-point group
- validate and register plugin tools alongside the built-in registry used by the CLI and hosted service
- document plugin authoring and include a minimal installable example package

## Validation
- `ruff check agent_forge/tools tests/unit/test_tool_plugins.py tests/unit/test_tools.py tests/unit/test_tools_extra.py tests/conftest.py tests/e2e/test_agent_e2e.py`
- `python -m pytest tests/unit/test_tool_plugins.py tests/unit/test_tools.py tests/unit/test_tools_extra.py tests/unit/test_agent_core.py tests/integration/test_tools_integration.py`
- `python -m pytest tests/unit/test_cli.py -k 'not serve_invokes_uvicorn' tests/unit/test_cli_orchestration.py`
- `mypy agent_forge/tools/plugins.py agent_forge/tools/__init__.py`

Closes #22
