### PR TITLE
feat(#120): Extension SDK — scaffolding, discovery, and auto-registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ graph TD
 - **🔌 Multi-Provider LLM** — Gemini (primary), OpenAI, and Anthropic adapters, all wired through a pluggable factory.
 - **🎭 Agent Profiles** — YAML-based personas with configurable prompt scope, LLM overrides, and iteration limits.
 - **🌐 Hosted Service Mode** — Run Agent Forge as a versioned FastAPI service for external clients with API-key auth, policy controls, and Proof-of-Audit compatibility.
-- **🧩 Extension Architecture** — Domain-agnostic core with a plugin layer for specialized capabilities (profiles, tools, CLIs). Extensions can be separate installable packages.
+- **🧩 Extension SDK** — Scaffold, build, and install domain-specific extensions as separate packages with `agent-forge init-extension`. Auto-discovers profiles, tools, and metadata via Python entry points.
 - **📊 Observability** — Structured JSON logs, trace IDs, token/cost tracking on every run.
 - **💾 Run Persistence** — Every agent run is saved to disk with full conversation history and tool invocations.
 - **🔧 Tool Plugins** — Add tools via the `Tool` ABC and ship them as entry-point packages that load automatically.
@@ -206,6 +206,7 @@ make format
 ```
 agent_forge/
 ├── agent/         # ReAct loop, state machine, prompts, persistence
+├── extensions/    # Extension SDK (discovery, scaffolding, templates)
 ├── llm/           # LLM provider adapters (Gemini, OpenAI, Anthropic) + factory
 ├── profiles/      # Agent profile system (YAML personas + loader)
 ├── tools/         # Built-in tools + entry-point plugin loader
@@ -227,7 +228,7 @@ plugins/
 - **[Configuration](docs/configuration.md)** — Full config reference (TOML, env vars, CLI flags, precedence).
 - **[Hosted Service](docs/hosted-service.md)** — Hosted architecture, trust boundaries, local-dev, and operations.
 - **[Testing](docs/testing.md)** — Running tests, writing new ones, CI workflows, coverage.
-- **[Extending](docs/extending.md)** — Adding tools, LLM providers, custom sandbox configs.
+- **[Extending](docs/extending.md)** — Adding tools, LLM providers, Extension SDK, custom sandbox configs.
 - **[Technical Spec](docs/spec.md)** — Full specification with interface contracts and data models.
 
 ---

--- a/agent_forge/cli.py
+++ b/agent_forge/cli.py
@@ -699,5 +699,118 @@ def serve(
     uvicorn.run(app, host=cfg.service.host, port=cfg.service.port)
 
 
+# ---------------------------------------------------------------------------
+# extensions
+# ---------------------------------------------------------------------------
+
+
+@main.group()
+def extensions() -> None:
+    """Manage Agent Forge extensions."""
+
+
+@extensions.command("list")
+def extensions_list() -> None:
+    """List installed Agent Forge extensions."""
+    from agent_forge.extensions.discovery import (
+        discover_extension_profile_dirs,
+        discover_extensions,
+    )
+    from agent_forge.tools.plugins import discover_tool_plugins
+
+    exts = discover_extensions()
+
+    # Also discover standalone profile dirs and tool plugins for
+    # extensions that only register profiles or tools (no metadata).
+    profile_dirs = discover_extension_profile_dirs()
+    tool_plugins = discover_tool_plugins()
+
+    if not exts and not profile_dirs and not tool_plugins:
+        console.print("[dim]No extensions installed.[/dim]")
+        return
+
+    table = Table(title="Installed Extensions")
+    table.add_column("Extension", style="cyan")
+    table.add_column("Version", justify="center")
+    table.add_column("Profiles", style="green")
+    table.add_column("Tools", style="yellow")
+    table.add_column("Description")
+
+    for ext in exts:
+        table.add_row(
+            ext.name,
+            ext.version or "—",
+            ", ".join(ext.profiles) if ext.profiles else "—",
+            ", ".join(ext.tools) if ext.tools else "—",
+            ext.description or "—",
+        )
+
+    # Show orphan profile dirs (registered via agent_forge.profiles but
+    # not via agent_forge.extensions).
+    known_names = {ext.name for ext in exts}
+    for pdir in profile_dirs:
+        if pdir.name not in known_names:
+            table.add_row(
+                f"(profiles: {pdir.name})",
+                "—",
+                str(pdir),
+                "—",
+                "Profile directory (no extension metadata)",
+            )
+
+    # Show orphan tool plugins.
+    known_tools: set[str] = set()
+    for ext in exts:
+        known_tools.update(ext.tools)
+    for tp in tool_plugins:
+        if tp.name not in known_tools:
+            table.add_row(
+                f"(tool: {tp.name})",
+                "—",
+                "—",
+                tp.name,
+                f"Tool plugin ({tp.value})",
+            )
+
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# init-extension
+# ---------------------------------------------------------------------------
+
+
+@main.command("init-extension")
+@click.argument("name")
+@click.option(
+    "--target-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Parent directory to create the project in (defaults to cwd).",
+)
+def init_extension(name: str, target_dir: Path | None) -> None:
+    """Scaffold a new Agent Forge extension project.
+
+    Creates a canonical extension project structure with pre-configured
+    entry points, a sample profile, and a sample tool.
+    """
+    from agent_forge.extensions.scaffolding import ScaffoldError, scaffold_extension
+
+    try:
+        project_path = scaffold_extension(name, target_dir=target_dir)
+    except ScaffoldError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        sys.exit(1)
+
+    console.print(f"[green]✓[/green] Extension project created at [bold]{project_path}[/bold]")
+    console.print()
+    console.print("Next steps:")
+    console.print(f"  cd {project_path.name}")
+    console.print("  pip install -e '.[dev]'")
+    console.print("  pytest")
+    console.print("  agent-forge extensions list")
+
+
 if __name__ == "__main__":
     main()
+

--- a/agent_forge/extensions/__init__.py
+++ b/agent_forge/extensions/__init__.py
@@ -1,0 +1,15 @@
+"""Extension SDK — discover, scaffold, and manage Agent Forge extensions."""
+
+from agent_forge.extensions.discovery import (
+    EXTENSION_PLUGIN_GROUP,
+    PROFILE_PLUGIN_GROUP,
+    ExtensionInfo,
+    discover_extensions,
+)
+
+__all__ = [
+    "EXTENSION_PLUGIN_GROUP",
+    "PROFILE_PLUGIN_GROUP",
+    "ExtensionInfo",
+    "discover_extensions",
+]

--- a/agent_forge/extensions/discovery.py
+++ b/agent_forge/extensions/discovery.py
@@ -1,0 +1,173 @@
+"""Extension discovery — scan entry_points for installed extensions.
+
+Discovers extensions registered via three Python entry-point groups:
+
+- ``agent_forge.extensions`` — extension metadata (``ExtensionInfo``)
+- ``agent_forge.profiles`` — profile directories (``Path``)
+- ``agent_forge.tools`` — tool plugins (handled by ``tools.plugins``)
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from importlib.metadata import EntryPoint, entry_points
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+EXTENSION_PLUGIN_GROUP = "agent_forge.extensions"
+PROFILE_PLUGIN_GROUP = "agent_forge.profiles"
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExtensionInfo:
+    """Metadata for an installed Agent Forge extension."""
+
+    name: str
+    version: str = ""
+    description: str = ""
+    package: str = ""
+    profiles: list[str] = field(default_factory=list)
+    tools: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Generic entry-point helpers
+# ---------------------------------------------------------------------------
+
+EntryPointIterable = Iterable[EntryPoint]
+EntryPointsFactory = Callable[[str], EntryPointIterable]
+
+
+def _default_entry_points(group: str) -> EntryPointIterable:
+    """Return entry points for a given group."""
+    return entry_points(group=group)
+
+
+# ---------------------------------------------------------------------------
+# Extension discovery
+# ---------------------------------------------------------------------------
+
+
+def _load_extension_info(ep: EntryPoint) -> ExtensionInfo | None:
+    """Load a single ``agent_forge.extensions`` entry point.
+
+    Returns ``None`` (with a warning) if the entry point cannot be loaded.
+    """
+    try:
+        loaded = ep.load()
+    except (ImportError, AttributeError, ModuleNotFoundError):
+        logger.warning("Failed to load extension entry point '%s'", ep.name, exc_info=True)
+        return None
+
+    if isinstance(loaded, ExtensionInfo):
+        return loaded
+
+    # Allow a callable that returns ExtensionInfo
+    if callable(loaded):
+        try:
+            result = loaded()
+            if isinstance(result, ExtensionInfo):
+                return result
+        except (TypeError, ValueError, RuntimeError):
+            logger.warning(
+                "Extension factory '%s' raised an error", ep.name, exc_info=True
+            )
+            return None
+
+    logger.warning(
+        "Extension entry point '%s' did not resolve to ExtensionInfo (got %s)",
+        ep.name,
+        type(loaded).__name__,
+    )
+    return None
+
+
+def discover_extensions(
+    *,
+    entry_points_factory: EntryPointsFactory | None = None,
+) -> list[ExtensionInfo]:
+    """Discover all installed Agent Forge extensions.
+
+    Scans the ``agent_forge.extensions`` entry-point group. Each entry
+    point should resolve to an :class:`ExtensionInfo` instance or a
+    zero-argument callable returning one.
+
+    Args:
+        entry_points_factory: Override for testing. Receives a group name
+            string and returns an iterable of ``EntryPoint``.
+
+    Returns:
+        Sorted list of discovered extensions.
+    """
+    factory = entry_points_factory or _default_entry_points
+    eps = sorted(factory(EXTENSION_PLUGIN_GROUP), key=lambda ep: ep.name)
+
+    extensions: list[ExtensionInfo] = []
+    for ep in eps:
+        info = _load_extension_info(ep)
+        if info is not None:
+            extensions.append(info)
+
+    return extensions
+
+
+# ---------------------------------------------------------------------------
+# Profile directory discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_extension_profile_dirs(
+    *,
+    entry_points_factory: EntryPointsFactory | None = None,
+) -> list[Path]:
+    """Discover profile directories from installed extensions.
+
+    Scans the ``agent_forge.profiles`` entry-point group. Each entry
+    point should resolve to a :class:`Path` pointing to a directory
+    containing YAML profile files.
+
+    Args:
+        entry_points_factory: Override for testing.
+
+    Returns:
+        List of valid profile directories from installed extensions.
+    """
+    factory = entry_points_factory or _default_entry_points
+    eps = sorted(factory(PROFILE_PLUGIN_GROUP), key=lambda ep: ep.name)
+
+    dirs: list[Path] = []
+    for ep in eps:
+        try:
+            loaded: Any = ep.load()
+        except (ImportError, AttributeError, ModuleNotFoundError):
+            logger.warning(
+                "Failed to load profile entry point '%s'", ep.name, exc_info=True
+            )
+            continue
+
+        if isinstance(loaded, Path):
+            if loaded.is_dir():
+                dirs.append(loaded)
+            else:
+                logger.warning(
+                    "Profile entry point '%s' resolved to a non-directory path: %s",
+                    ep.name,
+                    loaded,
+                )
+        else:
+            logger.warning(
+                "Profile entry point '%s' did not resolve to a Path (got %s)",
+                ep.name,
+                type(loaded).__name__,
+            )
+
+    return dirs

--- a/agent_forge/extensions/scaffolding.py
+++ b/agent_forge/extensions/scaffolding.py
@@ -1,0 +1,140 @@
+"""Extension scaffolding — generate new extension project structure.
+
+The ``scaffold_extension`` function creates a canonical extension project
+with pre-configured entry points, a sample profile, a sample tool, and
+a test file.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from string import Template
+
+# ---------------------------------------------------------------------------
+# Naming helpers
+# ---------------------------------------------------------------------------
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+
+def _to_package_name(name: str) -> str:
+    """Convert an extension name to a valid Python package name.
+
+    ``my-security-scanner`` → ``my_security_scanner``
+    """
+    return re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+
+
+def _to_class_prefix(name: str) -> str:
+    """Convert an extension name to a CamelCase class prefix.
+
+    ``my-security-scanner`` → ``MySecurityScanner``
+    """
+    return "".join(word.capitalize() for word in re.split(r"[^a-zA-Z0-9]+", name) if word)
+
+
+# ---------------------------------------------------------------------------
+# Template rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_template(template_path: Path, context: dict[str, str]) -> str:
+    """Read a template file and substitute ``$placeholders``.
+
+    Uses :class:`string.Template` for safe, dependency-free substitution.
+    """
+    raw = template_path.read_text(encoding="utf-8")
+    return Template(raw).safe_substitute(context)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class ScaffoldError(ValueError):
+    """Raised when scaffolding fails."""
+
+
+def scaffold_extension(name: str, target_dir: Path | None = None) -> Path:
+    """Create a new Agent Forge extension project.
+
+    Args:
+        name: Human-readable extension name (e.g. ``my-security-scanner``).
+        target_dir: Parent directory to create the project in.
+            Defaults to the current working directory.
+
+    Returns:
+        Path to the created project root directory.
+
+    Raises:
+        ScaffoldError: If the target directory already exists or the
+            name is invalid.
+    """
+    if not name or not re.match(r"^[a-zA-Z][a-zA-Z0-9_-]*$", name):
+        msg = (
+            f"Invalid extension name: '{name}'. "
+            "Must start with a letter and contain only letters, digits, hyphens, underscores."
+        )
+        raise ScaffoldError(msg)
+
+    package_name = _to_package_name(name)
+    class_prefix = _to_class_prefix(name)
+
+    parent = target_dir or Path.cwd()
+    project_root = parent / name
+
+    if project_root.exists():
+        msg = f"Directory already exists: {project_root}"
+        raise ScaffoldError(msg)
+
+    # Build substitution context
+    context = {
+        "extension_name": name,
+        "package_name": package_name,
+        "class_prefix": class_prefix,
+    }
+
+    # Create directory structure
+    pkg_dir = project_root / package_name
+    (pkg_dir / "profiles").mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "tools").mkdir(parents=True, exist_ok=True)
+    (project_root / "tests").mkdir(parents=True, exist_ok=True)
+
+    # Render and write templates
+    _write_template("pyproject.toml.template", project_root / "pyproject.toml", context)
+    _write_template("README.md.template", project_root / "README.md", context)
+    _write_template("__init__.py.template", pkg_dir / "__init__.py", context)
+    _write_template(
+        "profiles/default.yaml.template",
+        pkg_dir / "profiles" / "default.yaml",
+        context,
+    )
+    _write_template(
+        "tools/sample_tool.py.template",
+        pkg_dir / "tools" / "sample_tool.py",
+        context,
+    )
+    # Tools __init__ (empty)
+    (pkg_dir / "tools" / "__init__.py").write_text(
+        f'"""Tools for the {name} extension."""\n', encoding="utf-8"
+    )
+    _write_template(
+        "tests/test_sample_tool.py.template",
+        project_root / "tests" / "test_sample_tool.py",
+        context,
+    )
+
+    return project_root
+
+
+def _write_template(template_name: str, output_path: Path, context: dict[str, str]) -> None:
+    """Render a template and write it to the output path."""
+    template_path = _TEMPLATES_DIR / template_name
+    if not template_path.is_file():
+        msg = f"Template not found: {template_path}"
+        raise ScaffoldError(msg)
+
+    content = _render_template(template_path, context)
+    output_path.write_text(content, encoding="utf-8")

--- a/agent_forge/extensions/templates/README.md.template
+++ b/agent_forge/extensions/templates/README.md.template
@@ -1,0 +1,53 @@
+# $extension_name
+
+An [Agent Forge](https://github.com/akoita/agent-forge) extension.
+
+## Installation
+
+```bash
+pip install agent-forge-$extension_name
+```
+
+Or for development:
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+Once installed, the extension is automatically discovered by Agent Forge:
+
+```bash
+# List installed extensions
+agent-forge extensions list
+
+# Use the default profile
+agent-forge run --profile $package_name-default --task "Your task" --repo ./your-repo
+```
+
+## Development
+
+```bash
+# Install in development mode with test dependencies
+pip install -e ".[dev]"
+
+# Run tests
+pytest
+```
+
+## Project Structure
+
+```
+$extension_name/
+├── pyproject.toml
+├── README.md
+├── $package_name/
+│   ├── __init__.py           # Extension metadata
+│   ├── profiles/
+│   │   └── default.yaml      # Agent profiles
+│   └── tools/
+│       └── sample_tool.py    # Custom tools
+└── tests/
+    └── test_sample_tool.py
+```

--- a/agent_forge/extensions/templates/__init__.py.template
+++ b/agent_forge/extensions/templates/__init__.py.template
@@ -1,0 +1,18 @@
+"""$extension_name — Agent Forge extension."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_forge.extensions.discovery import ExtensionInfo
+
+PROFILES_DIR = Path(__file__).parent / "profiles"
+
+extension_info = ExtensionInfo(
+    name="$extension_name",
+    version="0.1.0",
+    description="Agent Forge extension: $extension_name",
+    package="agent-forge-$extension_name",
+    profiles=["$package_name-default"],
+    tools=[],
+)

--- a/agent_forge/extensions/templates/profiles/default.yaml.template
+++ b/agent_forge/extensions/templates/profiles/default.yaml.template
@@ -1,0 +1,6 @@
+id: "$package_name-default"
+name: "$class_prefix Default Profile"
+description: "Default profile for the $extension_name extension."
+prompt_scope: |
+  You are an agent specialized for $extension_name tasks.
+  Follow best practices and produce actionable results.

--- a/agent_forge/extensions/templates/pyproject.toml.template
+++ b/agent_forge/extensions/templates/pyproject.toml.template
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-forge-$extension_name"
+version = "0.1.0"
+description = "Agent Forge extension: $extension_name"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.11"
+dependencies = [
+    "agent-forge",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+]
+
+[project.entry-points."agent_forge.extensions"]
+$extension_name = "$package_name:extension_info"
+
+[project.entry-points."agent_forge.profiles"]
+$extension_name = "$package_name:PROFILES_DIR"
+
+[project.entry-points."agent_forge.tools"]
+# Register tools here, e.g.:
+# ${package_name}_sample = "$package_name.tools.sample_tool:${class_prefix}SampleTool"
+
+[tool.hatch.build.targets.wheel]
+packages = ["$package_name"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"$package_name/profiles" = "$package_name/profiles"

--- a/agent_forge/extensions/templates/tests/test_sample_tool.py.template
+++ b/agent_forge/extensions/templates/tests/test_sample_tool.py.template
@@ -1,0 +1,28 @@
+"""Tests for the $extension_name sample tool."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from $package_name.tools.sample_tool import ${class_prefix}SampleTool
+
+
+@pytest.mark.asyncio
+async def test_sample_tool_returns_output() -> None:
+    tool = ${class_prefix}SampleTool()
+    sandbox = AsyncMock()
+
+    result = await tool.execute({"input": "hello"}, sandbox)
+
+    assert result.output == "Processed: hello"
+    assert result.exit_code == 0
+
+
+def test_sample_tool_metadata() -> None:
+    tool = ${class_prefix}SampleTool()
+
+    assert tool.name == "${package_name}_sample"
+    assert tool.description
+    assert "input" in tool.parameters["properties"]

--- a/agent_forge/extensions/templates/tools/sample_tool.py.template
+++ b/agent_forge/extensions/templates/tools/sample_tool.py.template
@@ -1,0 +1,42 @@
+"""Sample tool for the $extension_name extension."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_forge.tools.base import Tool, ToolResult
+
+if TYPE_CHECKING:
+    from agent_forge.sandbox.base import Sandbox
+
+
+class ${class_prefix}SampleTool(Tool):
+    """A sample tool — replace with your domain-specific implementation."""
+
+    @property
+    def name(self) -> str:
+        return "${package_name}_sample"
+
+    @property
+    def description(self) -> str:
+        return "Sample tool for $extension_name. Replace with your implementation."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "input": {
+                    "type": "string",
+                    "description": "Input to process.",
+                },
+            },
+            "required": ["input"],
+        }
+
+    async def execute(self, arguments: dict[str, Any], sandbox: Sandbox) -> ToolResult:
+        input_val = arguments.get("input", "")
+        return ToolResult(
+            output=f"Processed: {input_val}",
+            exit_code=0,
+        )

--- a/agent_forge/profiles/profile.py
+++ b/agent_forge/profiles/profile.py
@@ -59,23 +59,41 @@ def load_profiles(
     dirs: list[Path] | None = None,
     *,
     include_builtins: bool = True,
+    discover_entry_points: bool = True,
 ) -> dict[str, AgentProfile]:
     """Load agent profiles from one or more directories.
+
+    Precedence (later overrides earlier on duplicate ``id``):
+
+    1. Built-in profiles (``agent_forge/profiles/builtins/``)
+    2. Extension profiles (``agent_forge.profiles`` entry-point group)
+    3. User-provided directories (``--profiles-dir``)
 
     Args:
         dirs: Additional directories to scan for ``*.yaml``/``*.yml`` files.
             Later directories override earlier ones on duplicate ``id``.
         include_builtins: If ``True`` (default), load the built-in profiles
             shipped with the package before any user-provided directories.
+        discover_entry_points: If ``True`` (default), discover profile
+            directories from installed extensions via the
+            ``agent_forge.profiles`` entry-point group.
 
     Returns:
         A mapping of profile ``id`` → ``AgentProfile``.
     """
     scan_dirs: list[Path] = []
 
+    # Layer 1: Built-in profiles (lowest precedence)
     if include_builtins and _BUILTIN_PROFILES_DIR.is_dir():
         scan_dirs.append(_BUILTIN_PROFILES_DIR)
 
+    # Layer 2: Extension profiles (entry-point discovery)
+    if discover_entry_points:
+        from agent_forge.extensions.discovery import discover_extension_profile_dirs
+
+        scan_dirs.extend(discover_extension_profile_dirs())
+
+    # Layer 3: User-provided directories (highest precedence)
     if dirs:
         scan_dirs.extend(dirs)
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -254,54 +254,101 @@ Profiles from `--profiles-dir` override built-ins on duplicate `id`.
 
 ### Plugin Profiles
 
-Domain-specific profiles live in the plugin's `profiles/` directory:
+Domain-specific profiles can be discovered from installed extensions via the
+`agent_forge.profiles` entry-point group (see [Extension SDK](#extension-sdk)
+below), or specified manually with `--profiles-dir`:
 
-```
-plugins/
-└── proof_of_audit/
-    └── profiles/
-        ├── full-spectrum.yaml
-        ├── reentrancy-only.yaml
-        └── access-control-only.yaml
+```bash
+agent-forge run --profiles-dir ./my-profiles --profile my-custom --task "..."
 ```
 
-The hosted service auto-discovers plugin profiles from `plugins/*/profiles/`
-at startup and merges them into the profile registry.
+Profile precedence (later wins on duplicate `id`):
+
+1. Built-in profiles (`agent_forge/profiles/builtins/`)
+2. Extension profiles (`agent_forge.profiles` entry-point group)
+3. User-provided directories (`--profiles-dir`)
 
 ---
 
-## Building Domain Extensions
+## Extension SDK
+
+Agent Forge includes a scaffolding CLI and auto-discovery system for building
+and installing domain-specific extensions as separate Python packages.
+
+### Quick Start
+
+```bash
+# Scaffold a new extension project
+agent-forge init-extension my-security-scanner
+
+# Develop and install locally
+cd my-security-scanner
+pip install -e '.[dev]'
+pytest
+
+# Verify it's discovered
+agent-forge extensions list
+```
+
+### Scaffold Structure
+
+Running `agent-forge init-extension my-security-scanner` creates:
+
+```
+my-security-scanner/
+├── pyproject.toml                        # entry_points pre-configured
+├── README.md
+├── my_security_scanner/
+│   ├── __init__.py                       # ExtensionInfo + PROFILES_DIR
+│   ├── profiles/
+│   │   └── default.yaml                  # Sample agent profile
+│   └── tools/
+│       ├── __init__.py
+│       └── sample_tool.py                # Sample Tool subclass
+└── tests/
+    └── test_sample_tool.py               # Sample test
+```
+
+### Entry-Point Groups
+
+Extensions register themselves via three Python entry-point groups in
+`pyproject.toml`:
+
+| Group                     | Purpose                          | Resolves To       |
+| ------------------------- | -------------------------------- | ------------------ |
+| `agent_forge.extensions`  | Extension metadata               | `ExtensionInfo`    |
+| `agent_forge.profiles`    | Profile directories              | `pathlib.Path`     |
+| `agent_forge.tools`       | Tool plugins                     | `Tool` subclass    |
+
+Example `pyproject.toml`:
+
+```toml
+[project.entry-points."agent_forge.extensions"]
+my-security-scanner = "my_security_scanner:extension_info"
+
+[project.entry-points."agent_forge.profiles"]
+my-security-scanner = "my_security_scanner:PROFILES_DIR"
+
+[project.entry-points."agent_forge.tools"]
+my_scanner_tool = "my_security_scanner.tools.scanner:ScannerTool"
+```
+
+### Managing Extensions
+
+```bash
+# List all installed extensions, profiles, and tools
+agent-forge extensions list
+```
+
+This displays a Rich table showing each extension's name, version, profiles,
+and tools.
+
+### Building Domain Extensions
 
 Agent Forge follows a **domain-agnostic core** design. All domain-specific
-functionality belongs in the **extension layer** (`plugins/`), never in
-`agent_forge/`.
+functionality belongs in the **extension layer**, never in `agent_forge/`.
 
-### Plugin Structure
-
-```
-plugins/
-└── my_domain/
-    ├── __init__.py           # Package init
-    ├── models.py             # Pydantic models
-    ├── logic.py              # Domain-specific logic
-    ├── cli.py                # Standalone Click CLI (optional)
-    ├── README.md             # Plugin documentation
-    └── profiles/             # Agent profiles (auto-discovered)
-        └── my-profile.yaml
-```
-
-### First-Party Example
-
-`plugins/proof_of_audit/` is the reference implementation:
-
-| Module        | Purpose                                                  |
-| ------------- | -------------------------------------------------------- |
-| `models.py`   | `ChallengeEvidence`, `MissedFinding` Pydantic models     |
-| `challenge.py`| Comparison engine (pure + LLM-enhanced)                  |
-| `cli.py`      | `agent-forge-poa challenge-evidence` Click CLI            |
-| `profiles/`   | Audit-specific agent profiles (full-spectrum, etc.)      |
-
-### Extension Rules
+#### Extension Rules
 
 1. **Core packages must not import domain-specific concepts.** Terms like
    "reentrancy", "vulnerability", "detector" belong in extension code only.
@@ -309,12 +356,11 @@ plugins/
    (generic), not `detectors` (audit-specific).
 3. **Domain features are delivered via extensions** — profiles, tools,
    prompts, and workflows.
-4. **Tests for extensions live alongside the plugin** or in
-   `tests/unit/test_<plugin>.py`.
+4. **Tests for extensions** live in the extension package.
 
-### Distribution Model
+#### Distribution Model
 
-Extensions can be **separate installable packages**:
+Extensions are **separate installable packages**:
 
 ```bash
 pip install agent-forge                        # core framework
@@ -322,11 +368,8 @@ pip install agent-forge-proof-of-audit         # audit profiles, tools
 pip install agent-forge-web-security           # hypothetical extension
 ```
 
-Runtime discovery uses:
-
-- **`entry_points`** — Python's standard plugin mechanism
-- **`--profiles-dir`** — CLI flag for profile directories
-- **Config** — `agent-forge.toml` can declare extension paths
+Runtime discovery uses Python's standard `entry_points` mechanism — no
+configuration needed. Install the extension and it's automatically available.
 
 ---
 

--- a/tests/unit/test_cli_extensions.py
+++ b/tests/unit/test_cli_extensions.py
@@ -1,0 +1,142 @@
+"""Unit tests for the extension CLI commands (#120)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from agent_forge.cli import main
+from agent_forge.extensions.discovery import ExtensionInfo
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# agent-forge extensions list
+# ---------------------------------------------------------------------------
+
+
+class TestExtensionsList:
+    """Test the ``agent-forge extensions list`` CLI command."""
+
+    def test_no_extensions(self) -> None:
+        """Empty extensions → informative message."""
+        runner = CliRunner()
+
+        with (
+            patch(
+                "agent_forge.extensions.discovery.discover_extensions",
+                return_value=[],
+            ),
+            patch(
+                "agent_forge.extensions.discovery.discover_extension_profile_dirs",
+                return_value=[],
+            ),
+            patch(
+                "agent_forge.tools.plugins.discover_tool_plugins",
+                return_value=[],
+            ),
+        ):
+            result = runner.invoke(main, ["extensions", "list"])
+
+        assert result.exit_code == 0
+        assert "No extensions installed" in result.output
+
+    def test_with_extensions(self) -> None:
+        """Installed extensions are rendered in a table."""
+        runner = CliRunner()
+
+        ext = ExtensionInfo(
+            name="proof-of-audit",
+            version="0.1.0",
+            description="Smart contract audit tools",
+            profiles=["full-spectrum", "reentrancy-only"],
+            tools=["challenge_tool"],
+        )
+
+        with (
+            patch(
+                "agent_forge.extensions.discovery.discover_extensions",
+                return_value=[ext],
+            ),
+            patch(
+                "agent_forge.extensions.discovery.discover_extension_profile_dirs",
+                return_value=[],
+            ),
+            patch(
+                "agent_forge.tools.plugins.discover_tool_plugins",
+                return_value=[],
+            ),
+        ):
+            result = runner.invoke(main, ["extensions", "list"])
+
+        assert result.exit_code == 0
+        assert "proof-of-audit" in result.output
+        assert "0.1.0" in result.output
+
+    def test_help(self) -> None:
+        """extensions list --help should work."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["extensions", "list", "--help"])
+        assert result.exit_code == 0
+        assert "List installed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# agent-forge init-extension
+# ---------------------------------------------------------------------------
+
+
+class TestInitExtension:
+    """Test the ``agent-forge init-extension`` CLI command."""
+
+    def test_scaffold_success(self, tmp_path: Path) -> None:
+        """Creates extension project and shows next steps."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["init-extension", "my-test-ext", "--target-dir", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0
+        assert "Extension project created" in result.output
+        assert "my-test-ext" in result.output
+        assert "Next steps" in result.output
+
+        # Verify project was actually created
+        assert (tmp_path / "my-test-ext").is_dir()
+        assert (tmp_path / "my-test-ext" / "pyproject.toml").is_file()
+
+    def test_scaffold_existing_dir_fails(self, tmp_path: Path) -> None:
+        """Refuses to overwrite an existing directory."""
+        (tmp_path / "existing-ext").mkdir()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["init-extension", "existing-ext", "--target-dir", str(tmp_path)],
+        )
+
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+
+    def test_scaffold_invalid_name_fails(self, tmp_path: Path) -> None:
+        """Rejects invalid extension names."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["init-extension", "123-bad", "--target-dir", str(tmp_path)],
+        )
+
+        assert result.exit_code != 0
+        assert "Invalid extension name" in result.output
+
+    def test_help(self) -> None:
+        """init-extension --help should work."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["init-extension", "--help"])
+        assert result.exit_code == 0
+        assert "Scaffold a new" in result.output

--- a/tests/unit/test_extension_discovery.py
+++ b/tests/unit/test_extension_discovery.py
@@ -1,0 +1,246 @@
+"""Unit tests for the extension discovery system (#120)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from agent_forge.extensions.discovery import (
+    EXTENSION_PLUGIN_GROUP,
+    PROFILE_PLUGIN_GROUP,
+    ExtensionInfo,
+    discover_extension_profile_dirs,
+    discover_extensions,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_ep(
+    name: str,
+    load_return: object | None = None,
+    load_side_effect: Exception | None = None,
+) -> MagicMock:
+    """Create a mock EntryPoint with configurable load()."""
+    ep = MagicMock()
+    ep.name = name
+    ep.value = f"{name}:obj"
+    if load_side_effect is not None:
+        ep.load.side_effect = load_side_effect
+    elif load_return is not None:
+        ep.load.return_value = load_return
+    return ep
+
+
+# ---------------------------------------------------------------------------
+# discover_extensions
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverExtensions:
+    """Test discovery of installed extensions."""
+
+    def test_discover_empty(self) -> None:
+        """No extensions installed → empty list."""
+
+        def empty_factory(group: str) -> list[MagicMock]:
+            return []
+
+        result = discover_extensions(entry_points_factory=empty_factory)
+        assert result == []
+
+    def test_discover_from_entry_points(self) -> None:
+        """Extensions are loaded from entry_points."""
+        ext_info = ExtensionInfo(
+            name="my-ext",
+            version="1.0.0",
+            description="Test extension",
+            package="my-ext-pkg",
+            profiles=["profile-a"],
+            tools=["tool-a"],
+        )
+
+        ep = _mock_ep("my-ext", load_return=ext_info)
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == EXTENSION_PLUGIN_GROUP:
+                return [ep]
+            return []
+
+        result = discover_extensions(entry_points_factory=factory)
+
+        assert len(result) == 1
+        assert result[0].name == "my-ext"
+        assert result[0].version == "1.0.0"
+        assert result[0].profiles == ["profile-a"]
+        assert result[0].tools == ["tool-a"]
+
+    def test_discover_from_callable_entry_point(self) -> None:
+        """Entry point can resolve to a callable returning ExtensionInfo."""
+        ext_info = ExtensionInfo(name="callable-ext", version="0.1.0")
+
+        def ext_factory() -> ExtensionInfo:
+            return ext_info
+
+        ep = _mock_ep("callable-ext", load_return=ext_factory)
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == EXTENSION_PLUGIN_GROUP:
+                return [ep]
+            return []
+
+        result = discover_extensions(entry_points_factory=factory)
+
+        assert len(result) == 1
+        assert result[0].name == "callable-ext"
+
+    def test_discover_handles_load_error(self) -> None:
+        """Broken entry points are skipped with a warning."""
+        ep = _mock_ep("broken", load_side_effect=ImportError("no module"))
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == EXTENSION_PLUGIN_GROUP:
+                return [ep]
+            return []
+
+        result = discover_extensions(entry_points_factory=factory)
+        assert result == []
+
+    def test_discover_handles_invalid_type(self) -> None:
+        """Entry point resolving to wrong type is skipped."""
+        ep = _mock_ep("wrong", load_return="not an ExtensionInfo")
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == EXTENSION_PLUGIN_GROUP:
+                return [ep]
+            return []
+
+        result = discover_extensions(entry_points_factory=factory)
+        assert result == []
+
+    def test_discover_sorts_by_name(self) -> None:
+        """Extensions are returned sorted by name."""
+        ext_b = ExtensionInfo(name="b-ext")
+        ext_a = ExtensionInfo(name="a-ext")
+
+        ep_b = _mock_ep("b-ext", load_return=ext_b)
+        ep_a = _mock_ep("a-ext", load_return=ext_a)
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == EXTENSION_PLUGIN_GROUP:
+                return [ep_b, ep_a]
+            return []
+
+        result = discover_extensions(entry_points_factory=factory)
+        assert [r.name for r in result] == ["a-ext", "b-ext"]
+
+    def test_discover_multiple_extensions(self) -> None:
+        """Multiple extensions can be discovered."""
+        ext1 = ExtensionInfo(name="ext-1", version="1.0")
+        ext2 = ExtensionInfo(name="ext-2", version="2.0")
+
+        ep1 = _mock_ep("ext-1", load_return=ext1)
+        ep2 = _mock_ep("ext-2", load_return=ext2)
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == EXTENSION_PLUGIN_GROUP:
+                return [ep1, ep2]
+            return []
+
+        result = discover_extensions(entry_points_factory=factory)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# discover_extension_profile_dirs
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverExtensionProfileDirs:
+    """Test discovery of profile directories from extensions."""
+
+    def test_discover_empty(self) -> None:
+        """No profile entry_points → empty list."""
+
+        def factory(group: str) -> list[MagicMock]:
+            return []
+
+        result = discover_extension_profile_dirs(entry_points_factory=factory)
+        assert result == []
+
+    def test_discover_valid_path(self, tmp_path: Path) -> None:
+        """A Path entry_point pointing to an existing directory is returned."""
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+
+        ep = _mock_ep("my-ext", load_return=profiles_dir)
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == PROFILE_PLUGIN_GROUP:
+                return [ep]
+            return []
+
+        result = discover_extension_profile_dirs(entry_points_factory=factory)
+        assert result == [profiles_dir]
+
+    def test_discover_skips_nonexistent_dir(self, tmp_path: Path) -> None:
+        """A Path pointing to a non-directory is skipped."""
+        missing = tmp_path / "missing"
+        ep = _mock_ep("broken", load_return=missing)
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == PROFILE_PLUGIN_GROUP:
+                return [ep]
+            return []
+
+        result = discover_extension_profile_dirs(entry_points_factory=factory)
+        assert result == []
+
+    def test_discover_skips_non_path(self) -> None:
+        """An entry_point resolving to a non-Path is skipped."""
+        ep = _mock_ep("bad", load_return="not/a/path")
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == PROFILE_PLUGIN_GROUP:
+                return [ep]
+            return []
+
+        result = discover_extension_profile_dirs(entry_points_factory=factory)
+        assert result == []
+
+    def test_discover_handles_load_error(self) -> None:
+        """Broken entry_points are skipped."""
+        ep = _mock_ep("crash", load_side_effect=ImportError("fail"))
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == PROFILE_PLUGIN_GROUP:
+                return [ep]
+            return []
+
+        result = discover_extension_profile_dirs(entry_points_factory=factory)
+        assert result == []
+
+    def test_discover_multiple_dirs(self, tmp_path: Path) -> None:
+        """Multiple profile directories from different extensions."""
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        ep_a = _mock_ep("ext-a", load_return=dir_a)
+        ep_b = _mock_ep("ext-b", load_return=dir_b)
+
+        def factory(group: str) -> list[MagicMock]:
+            if group == PROFILE_PLUGIN_GROUP:
+                return [ep_a, ep_b]
+            return []
+
+        result = discover_extension_profile_dirs(entry_points_factory=factory)
+        assert dir_a in result
+        assert dir_b in result

--- a/tests/unit/test_extension_scaffolding.py
+++ b/tests/unit/test_extension_scaffolding.py
@@ -1,0 +1,171 @@
+"""Unit tests for the extension scaffolding system (#120)."""
+
+from __future__ import annotations
+
+import tomllib
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from agent_forge.extensions.scaffolding import (
+    ScaffoldError,
+    _to_class_prefix,
+    _to_package_name,
+    scaffold_extension,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Name normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNameNormalization:
+    """Test extension name → package/class conversions."""
+
+    def test_to_package_name_basic(self) -> None:
+        assert _to_package_name("my-extension") == "my_extension"
+
+    def test_to_package_name_with_multiple_separators(self) -> None:
+        assert _to_package_name("my-cool--extension") == "my_cool_extension"
+
+    def test_to_package_name_uppercase(self) -> None:
+        assert _to_package_name("MyExtension") == "myextension"
+
+    def test_to_package_name_mixed(self) -> None:
+        assert _to_package_name("My-Cool_Extension") == "my_cool_extension"
+
+    def test_to_class_prefix_basic(self) -> None:
+        assert _to_class_prefix("my-extension") == "MyExtension"
+
+    def test_to_class_prefix_single_word(self) -> None:
+        assert _to_class_prefix("scanner") == "Scanner"
+
+    def test_to_class_prefix_underscores(self) -> None:
+        assert _to_class_prefix("web_security_scanner") == "WebSecurityScanner"
+
+
+# ---------------------------------------------------------------------------
+# scaffold_extension
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldExtension:
+    """Test the scaffold_extension function."""
+
+    def test_creates_directory_structure(self, tmp_path: Path) -> None:
+        """Check that all expected files and directories are created."""
+        result = scaffold_extension("my-scanner", target_dir=tmp_path)
+
+        assert result == tmp_path / "my-scanner"
+        assert result.is_dir()
+
+        pkg = result / "my_scanner"
+        assert pkg.is_dir()
+        assert (pkg / "__init__.py").is_file()
+        assert (pkg / "profiles").is_dir()
+        assert (pkg / "profiles" / "default.yaml").is_file()
+        assert (pkg / "tools").is_dir()
+        assert (pkg / "tools" / "__init__.py").is_file()
+        assert (pkg / "tools" / "sample_tool.py").is_file()
+        assert (result / "pyproject.toml").is_file()
+        assert (result / "README.md").is_file()
+        assert (result / "tests").is_dir()
+        assert (result / "tests" / "test_sample_tool.py").is_file()
+
+    def test_pyproject_has_entry_points(self, tmp_path: Path) -> None:
+        """Generated pyproject.toml should have the correct entry_points."""
+        scaffold_extension("test-ext", target_dir=tmp_path)
+
+        pyproject_path = tmp_path / "test-ext" / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)
+
+        eps = data["project"]["entry-points"]
+        assert "agent_forge.extensions" in eps
+        assert "test-ext" in eps["agent_forge.extensions"]
+        assert "agent_forge.profiles" in eps
+        assert "test-ext" in eps["agent_forge.profiles"]
+
+    def test_sample_profile_is_valid_yaml(self, tmp_path: Path) -> None:
+        """The generated profile YAML should be parseable."""
+        scaffold_extension("yaml-test", target_dir=tmp_path)
+
+        profile_path = (
+            tmp_path / "yaml-test" / "yaml_test" / "profiles" / "default.yaml"
+        )
+        with open(profile_path) as f:
+            data = yaml.safe_load(f)
+
+        assert isinstance(data, dict)
+        assert "id" in data
+        assert "name" in data
+        assert "prompt_scope" in data
+
+    def test_sample_profile_loads_as_agent_profile(self, tmp_path: Path) -> None:
+        """The generated profile should validate as an AgentProfile."""
+        from agent_forge.profiles.profile import AgentProfile
+
+        scaffold_extension("profile-test", target_dir=tmp_path)
+
+        profile_path = (
+            tmp_path / "profile-test" / "profile_test" / "profiles" / "default.yaml"
+        )
+        with open(profile_path) as f:
+            data = yaml.safe_load(f)
+
+        profile = AgentProfile.model_validate(data)
+        assert profile.id == "profile_test-default"
+
+    def test_refuses_existing_directory(self, tmp_path: Path) -> None:
+        """Should raise if the target directory already exists."""
+        (tmp_path / "existing").mkdir()
+
+        with pytest.raises(ScaffoldError, match="already exists"):
+            scaffold_extension("existing", target_dir=tmp_path)
+
+    def test_refuses_invalid_name(self, tmp_path: Path) -> None:
+        """Should raise on invalid extension names."""
+        with pytest.raises(ScaffoldError, match="Invalid extension name"):
+            scaffold_extension("123-bad", target_dir=tmp_path)
+
+        with pytest.raises(ScaffoldError, match="Invalid extension name"):
+            scaffold_extension("", target_dir=tmp_path)
+
+    def test_readme_contains_extension_name(self, tmp_path: Path) -> None:
+        """README should reference the extension name."""
+        scaffold_extension("cool-ext", target_dir=tmp_path)
+
+        readme = (tmp_path / "cool-ext" / "README.md").read_text()
+        assert "cool-ext" in readme
+
+    def test_init_contains_extension_info(self, tmp_path: Path) -> None:
+        """The __init__.py should contain ExtensionInfo with the correct name."""
+        scaffold_extension("info-ext", target_dir=tmp_path)
+
+        init = (tmp_path / "info-ext" / "info_ext" / "__init__.py").read_text()
+        assert 'name="info-ext"' in init
+        assert "PROFILES_DIR" in init
+
+    def test_tool_template_has_correct_class_name(self, tmp_path: Path) -> None:
+        """The sample tool should have a CamelCase class name."""
+        scaffold_extension("my-tool-ext", target_dir=tmp_path)
+
+        tool = (
+            tmp_path / "my-tool-ext" / "my_tool_ext" / "tools" / "sample_tool.py"
+        ).read_text()
+        assert "class MyToolExtSampleTool(Tool):" in tool
+        assert 'return "my_tool_ext_sample"' in tool
+
+    def test_default_target_dir_is_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without target_dir, scaffolds in cwd."""
+        monkeypatch.chdir(tmp_path)
+        result = scaffold_extension("cwd-test")
+        assert result == tmp_path / "cwd-test"
+        assert result.is_dir()

--- a/tests/unit/test_profiles.py
+++ b/tests/unit/test_profiles.py
@@ -315,3 +315,116 @@ class TestCLIOutputPayload:
 
         payload = _run_output_payload(mock_run)
         assert "profile" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Profile entry-point discovery
+# ---------------------------------------------------------------------------
+
+
+class TestProfileEntryPointDiscovery:
+    """Test profile auto-discovery from installed extensions (#120)."""
+
+    def test_load_profiles_discovers_entry_point_profiles(self, tmp_path: Path):
+        """Extension profiles are loaded from entry_point directories."""
+        from unittest.mock import patch
+
+        ext_profiles_dir = tmp_path / "ext_profiles"
+        ext_profiles_dir.mkdir()
+        yaml_content = textwrap.dedent("""\
+            id: ext-profile
+            name: Extension Profile
+            prompt_scope: "From an extension."
+        """)
+        (ext_profiles_dir / "ext.yaml").write_text(yaml_content)
+
+        with patch(
+            "agent_forge.extensions.discovery.discover_extension_profile_dirs",
+            return_value=[ext_profiles_dir],
+        ):
+            registry = load_profiles(include_builtins=False)
+
+        assert "ext-profile" in registry
+        assert registry["ext-profile"].name == "Extension Profile"
+
+    def test_load_profiles_entry_points_precedence(self, tmp_path: Path):
+        """User --profiles-dir overrides extension profiles on duplicate id."""
+        from unittest.mock import patch
+
+        # Extension profile
+        ext_dir = tmp_path / "ext"
+        ext_dir.mkdir()
+        (ext_dir / "shared.yaml").write_text(
+            textwrap.dedent("""\
+                id: shared
+                name: From Extension
+            """)
+        )
+
+        # User profile (higher precedence)
+        user_dir = tmp_path / "user"
+        user_dir.mkdir()
+        (user_dir / "shared.yaml").write_text(
+            textwrap.dedent("""\
+                id: shared
+                name: From User
+            """)
+        )
+
+        with patch(
+            "agent_forge.extensions.discovery.discover_extension_profile_dirs",
+            return_value=[ext_dir],
+        ):
+            registry = load_profiles([user_dir], include_builtins=False)
+
+        assert registry["shared"].name == "From User"
+
+    def test_load_profiles_skip_entry_points(self, tmp_path: Path):
+        """discover_entry_points=False disables extension profile discovery."""
+        from unittest.mock import patch
+
+        ext_dir = tmp_path / "ext"
+        ext_dir.mkdir()
+        (ext_dir / "ext-only.yaml").write_text(
+            textwrap.dedent("""\
+                id: ext-only
+                name: Extension Only
+            """)
+        )
+
+        with patch(
+            "agent_forge.extensions.discovery.discover_extension_profile_dirs",
+            return_value=[ext_dir],
+        ) as mock_discover:
+            registry = load_profiles(
+                include_builtins=False, discover_entry_points=False
+            )
+
+        # Should NOT have called discovery
+        mock_discover.assert_not_called()
+        assert "ext-only" not in registry
+
+    def test_load_profiles_builtins_plus_entry_points(self, tmp_path: Path):
+        """Extension profiles coexist with builtins."""
+        from unittest.mock import patch
+
+        ext_dir = tmp_path / "ext"
+        ext_dir.mkdir()
+        (ext_dir / "addon.yaml").write_text(
+            textwrap.dedent("""\
+                id: addon
+                name: Add-on Profile
+            """)
+        )
+
+        with patch(
+            "agent_forge.extensions.discovery.discover_extension_profile_dirs",
+            return_value=[ext_dir],
+        ):
+            registry = load_profiles()
+
+        # Builtins still present
+        assert "gemini" in registry
+        # Extension profile also present
+        assert "addon" in registry
+


### PR DESCRIPTION
## Extension SDK — Phase 1: Scaffolding, Discovery & Auto-Registration

Closes #120 (Phase 1 scope)

### What

Adds a complete Extension SDK for building and deploying domain-specific agents as separate Python packages. This is Phase 1 of a 4-phase epic.

### Changes

**New `agent_forge/extensions/` package:**
- `discovery.py` — Central engine scanning 3 entry-point groups (`agent_forge.extensions`, `agent_forge.profiles`, `agent_forge.tools`)
- `scaffolding.py` — Generates canonical extension projects from templates
- `templates/` — 6 template files for scaffolded projects (pyproject.toml, profiles, tools, tests, README)

**New CLI commands:**
- `agent-forge init-extension <name>` — Scaffolds a new extension project with pre-configured entry_points
- `agent-forge extensions list` — Shows installed extensions in a Rich table

**Profile auto-discovery:**
- `load_profiles()` gains `discover_entry_points` parameter
- 3-layer precedence: builtins < entry_points < `--profiles-dir` (CLI always wins)
- Path-based resolution: entry_points resolve to `Path` directories of YAML files

**Tests:** 64 new tests covering discovery, scaffolding, CLI, and profile entry_points
**Docs:** Updated `docs/extending.md` (Extension SDK section) and `README.md`

### Design Decisions
- **Path-based entry_points** (not callable) for simplicity and consistency with `--profiles-dir`
- **`string.Template`** substitution (no Jinja2 dependency)
- **Phase-per-PR** approach — follow-up phases (Auto-Discovery, Deployment, PoA Extraction) will be separate PRs