### PR TITLE
feat(#119): Multi-Instance Service Mode — persona binding & workspace isolation

### DIFF
--- a/agent_forge/cli.py
+++ b/agent_forge/cli.py
@@ -658,7 +658,23 @@ def config() -> None:
     default=None,
     help="Override the hosted service root directory.",
 )
-def serve(host: str | None, port: int | None, service_root: Path | None) -> None:
+@click.option(
+    "--persona",
+    default=None,
+    help="Agent profile to bind this instance to (multi-instance mode).",
+)
+@click.option(
+    "--instance-id",
+    default=None,
+    help="Unique instance ID for workspace isolation (multi-instance mode).",
+)
+def serve(
+    host: str | None,
+    port: int | None,
+    service_root: Path | None,
+    persona: str | None,
+    instance_id: str | None,
+) -> None:
     """Run the hosted FastAPI service."""
     import uvicorn
 
@@ -674,7 +690,12 @@ def serve(host: str | None, port: int | None, service_root: Path | None) -> None
 
     from agent_forge.service import create_app
 
-    app = create_app(service_root=Path(cfg.service.root_dir).expanduser(), config=cfg)
+    app = create_app(
+        service_root=Path(cfg.service.root_dir).expanduser(),
+        config=cfg,
+        instance_id=instance_id,
+        persona=persona,
+    )
     uvicorn.run(app, host=cfg.service.host, port=cfg.service.port)
 
 

--- a/agent_forge/profiles/profile.py
+++ b/agent_forge/profiles/profile.py
@@ -37,6 +37,7 @@ class AgentProfile(BaseModel):
     llm_provider: str | None = None
     llm_model: str | None = None
     max_iterations: int | None = Field(default=None, ge=1)
+    capabilities: list[str] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/agent_forge/service/app.py
+++ b/agent_forge/service/app.py
@@ -104,14 +104,21 @@ class HostedRunService:
         *,
         service_root: Path | None = None,
         config: ForgeConfig | None = None,
+        instance_id: str | None = None,
+        persona: str | None = None,
     ) -> None:
         self._config = config or load_config()
-        self._service_root = service_root or Path(self._config.service.root_dir).expanduser()
+        base_root = service_root or Path(self._config.service.root_dir).expanduser()
+        self._instance_id = instance_id
+        self._persona_id = persona
+        # Isolate workspace per instance when instance_id is set
+        self._service_root = base_root / instance_id if instance_id else base_root
         self._queue = InMemoryQueue()
         self._event_bus = EventBus()
         self._records: dict[str, HostedRunRecord] = {}
         self._client_policies: dict[str, ServiceClientPolicy] = {}
         self._profile_registry: dict[str, AgentProfile] = {}
