### PR TITLE
fix(#115): add report finalization with recovery pass and granular validation

### DIFF
--- a/agent_forge/agent/prompts.py
+++ b/agent_forge/agent/prompts.py
@@ -34,6 +34,30 @@ You can use the following tools to complete the task:
 {task_description}"""
 
 
+def _format_tool_descriptions(tool_definitions: list[ToolDefinition]) -> str:
+    """Format tool definitions into a readable list for system prompts."""
+    tool_lines: list[str] = []
+    for td in tool_definitions:
+        props: dict[str, dict[str, object]] = td.parameters.get("properties", {})  # type: ignore[assignment]
+        params = ", ".join(f"{k}: {v.get('type', 'any')}" for k, v in props.items())
+        tool_lines.append(f"- **{td.name}**({params}) — {td.description}")
+    return "\n".join(tool_lines)
+
+
+def _format_network_rule(network_enabled: bool) -> tuple[str, str]:
+    """Return (network_rule, network_status) based on network flag."""
+    if network_enabled:
+        return (
+            "Network access is enabled in this sandbox. Use it only when required for "
+            "the task, such as installing dependencies or fetching remote resources.",
+            "enabled",
+        )
+    return (
+        "Do NOT attempt to access the internet or external services.",
+        "disabled",
+    )
+
+
 def build_system_prompt(
     task: str,
     tool_definitions: list[ToolDefinition],
@@ -44,24 +68,83 @@ def build_system_prompt(
     command_timeout_seconds: int = 300,
 ) -> str:
     """Render the system prompt with tool descriptions and task."""
-    tool_lines: list[str] = []
-    for td in tool_definitions:
-        props: dict[str, dict[str, object]] = td.parameters.get("properties", {})  # type: ignore[assignment]
-        params = ", ".join(f"{k}: {v.get('type', 'any')}" for k, v in props.items())
-        tool_lines.append(f"- **{td.name}**({params}) — {td.description}")
-
-    if network_enabled:
-        network_rule = (
-            "Network access is enabled in this sandbox. Use it only when required for "
-            "the task, such as installing dependencies or fetching remote resources."
-        )
-        network_status = "enabled"
-    else:
-        network_rule = "Do NOT attempt to access the internet or external services."
-        network_status = "disabled"
+    network_rule, network_status = _format_network_rule(network_enabled)
 
     return _SYSTEM_PROMPT_TEMPLATE.format(
-        tool_descriptions="\n".join(tool_lines),
+        tool_descriptions=_format_tool_descriptions(tool_definitions),
+        sandbox_backend=sandbox_backend,
+        sandbox_image=sandbox_image,
+        network_rule=network_rule,
+        network_status=network_status,
+        command_timeout_seconds=command_timeout_seconds,
+        task_description=task,
+    )
+
+
+_HOSTED_POA_SYSTEM_PROMPT_TEMPLATE = """\
+You are Agent Forge running a hosted Proof-of-Audit smart contract audit.
+
+## CRITICAL OUTPUT REQUIREMENT
+Before you stop, you MUST write a valid JSON report to .agent-forge/report.json \
+using the write_file tool. The hosted run will FAIL if this file is not written. \
+This is not optional — if you skip this step the entire audit is wasted.
+
+## Report Schema (proof-of-audit-report-v1)
+The JSON report MUST contain these top-level fields:
+- "schema_version": must be exactly "proof-of-audit-report-v1"
+- "run_id": the run identifier (use the task description for reference)
+- "summary": a brief natural-language overall assessment
+- "confidence": one of "low", "medium", "high"
+- "findings": array of finding objects (may be empty if no issues found)
+- "stats": object with finding_count (int), max_severity (string or null), \
+and severity_breakdown (object with critical, high, medium, low counts)
+
+Each finding in "findings" MUST have:
+- finding_id, title, severity, category, description, impact, recommendation, confidence
+
+Optional finding fields: detector, affected_function, source_path, start_line, \
+end_line, evidence_uri
+
+Optional report fields: benchmark_id, target, provenance
+
+If no findings are confirmed, write an empty findings array and stats with \
+finding_count=0.
+
+## Your Capabilities
+{tool_descriptions}
+
+## Rules
+1. Always read relevant files before making changes.
+2. Make small, focused changes. Do not rewrite entire files unnecessarily.
+3. Do not modify the source code under audit.
+4. {network_rule}
+5. Stay within the /workspace directory.
+6. Your FINAL action before stopping MUST be writing .agent-forge/report.json.
+
+## Sandbox
+- Backend: {sandbox_backend}
+- Runtime image: {sandbox_image}
+- Network: {network_status}
+- Max shell command timeout: {command_timeout_seconds}s
+
+## Task
+{task_description}"""
+
+
+def build_hosted_poa_system_prompt(
+    task: str,
+    tool_definitions: list[ToolDefinition],
+    *,
+    sandbox_backend: str = "docker",
+    sandbox_image: str = "agent-forge-sandbox:latest",
+    network_enabled: bool = False,
+    command_timeout_seconds: int = 300,
+) -> str:
+    """Render the hosted Proof-of-Audit system prompt with strict report emission."""
+    network_rule, network_status = _format_network_rule(network_enabled)
+
+    return _HOSTED_POA_SYSTEM_PROMPT_TEMPLATE.format(
+        tool_descriptions=_format_tool_descriptions(tool_definitions),
         sandbox_backend=sandbox_backend,
         sandbox_image=sandbox_image,
         network_rule=network_rule,

--- a/agent_forge/service/app.py
+++ b/agent_forge/service/app.py
@@ -22,6 +22,7 @@ from fastapi.responses import JSONResponse
 
 from agent_forge.agent.core import react_loop
 from agent_forge.agent.models import AgentConfig, AgentRun
+from agent_forge.agent.prompts import build_hosted_poa_system_prompt
 from agent_forge.cli import _create_llm
 from agent_forge.config import USER_CONFIG_DIR, ForgeConfig, load_config
 from agent_forge.orchestration.events import EventBus
@@ -49,6 +50,18 @@ from agent_forge.service.security import ServiceClientPolicy, load_client_regist
 from agent_forge.tools import create_default_registry
 
 _REPORT_RELATIVE_PATH = Path(".agent-forge/report.json")
+
+_REPORT_REQUIRED_FIELDS = {"schema_version", "run_id", "summary", "confidence", "findings", "stats"}
+
+_REPORT_RECOVERY_PROMPT = (
+    "The audit analysis is complete but you did not write the required report file. "
+    "You MUST now write a valid JSON report to .agent-forge/report.json using the "
+    "write_file tool. The report must use schema_version \"proof-of-audit-report-v1\" "
+    "and include the fields: run_id, summary, confidence, findings (array), and stats "
+    "(object with finding_count, max_severity, severity_breakdown with critical/high/"
+    "medium/low counts). If you found no issues, use an empty findings array and "
+    "stats with finding_count=0. Write the file NOW — this is your only chance."
+)
 
 
 @dataclass
@@ -825,6 +838,36 @@ class HostedRunService:
             "If no finding is confirmed, write an empty findings array and matching stats."
         )
 
+    def _validate_report_artifact(self, record: HostedRunRecord) -> None:
+        """Validate that the report file exists, is valid JSON, and has required fields."""
+        if not record.report_path.exists():
+            record.error = RunError(
+                code="report_generation_failed",
+                message="run completed without writing .agent-forge/report.json",
+                retryable=False,
+            )
+            raise RuntimeError(record.error.message)
+
+        raw = record.report_path.read_text(encoding="utf-8")
+        try:
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            record.error = RunError(
+                code="report_invalid_json",
+                message=f"report.json exists but is not valid JSON: {exc}",
+                retryable=False,
+            )
+            raise RuntimeError(record.error.message) from exc
+
+        missing = _REPORT_REQUIRED_FIELDS - set(payload.keys())
+        if missing:
+            record.error = RunError(
+                code="report_schema_invalid",
+                message=f"report.json missing required fields: {sorted(missing)}",
+                retryable=False,
+            )
+            raise RuntimeError(record.error.message)
+
     def _make_task_runner(self) -> Any:
         async def _runner(task: Task) -> None:
             record = self._records[task.id]
@@ -859,22 +902,66 @@ class HostedRunService:
                 writable_cache_mounts=self._config.sandbox.writable_cache_mounts,
             )
             sandbox = create_sandbox(sandbox_config)
+            tool_definitions = tools.list_definitions()
+            hosted_prompt = build_hosted_poa_system_prompt(
+                task.task_description,
+                tool_definitions,
+                sandbox_backend=sandbox_config.backend,
+                sandbox_image=sandbox_config.image,
+                network_enabled=sandbox_config.network_enabled,
+            )
+            agent_config = AgentConfig(
+                model=task.config.model,
+                max_iterations=task.config.max_iterations,
+                max_tokens_per_run=task.config.max_tokens_per_run,
+                temperature=task.config.temperature,
+                system_prompt=hosted_prompt,
+            )
             agent_run = AgentRun(
                 task=task.task_description,
                 repo_path=task.repo_path,
-                config=task.config,
+                config=agent_config,
                 id=task.id,
             )
             try:
                 await sandbox.start(repo_path=task.repo_path, config=sandbox_config)
                 await react_loop(agent_run, llm, tools, sandbox, event_bus=self._event_bus)
+
+                # Report finalization: recovery pass if report is missing
                 if not record.report_path.exists():
-                    record.error = RunError(
-                        code="report_generation_failed",
-                        message="run completed without writing .agent-forge/report.json",
-                        retryable=False,
+                    self._append_audit_event(
+                        event="run.report_recovery_started",
+                        client_service_id=record.request.client.service_id,
+                        run_id=record.run_id,
+                        request_id=record.request.client.request_id,
+                        profile_id=record.request.profile.id,
+                        submitted_at=record.created_at,
+                        final_status="running",
+                        reason="report missing after primary run; attempting recovery",
+                        request_origin=record.request_origin,
+                        user_agent=record.user_agent,
                     )
-                    raise RuntimeError(record.error.message)
+                    recovery_config = AgentConfig(
+                        model=agent_config.model,
+                        max_iterations=1,
+                        max_tokens_per_run=agent_config.max_tokens_per_run,
+                        temperature=agent_config.temperature,
+                    )
+                    recovery_run = AgentRun(
+                        task=_REPORT_RECOVERY_PROMPT,
+                        repo_path=task.repo_path,
+                        config=recovery_config,
+                        id=f"{task.id}_recovery",
+                    )
+                    # Carry forward conversation history so the model has context
+                    recovery_run.messages = list(agent_run.messages)
+                    await react_loop(
+                        recovery_run, llm, tools, sandbox, event_bus=self._event_bus,
+                    )
+
+                # Post-run validation: existence + JSON + schema
+                self._validate_report_artifact(record)
+
                 record.completed_at = datetime.now(UTC)
                 self._append_audit_event(
                     event="run.completed",

--- a/agent_forge/service/models.py
+++ b/agent_forge/service/models.py
@@ -21,6 +21,8 @@ ErrorCode = Literal[
     "sandbox_start_failed",
     "sandbox_execution_failed",
     "report_generation_failed",
+    "report_invalid_json",
+    "report_schema_invalid",
     "policy_denied",
     "unauthorized",
     "quota_exceeded",

--- a/docs/hosted-service.md
+++ b/docs/hosted-service.md
@@ -203,7 +203,24 @@ Hosted mode writes useful state to disk:
 - `quota_exceeded`: active-run or daily-run limit reached
 - `source_fetch_failed`: the submitted source URI could not be resolved, downloaded, or extracted
 - `sandbox_execution_failed`: run reached the sandbox but failed during execution
-- `report_generation_failed`: agent completed without emitting the expected machine report
+- `report_generation_failed`: agent completed (including recovery pass) without ever writing the report file
+- `report_invalid_json`: report.json exists but contains malformed JSON
+- `report_schema_invalid`: report.json is valid JSON but is missing required schema fields (e.g., `schema_version`, `summary`, `findings`, `stats`)
+
+#### Report Recovery Pass
+
+When the primary agent loop completes without writing `.agent-forge/report.json`,
+the hosted service automatically attempts a **single-turn recovery pass** — one
+additional LLM call that explicitly instructs the model to write the report
+using its existing audit context. This costs one extra LLM round-trip but
+avoids failing runs where the model simply forgot to call `write_file`.
+
+After the recovery pass (or if the primary run already wrote the file), the
+service validates the report:
+
+1. File must exist → otherwise `report_generation_failed`
+2. File must parse as valid JSON → otherwise `report_invalid_json`
+3. JSON must contain all required top-level fields → otherwise `report_schema_invalid`
 
 ### Rollout Guidance
 

--- a/tests/unit/test_service_report_finalization.py
+++ b/tests/unit/test_service_report_finalization.py
@@ -1,0 +1,347 @@
+"""Unit tests for hosted report finalization — validation and recovery logic."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent_forge.config import ForgeConfig, ServiceSettings
+from agent_forge.service.app import _REPORT_REQUIRED_FIELDS, HostedRunRecord, HostedRunService
+from agent_forge.service.models import (
+    ClientRef,
+    ProfileRef,
+    RunRequest,
+    SourceRef,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _minimal_run_request(source_uri: str) -> RunRequest:
+    return RunRequest(
+        schema_version="agent-forge-run-request-v1",
+        client=ClientRef(
+            name="test-client",
+            request_id="req-001",
+            service_id="test-service",
+        ),
+        profile=ProfileRef(
+            id="proof-of-audit-solidity-v1",
+            report_schema="proof-of-audit-report-v1",
+        ),
+        source=SourceRef(
+            kind="local_path",
+            uri=source_uri,
+            entry_contract="Vault",
+        ),
+    )
+
+
+def _make_record(tmp_path: Path) -> HostedRunRecord:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    return HostedRunRecord(
+        run_id="run_test001",
+        request=_minimal_run_request(str(tmp_path / "repo")),
+        workspace_dir=workspace,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _valid_report_payload(run_id: str = "run_test001") -> dict:
+    return {
+        "schema_version": "proof-of-audit-report-v1",
+        "run_id": run_id,
+        "summary": "No issues found.",
+        "confidence": "high",
+        "findings": [],
+        "stats": {
+            "finding_count": 0,
+            "max_severity": None,
+            "severity_breakdown": {
+                "critical": 0,
+                "high": 0,
+                "medium": 0,
+                "low": 0,
+            },
+        },
+    }
+
+
+def _make_service(tmp_path: Path) -> HostedRunService:
+    config = ForgeConfig(
+        service=ServiceSettings(
+            root_dir=str(tmp_path / "service-root"),
+            auth_enabled=False,
+        )
+    )
+    return HostedRunService(service_root=tmp_path / "service-root", config=config)
+
+
+class TestValidateReportArtifact:
+    """Tests for HostedRunService._validate_report_artifact()."""
+
+    def test_missing_report_raises_report_generation_failed(self, tmp_path: Path) -> None:
+        service = _make_service(tmp_path)
+        record = _make_record(tmp_path)
+        # report_path does not exist
+
+        with pytest.raises(RuntimeError, match="run completed without writing"):
+            service._validate_report_artifact(record)
+
+        assert record.error is not None
+        assert record.error.code == "report_generation_failed"
+
+    def test_invalid_json_raises_report_invalid_json(self, tmp_path: Path) -> None:
+        service = _make_service(tmp_path)
+        record = _make_record(tmp_path)
+        record.report_path.parent.mkdir(parents=True, exist_ok=True)
+        record.report_path.write_text("this is not json {{{", encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="not valid JSON"):
+            service._validate_report_artifact(record)
+
+        assert record.error is not None
+        assert record.error.code == "report_invalid_json"
+
+    def test_missing_required_fields_raises_schema_invalid(self, tmp_path: Path) -> None:
+        service = _make_service(tmp_path)
+        record = _make_record(tmp_path)
+        record.report_path.parent.mkdir(parents=True, exist_ok=True)
+        # Valid JSON but missing required fields
+        record.report_path.write_text(
+            json.dumps({"schema_version": "proof-of-audit-report-v1"}),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(RuntimeError, match="missing required fields"):
+            service._validate_report_artifact(record)
+
+        assert record.error is not None
+        assert record.error.code == "report_schema_invalid"
+
+    def test_valid_report_passes_validation(self, tmp_path: Path) -> None:
+        service = _make_service(tmp_path)
+        record = _make_record(tmp_path)
+        record.report_path.parent.mkdir(parents=True, exist_ok=True)
+        record.report_path.write_text(
+            json.dumps(_valid_report_payload()),
+            encoding="utf-8",
+        )
+
+        # Should not raise
+        service._validate_report_artifact(record)
+        assert record.error is None
+
+    def test_all_required_fields_are_checked(self, tmp_path: Path) -> None:
+        """Verify each required field individually causes a validation failure."""
+        service = _make_service(tmp_path)
+        for field_name in _REPORT_REQUIRED_FIELDS:
+            record = _make_record(tmp_path)
+            record.report_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = _valid_report_payload()
+            del payload[field_name]
+            record.report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            with pytest.raises(RuntimeError, match="missing required fields"):
+                service._validate_report_artifact(record)
+
+            assert record.error is not None
+            assert record.error.code == "report_schema_invalid"
+            assert field_name in record.error.message
+
+
+class TestReportRecoveryIntegration:
+    """Tests verifying the recovery pass is triggered when report is missing."""
+
+    @pytest.mark.asyncio
+    async def test_recovery_writes_report_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When recovery writes the report file, the run should succeed."""
+        from agent_forge.agent.models import AgentConfig
+        from agent_forge.orchestration.queue import Task
+
+        service = _make_service(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "Vault.sol").write_text("contract Vault {}\n", encoding="utf-8")
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        task_config = AgentConfig(model="test-model", max_iterations=5)
+        task = Task(
+            id="run_recovery_ok",
+            task_description="Audit this contract",
+            repo_path=str(repo),
+            config=task_config,
+        )
+
+        record = HostedRunRecord(
+            run_id=task.id,
+            request=_minimal_run_request(str(repo)),
+            workspace_dir=repo,
+            created_at=datetime.now(UTC),
+        )
+        service._records[task.id] = record
+
+        call_count = 0
+
+        async def fake_react_loop(run, llm, tools, sandbox, *, event_bus=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                # Recovery pass writes the report
+                record.report_path.parent.mkdir(parents=True, exist_ok=True)
+                record.report_path.write_text(
+                    json.dumps(_valid_report_payload(run_id=task.id)),
+                    encoding="utf-8",
+                )
+            return run
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.start = AsyncMock()
+        mock_sandbox.stop = AsyncMock()
+        mock_sandbox.is_alive = AsyncMock(return_value=True)
+
+        mock_llm = AsyncMock()
+        mock_llm.close = AsyncMock()
+
+        with (
+            patch("agent_forge.service.app.react_loop", side_effect=fake_react_loop),
+            patch("agent_forge.service.app._create_llm", return_value=mock_llm),
+            patch("agent_forge.service.app.create_sandbox", return_value=mock_sandbox),
+            patch("agent_forge.service.app.create_default_registry"),
+        ):
+            runner = service._make_task_runner()
+            await runner(task)
+
+        assert call_count == 2, "recovery pass should have been triggered"
+        assert record.error is None
+        assert record.completed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_recovery_fails_still_missing_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When recovery also fails to write the report, error is raised."""
+        from agent_forge.agent.models import AgentConfig
+        from agent_forge.orchestration.queue import Task
+
+        service = _make_service(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "Vault.sol").write_text("contract Vault {}\n", encoding="utf-8")
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        task_config = AgentConfig(model="test-model", max_iterations=5)
+        task = Task(
+            id="run_recovery_fail",
+            task_description="Audit this contract",
+            repo_path=str(repo),
+            config=task_config,
+        )
+
+        record = HostedRunRecord(
+            run_id=task.id,
+            request=_minimal_run_request(str(repo)),
+            workspace_dir=repo,
+            created_at=datetime.now(UTC),
+        )
+        service._records[task.id] = record
+
+        async def fake_react_loop(run, llm, tools, sandbox, *, event_bus=None):
+            # Never writes the report
+            return run
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.start = AsyncMock()
+        mock_sandbox.stop = AsyncMock()
+        mock_sandbox.is_alive = AsyncMock(return_value=True)
+
+        mock_llm = AsyncMock()
+        mock_llm.close = AsyncMock()
+
+        with (
+            patch("agent_forge.service.app.react_loop", side_effect=fake_react_loop),
+            patch("agent_forge.service.app._create_llm", return_value=mock_llm),
+            patch("agent_forge.service.app.create_sandbox", return_value=mock_sandbox),
+            patch("agent_forge.service.app.create_default_registry"),
+        ):
+            runner = service._make_task_runner()
+            with pytest.raises(RuntimeError, match="run completed without writing"):
+                await runner(task)
+
+        assert record.error is not None
+        assert record.error.code == "report_generation_failed"
+
+    @pytest.mark.asyncio
+    async def test_no_recovery_when_report_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the primary run writes the report, no recovery is attempted."""
+        from agent_forge.agent.models import AgentConfig
+        from agent_forge.orchestration.queue import Task
+
+        service = _make_service(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "Vault.sol").write_text("contract Vault {}\n", encoding="utf-8")
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        task_config = AgentConfig(model="test-model", max_iterations=5)
+        task = Task(
+            id="run_no_recovery",
+            task_description="Audit this contract",
+            repo_path=str(repo),
+            config=task_config,
+        )
+
+        record = HostedRunRecord(
+            run_id=task.id,
+            request=_minimal_run_request(str(repo)),
+            workspace_dir=repo,
+            created_at=datetime.now(UTC),
+        )
+        service._records[task.id] = record
+
+        call_count = 0
+
+        async def fake_react_loop(run, llm, tools, sandbox, *, event_bus=None):
+            nonlocal call_count
+            call_count += 1
+            # Primary run writes the report
+            record.report_path.parent.mkdir(parents=True, exist_ok=True)
+            record.report_path.write_text(
+                json.dumps(_valid_report_payload(run_id=task.id)),
+                encoding="utf-8",
+            )
+            return run
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.start = AsyncMock()
+        mock_sandbox.stop = AsyncMock()
+        mock_sandbox.is_alive = AsyncMock(return_value=True)
+
+        mock_llm = AsyncMock()
+        mock_llm.close = AsyncMock()
+
+        with (
+            patch("agent_forge.service.app.react_loop", side_effect=fake_react_loop),
+            patch("agent_forge.service.app._create_llm", return_value=mock_llm),
+            patch("agent_forge.service.app.create_sandbox", return_value=mock_sandbox),
+            patch("agent_forge.service.app.create_default_registry"),
+        ):
+            runner = service._make_task_runner()
+            await runner(task)
+
+        assert call_count == 1, "recovery should NOT have been triggered"
+        assert record.error is None
+        assert record.completed_at is not None


### PR DESCRIPTION
Hosted `proof-of-audit-solidity-v1` runs could complete `react_loop(...)` successfully but never write `.agent-forge/report.json`, causing a hard `report_generation_failed` error with no recovery or granular diagnostics.

**Changes:**
- Recovery pass: single-turn LLM call with prior context when report missing
- 3-phase validation: existence, JSON parse, required schema fields
- Hosted PoA system prompt with strict report emission language
- New error codes: `report_invalid_json`, `report_schema_invalid`
- 8 new tests covering all validation and recovery branches
- Updated hosted-service.md docs

Closes #115