### PR TITLE
docs(#119): multi-instance mode guide + mandatory docs rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,17 @@ Document any new env var in `docs/spec.md § Configuration` and the project's `a
 
 7. **Automatically run `/finish-issue` when completing work.** When work on any issue or task is done, **always execute every step** in `.agents/workflows/finish-issue.md` — verify coverage, run tests, lint, commit, push, open PR, wait for CI green, and merge. This workflow is mandatory, not optional. Do not skip steps or ask whether to run it.
 
+8. **Update documentation with every user-facing change.** Any change that
+   modifies CLI flags, API endpoints, configuration options, deployment
+   topology, or observable behavior **must** include corresponding documentation
+   updates in the same branch. Review and update as needed:
+   - `README.md` — features, project structure, usage examples
+   - `docs/` — architecture, configuration, hosted-service, extending, testing
+   - `docs/spec.md` — technical specification, interface contracts
+   - Inline docstrings in changed modules
+   
+   Skip only for purely internal refactors with zero user-facing impact.
+
 ---
 
 ## Architecture Conventions

--- a/docs/hosted-service.md
+++ b/docs/hosted-service.md
@@ -64,6 +64,45 @@ deployments:
 - a persistent volume stores service data and audit artifacts
 - the Docker socket is mounted so the hosted service can start per-run sandboxes
 
+### Multi-Instance Mode
+
+For production deployments, multiple instances can run concurrently behind a
+load balancer, each bound to a specific **persona** (agent profile):
+
+```
+                    ┌─────────────────┐
+                    │   Load Balancer  │
+                    └────────┬────────┘
+         ┌──────────────┬────┴─────┬──────────────┐
+    ┌────┴────┐   ┌─────┴───┐ ┌───┴─────┐  ┌─────┴─────┐
+    │ :8001   │   │ :8002   │ │ :8003   │  │ :8004     │
+    │ reentry │   │ access  │ │ full    │  │ gemini    │
+    └─────────┘   └─────────┘ └─────────┘  └───────────┘
+```
+
+```bash
+# Instance 1: reentrancy specialist
+agent-forge serve --port 8001 --persona reentrancy-only --instance-id agent-01
+
+# Instance 2: access control specialist
+agent-forge serve --port 8002 --persona access-control-only --instance-id agent-02
+
+# Instance 3: full spectrum
+agent-forge serve --port 8003 --persona full-spectrum --instance-id agent-03
+```
+
+Key behavior:
+
+- **`--persona`**: binds the instance to a specific agent profile from the
+  profile registry. The persona is validated at startup — unknown profiles
+  cause an immediate error. The health endpoint reports the persona's
+  capabilities and LLM provider.
+- **`--instance-id`**: isolates the workspace under
+  `{service.root_dir}/{instance-id}/` so instances sharing a disk never
+  collide on source material, audit logs, or run artifacts.
+- Both flags are optional. Without them, the service runs in single-instance
+  mode exactly as before (backward compatible).
+
 ## Hosted Configuration
 
 Hosted mode extends the standard config with a `service` section:
@@ -159,7 +198,12 @@ variables explicitly or the service will fall back to repo defaults.
 ### 4. Run The Hosted Service
 
 ```bash
+# Single-instance mode (default)
 agent-forge serve --host 127.0.0.1 --port 8000
+
+# Multi-instance mode with persona binding
+agent-forge serve --host 0.0.0.0 --port 8001 \
+  --persona reentrancy-only --instance-id agent-01
 ```
 
 Or use compose:
@@ -186,6 +230,23 @@ curl -X POST http://127.0.0.1:8000/v1/runs \
 
 - `GET /healthz` returns readiness information for the current service process
 - compose uses this endpoint for container health
+
+The health response includes multi-instance persona metadata when available:
+
+```json
+{
+  "status": "ok",
+  "service_root": "/var/lib/agent-forge/service/agent-01",
+  "queue_backend": "memory",
+  "sandbox_image": "agent-forge-sandbox:latest",
+  "instance_id": "agent-01",
+  "persona": "reentrancy-only",
+  "capabilities": ["reentrancy"],
+  "llm_provider": "gemini"
+}
+```
+
+Without `--persona` / `--instance-id`, the extra fields default to `null` / `[]`.
 
 ### Artifact Locations
 


### PR DESCRIPTION
## Summary

Follow-up documentation for #119 multi-instance service mode, plus a new mandatory docs rule in AGENTS.md.

### Changes

#### `AGENTS.md`
- Add **rule 8**: mandate documentation updates in-branch for any user-facing change (CLI flags, APIs, config, deployment topology)

#### `docs/hosted-service.md`
- Add **Multi-Instance Mode** section with LB topology diagram and CLI examples
- Update **Run The Hosted Service** section with `--persona` and `--instance-id` flags
- Update **Health Checks** section with enriched response JSON (instance_id, persona, capabilities, llm_provider)

Closes #119