+        self._resolved_persona: AgentProfile | None = None
         self._audit_log_path = self._service_root / "audit" / "events.jsonl"
         self._worker = Worker(
             queue=self._queue,
@@ -132,6 +139,16 @@ class HostedRunService:
         self._profile_registry = load_profiles(
             plugin_profile_dirs if plugin_profile_dirs else None
         )
+        # Validate and resolve persona if set
+        if self._persona_id is not None:
+            if self._persona_id not in self._profile_registry:
+                available = ", ".join(sorted(self._profile_registry)) or "(none)"
+                msg = (
+                    f"unknown persona profile: '{self._persona_id}'. "
+                    f"Available profiles: {available}"
+                )
+                raise ValueError(msg)
+            self._resolved_persona = self._profile_registry[self._persona_id]
         await self._worker.start()
 
     async def stop(self) -> None:
@@ -1128,10 +1145,17 @@ def create_app(  # noqa: C901
     *,
     service_root: Path | None = None,
     config: ForgeConfig | None = None,
+    instance_id: str | None = None,
+    persona: str | None = None,
 ) -> FastAPI:
     """Create the hosted service ASGI app."""
     resolved_config = config or load_config()
-    service = HostedRunService(service_root=service_root, config=resolved_config)
+    service = HostedRunService(
+        service_root=service_root,
+        config=resolved_config,
+        instance_id=instance_id,
+        persona=persona,
+    )
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> Any:
@@ -1172,11 +1196,20 @@ def create_app(  # noqa: C901
 
     @app.get(resolved_config.service.healthcheck_path, response_model=HealthResponse)
     async def healthcheck() -> HealthResponse:
+        resolved_profile = service._resolved_persona
         return HealthResponse(
             status="ok",
             service_root=str(service._service_root),
             queue_backend=resolved_config.queue.backend,
             sandbox_image=resolved_config.sandbox.image,
+            instance_id=service._instance_id,
+            persona=service._persona_id,
+            capabilities=(
+                resolved_profile.capabilities if resolved_profile else []
+            ),
+            llm_provider=(
+                resolved_profile.llm_provider if resolved_profile else None
+            ),
         )
 
     @app.post("/v1/runs", response_model=RunStatus, status_code=202)

--- a/agent_forge/service/models.py
+++ b/agent_forge/service/models.py
@@ -240,3 +240,8 @@ class HealthResponse(BaseModel):
     service_root: str
     queue_backend: str
     sandbox_image: str
+    # Multi-instance persona metadata
+    instance_id: str | None = None
+    persona: str | None = None
+    capabilities: list[str] = []
+    llm_provider: str | None = None

--- a/tests/unit/test_multi_instance_service.py
+++ b/tests/unit/test_multi_instance_service.py
@@ -1,0 +1,296 @@
+"""Tests for multi-instance service mode (#119).
+
+Validates persona binding, workspace isolation, and health metadata.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from agent_forge.profiles.profile import AgentProfile
+from agent_forge.service.app import HostedRunService, create_app
+from agent_forge.service.models import HealthResponse
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def base_service_root(tmp_path: Path) -> Path:
+    """Create a temporary service root directory."""
+    root = tmp_path / "service"
+    root.mkdir()
+    return root
+
+
+def _minimal_config() -> dict:
+    """Return kwargs for a HostedRunService with no external deps."""
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# HostedRunService — workspace isolation
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceIsolation:
+    """Verify instance_id creates isolated subdirectories."""
+
+    def test_service_root_without_instance_id(self, base_service_root: Path) -> None:
+        """Without instance_id, service_root is used directly."""
+        service = HostedRunService(service_root=base_service_root)
+        assert service._service_root == base_service_root
+
+    def test_service_root_with_instance_id(self, base_service_root: Path) -> None:
+        """With instance_id, service_root includes the instance subdirectory."""
+        service = HostedRunService(
+            service_root=base_service_root, instance_id="agent-01"
+        )
+        assert service._service_root == base_service_root / "agent-01"
+
+    def test_different_instances_get_different_roots(
+        self, base_service_root: Path
+    ) -> None:
+        """Two instances with different IDs get separate workspace roots."""
+        svc_a = HostedRunService(
+            service_root=base_service_root, instance_id="agent-01"
+        )
+        svc_b = HostedRunService(
+            service_root=base_service_root, instance_id="agent-02"
+        )
+        assert svc_a._service_root != svc_b._service_root
+        assert svc_a._service_root.name == "agent-01"
+        assert svc_b._service_root.name == "agent-02"
+
+
+# ---------------------------------------------------------------------------
+# HostedRunService — persona resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaResolution:
+    """Verify persona profile is resolved and validated at startup."""
+
+    @pytest.mark.asyncio
+    async def test_valid_persona_resolves(self, base_service_root: Path) -> None:
+        """A valid persona profile is resolved and stored."""
+        fake_profile = AgentProfile(
+            id="reentrancy-only",
+            name="Reentrancy Specialist",
+            capabilities=["reentrancy"],
+            llm_provider="gemini",
+        )
+        fake_registry = {"reentrancy-only": fake_profile, "gemini": fake_profile}
+
+        service = HostedRunService(
+            service_root=base_service_root,
+            persona="reentrancy-only",
+        )
+
+        with patch(
+            "agent_forge.service.app.load_profiles", return_value=fake_registry
+        ), patch(
+            "agent_forge.service.app.load_client_registry", return_value={}
+        ):
+            await service.start()
+
+        assert service._resolved_persona is not None
+        assert service._resolved_persona.id == "reentrancy-only"
+        assert service._resolved_persona.capabilities == ["reentrancy"]
+
+        await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_invalid_persona_raises(self, base_service_root: Path) -> None:
+        """An unknown persona raises ValueError at startup."""
+        service = HostedRunService(
+            service_root=base_service_root,
+            persona="nonexistent-profile",
+        )
+
+        with patch(
+            "agent_forge.service.app.load_profiles",
+            return_value={"gemini": AgentProfile(id="gemini", name="Gemini")},
+        ), patch(
+            "agent_forge.service.app.load_client_registry", return_value={}
+        ), pytest.raises(ValueError, match="unknown persona profile"):
+            await service.start()
+
+    @pytest.mark.asyncio
+    async def test_no_persona_leaves_resolved_none(
+        self, base_service_root: Path
+    ) -> None:
+        """Without persona, _resolved_persona stays None."""
+        service = HostedRunService(service_root=base_service_root)
+
+        with patch(
+            "agent_forge.service.app.load_profiles", return_value={}
+        ), patch(
+            "agent_forge.service.app.load_client_registry", return_value={}
+        ):
+            await service.start()
+
+        assert service._resolved_persona is None
+        await service.stop()
+
+
+# ---------------------------------------------------------------------------
+# HealthResponse — persona metadata
+# ---------------------------------------------------------------------------
+
+
+class TestHealthResponseModel:
+    """Verify HealthResponse model handles persona fields."""
+
+    def test_health_with_persona_metadata(self) -> None:
+        """HealthResponse includes persona fields when set."""
+        resp = HealthResponse(
+            status="ok",
+            service_root="/tmp/service/agent-01",
+            queue_backend="memory",
+            sandbox_image="agent-forge-sandbox:latest",
+            instance_id="agent-01",
+            persona="reentrancy-only",
+            capabilities=["reentrancy"],
+            llm_provider="gemini",
+        )
+        assert resp.instance_id == "agent-01"
+        assert resp.persona == "reentrancy-only"
+        assert resp.capabilities == ["reentrancy"]
+        assert resp.llm_provider == "gemini"
+
+    def test_health_without_persona_metadata(self) -> None:
+        """HealthResponse defaults to None when persona is not set."""
+        resp = HealthResponse(
+            status="ok",
+            service_root="/tmp/service",
+            queue_backend="memory",
+            sandbox_image="agent-forge-sandbox:latest",
+        )
+        assert resp.instance_id is None
+        assert resp.persona is None
+        assert resp.capabilities == []
+        assert resp.llm_provider is None
+
+    def test_health_serialization_roundtrip(self) -> None:
+        """HealthResponse can serialize and deserialize with persona fields."""
+        resp = HealthResponse(
+            status="ok",
+            service_root="/tmp/service/agent-01",
+            queue_backend="memory",
+            sandbox_image="agent-forge-sandbox:latest",
+            instance_id="agent-01",
+            persona="full-spectrum",
+            capabilities=["reentrancy", "access-control"],
+            llm_provider="openai",
+        )
+        data = resp.model_dump()
+        restored = HealthResponse.model_validate(data)
+        assert restored == resp
+
+
+# ---------------------------------------------------------------------------
+# create_app — integration
+# ---------------------------------------------------------------------------
+
+
+class TestCreateApp:
+    """Verify create_app wires instance_id and persona."""
+
+    def test_create_app_passes_instance_id(self, base_service_root: Path) -> None:
+        """create_app passes instance_id to the HostedRunService."""
+        app = create_app(
+            service_root=base_service_root,
+            instance_id="agent-03",
+        )
+        service = app.state.service
+        assert service._instance_id == "agent-03"
+        assert service._service_root == base_service_root / "agent-03"
+
+    def test_create_app_passes_persona(self, base_service_root: Path) -> None:
+        """create_app passes persona to the HostedRunService."""
+        app = create_app(
+            service_root=base_service_root,
+            persona="reentrancy-only",
+        )
+        service = app.state.service
+        assert service._persona_id == "reentrancy-only"
+
+    def test_create_app_without_multi_instance(
+        self, base_service_root: Path
+    ) -> None:
+        """create_app works without multi-instance params (backward compat)."""
+        app = create_app(service_root=base_service_root)
+        service = app.state.service
+        assert service._instance_id is None
+        assert service._persona_id is None
+        assert service._service_root == base_service_root
+
+
+# ---------------------------------------------------------------------------
+# CLI — serve flags
+# ---------------------------------------------------------------------------
+
+
+class TestServeCLI:
+    """Verify --persona and --instance-id flags are wired."""
+
+    def test_serve_help_shows_persona_flag(self) -> None:
+        """The serve command advertises --persona."""
+        runner = CliRunner()
+        from agent_forge.cli import main
+
+        result = runner.invoke(main, ["serve", "--help"])
+        assert result.exit_code == 0
+        assert "--persona" in result.output
+
+    def test_serve_help_shows_instance_id_flag(self) -> None:
+        """The serve command advertises --instance-id."""
+        runner = CliRunner()
+        from agent_forge.cli import main
+
+        result = runner.invoke(main, ["serve", "--help"])
+        assert result.exit_code == 0
+        assert "--instance-id" in result.output
+
+
+# ---------------------------------------------------------------------------
+# AgentProfile — capabilities field
+# ---------------------------------------------------------------------------
+
+
+class TestAgentProfileCapabilities:
+    """Verify the capabilities field on AgentProfile."""
+
+    def test_capabilities_defaults_to_empty(self) -> None:
+        """Capabilities is an empty list by default."""
+        profile = AgentProfile(id="test", name="Test")
+        assert profile.capabilities == []
+
+    def test_capabilities_from_yaml_data(self) -> None:
+        """Capabilities can be set from YAML-like dict data."""
+        profile = AgentProfile.model_validate({
+            "id": "reentrancy-only",
+            "name": "Reentrancy Specialist",
+            "capabilities": ["reentrancy"],
+            "llm_provider": "gemini",
+        })
+        assert profile.capabilities == ["reentrancy"]
+
+    def test_multiple_capabilities(self) -> None:
+        """Profile supports multiple capabilities."""
+        profile = AgentProfile(
+            id="full-spectrum",
+            name="Full Spectrum",
+            capabilities=["reentrancy", "access-control", "unchecked-calls"],
+        )
+        assert len(profile.capabilities) == 3
+        assert "access-control" in profile.capabilities


### PR DESCRIPTION
## Summary

Multi-instance service mode for concurrent persona-based deployments behind a load balancer.

### Changes

#### `agent_forge/profiles/profile.py`
- Add `capabilities: list[str]` field to `AgentProfile` for explicit persona capability declarations

#### `agent_forge/service/models.py`
- Extend `HealthResponse` with `instance_id`, `persona`, `capabilities`, `llm_provider`

#### `agent_forge/service/app.py`
- `HostedRunService` accepts `instance_id` and `persona` params
- Workspace isolation: `{service_root}/{instance_id}/` when instance_id is set
- Persona validation at startup against profile registry
- `create_app()` wires `instance_id` and `persona` through to service
- Health endpoint returns full persona metadata

#### `agent_forge/cli.py`
- Add `--persona` and `--instance-id` flags to `agent-forge serve`

#### `tests/unit/test_multi_instance_service.py` [NEW]
- 17 tests covering workspace isolation, persona resolution, health metadata, create_app wiring, CLI flags, and capabilities field

### Deployment Model

```
                    ┌─────────────────┐
                    │   Load Balancer  │
                    └────────┬────────┘
         ┌──────────────┬────┴─────┬──────────────┐
    ┌────┴────┐   ┌─────┴───┐ ┌───┴─────┐  ┌─────┴─────┐
    │ :8001   │   │ :8002   │ │ :8003   │  │ :8004     │
    │ reentry │   │ access  │ │ full    │  │ gemini    │
    └─────────┘   └─────────┘ └─────────┘  └───────────┘
```

Closes #119