### PR TITLE
fix: use IAP tunneling for dev deploy SSH

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -85,6 +85,7 @@ jobs:
           gcloud compute ssh "${DEV_GCP_VM_NAME}" \
             --zone "${DEV_GCP_ZONE}" \
             --project "${DEV_GCP_PROJECT}" \
+            --tunnel-through-iap \
             --command "${REMOTE_COMMAND}"
 
       - name: Verify hosted service health
@@ -99,4 +100,5 @@ jobs:
           gcloud compute ssh "${DEV_GCP_VM_NAME}" \
             --zone "${DEV_GCP_ZONE}" \
             --project "${DEV_GCP_PROJECT}" \
+            --tunnel-through-iap \
             --command "${REMOTE_COMMAND}"

--- a/docs/hosted-service.md
+++ b/docs/hosted-service.md
@@ -220,10 +220,23 @@ Operational contract:
 
 - the VM must already expose the deploy script at
   `DEV_DEPLOY_SCRIPT_PATH`
-- the GitHub identity must be allowed to SSH to the VM through OS Login
+- the GitHub identity must be allowed to SSH to the VM through IAP and OS Login
 - the remote deploy script is responsible for fetching the requested ref,
   rebuilding the hosted runtime, restarting services, and leaving the service
   ready for the health probe
+
+The supported deploy path is:
+
+- `gcloud compute ssh --tunnel-through-iap`
+
+That requires the target project to have:
+
+- `iap.googleapis.com` enabled
+- `roles/iap.tunnelResourceAccessor` on the deploy service account
+- `roles/compute.osAdminLogin` on the deploy service account
+
+Direct SSH from a GitHub-hosted runner to the VM external IP is not the
+supported deploy path.
 
 If the paired `agent-forge-iac` work has not been applied yet, the workflow can
 still be merged here, but live deployment attempts will fail until the VM

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1360,7 +1360,8 @@ manual dispatches.
 ### 11.3 GitHub Actions Dev Deployment
 
 The dev deployment workflow uses GitHub's OIDC token with Google Cloud Workload
-Identity Federation, then runs a remote deploy script on the dev VM over SSH.
+Identity Federation, then runs a remote deploy script on the dev VM over SSH
+through IAP TCP forwarding.
 
 Required GitHub environment configuration for `dev`:
 
@@ -1380,12 +1381,14 @@ Workflow behavior:
 2. Resolve the deploy ref from the manual input when present, otherwise use the
    triggering commit SHA
 3. Authenticate to Google Cloud with Workload Identity Federation
-4. SSH to the configured VM and invoke the remote deploy script with the ref
+4. SSH to the configured VM with `gcloud compute ssh --tunnel-through-iap` and
+   invoke the remote deploy script with the ref
 5. Verify the hosted service health endpoint from the VM after deploy
 
 The deploy workflow depends on infrastructure managed outside this repository:
 the VM deploy script must already exist, the service account must have VM login
-permissions, and the WIF provider must trust `repo:akoita/agent-forge:*`.
+permissions, the service account must have IAP tunnel access, and the WIF
+provider must trust `repo:akoita/agent-forge:*`.
 
 ### 11.4 Docker Compose (Development)
 


### PR DESCRIPTION
Summary:
- switch the dev deploy workflow from direct SSH to IAP-tunneled SSH
- document IAP as the supported deploy path in hosted service docs and spec

Verification:
- parsed .github/workflows/deploy-dev.yml with PyYAML
- confirmed the paired infra repo now provisions IAP API and the required deploy-runner roles
- confirmed the previous failure moved past Google auth and failed on direct SSH timeout, which this workflow change addresses

Closes #130