### PR TITLE
feat: harness-first strategic reset — roadmap, governance, boundary enforcement

### DIFF
--- a/.agents/plans/strategic-reset-2026-07.md
+++ b/.agents/plans/strategic-reset-2026-07.md
@@ -1,0 +1,91 @@
+# Strategic Reset — Harness-First (July 2026)
+
+**Status:** Plan of record. Approved direction from the July 2026 project audit.
+**Decision record:** see `docs/adr/002-harness-first-reset.md`.
+**Roadmap:** see `docs/roadmap.md` (canonical).
+
+## Verdict
+
+Agent Forge pivots from "broad agent platform" to a **small, measurable,
+high-correctness coding harness**, targeting the capability bar of the first
+releases of leading harnesses (Claude Code, Codex CLI, OpenHands, aider).
+
+Verified findings that motivated the reset:
+
+- Completion currently means "the model stopped calling tools"
+  (`agent_forge/agent/core.py`), not "the requested change is correct and
+  verified".
+- E2E "fix" tests do not assert a patch was produced
+  (`tests/e2e/test_pipeline_e2e.py`), and real-LLM tests accept failure.
+- Audit-domain (Proof-of-Audit) vocabulary and schemas leak into six core
+  modules (`agent/prompts.py`, `service/app.py`, `service/models.py`,
+  `service/client.py`, `service/__init__.py`, `profiles/profile.py`),
+  violating the repo's own domain-agnostic-core rule.
+- The roadmap (spec §12) is stale (finished phases unchecked) and prioritizes
+  breadth (dashboard, K8s, multi-agent, marketplace) over measured harness
+  quality.
+- Governance is contradictory: AGENTS.md demands explicit merge approval AND
+  mandates autonomous merge; start-issue forbids committing before approval
+  while finish-issue auto-merges.
+- `docker-compose.yml` mounts the Docker socket (dev-only trust boundary);
+  base deps include fastapi/uvicorn/google-cloud-storage.
+
+## New direction (priority order)
+
+1. **M0 — Evaluation before features.** Reproducible coding benchmark with
+   real patch assertions, success/cost/latency/tool-error metrics, trajectory
+   capture. No feature is "complete" without eval evidence.
+2. **M1 — Agent-computer interface.** Atomic multi-file `apply_patch` with
+   preconditions and rollback; resumable PTY shell sessions with polling,
+   cancellation, and explicit truncation metadata.
+3. **M2 — Context engine.** Hierarchical AGENTS.md/CLAUDE.md discovery,
+   repository map, working-set management, compaction, prompt caching,
+   durable summaries.
+4. **M3 — Provider API v2.** Capability model (reasoning continuity, parallel
+   tools, caching, structured output, stateful IDs); OpenAI adapter migrates
+   to Responses; configurable OpenAI-compatible endpoints.
+5. **M4 — Policy & approval engine.** Read-only / workspace-write / elevated
+   policies; command classification; recorded approval decisions.
+6. **M5 — Durable execution & verification-aware completion.** Step-level
+   checkpoints, resume/replay, idempotency; completion contract (change
+   exists, patch applies, checks ran, no unacknowledged failures).
+7. **M6 — Standards interop.** MCP client first, ACP server for IDEs,
+   worktree-isolated parallelism. Multi-agent only after M0 gate is credible.
+
+**Out of core:** web dashboard, multi-tenant RBAC/billing/quotas, K8s
+scheduling, Firecracker fleets, capacity dashboards, marketplace, custom A2A
+protocol, orchestration DSL, opaque vector memory, bespoke IDE plugins.
+SaaS lives in a future separate `agent-forge-cloud` project consuming the
+core's runner contract. Proof-of-Audit moves entirely to
+`plugins/proof-of-audit/` (installable extension).
+
+## Work items (this reset)
+
+- **W1 — Strategy docs:** `docs/roadmap.md` (new, canonical),
+  `docs/adr/002-harness-first-reset.md`, `docs/spec.md` §12 replaced with a
+  pointer, README direction blurb reconciled.
+- **W2 — Governance & agent configs:** AGENTS.md rewritten (authority
+  boundaries: autonomous on feature branches through PR; merge requires green
+  CI + developer approval, standing approval allowed), new root CLAUDE.md
+  importing AGENTS.md, `.codex/config.toml` (model "gpt-5.6",
+  `model_reasoning_effort = "high"`), `.claude/settings.json` (secret-read
+  denials, force-push protection), start/finish-issue workflows made
+  consistent.
+- **W3 — Enforcement:** `scripts/check_boundaries.py` (domain-vocabulary scan
+  of `agent_forge/` with ratchet baseline of the six known violations +
+  `# boundary-ok` pragma), unit tests, CI job, PR template requiring
+  evidence/benchmark impact/boundary analysis/rollback, harness issue
+  template.
+- **W4 — Issue migration:** rewrite #24, #27, #29, #33, #40, #42, #46, #47;
+  keep #32 (deferred) and #43 (elevated P0); close #23, #25, #26, #31, #34,
+  #44, #45, #123 (superseded/not planned) and #28, #30, #35–#39, #41 (parked
+  under the agent-forge-cloud umbrella issue); create new P0 issues for M0,
+  patch layer, terminal protocol, durable execution, completion contract,
+  PoA extraction, runner extraction.
+
+## Quality gates going forward
+
+- Eval evidence (or explicit N/A) required in every PR.
+- Boundary check green in CI; baseline may only shrink.
+- ADR required for architecture-affecting changes.
+- Docs updated in the same branch as behavior changes.

--- a/.agents/workflows/finish-issue.md
+++ b/.agents/workflows/finish-issue.md
@@ -37,10 +37,12 @@ When the user says "finish issue", "wrap up", or indicates the work is done, fol
 - If any tests fail, fix the code or tests and re-run
 - Do NOT proceed until all tests pass
 
-## 5. Run linters
+## 5. Run linters and boundary check
 
 - Run `make lint` to check code quality
 - Fix any lint errors before proceeding
+- Run `python scripts/check_boundaries.py` — the architecture-boundary check
+  must be green. `scripts/boundary_baseline.txt` may only shrink, never grow.
 
 ## 6. Update documentation
 
@@ -82,21 +84,29 @@ When the user says "finish issue", "wrap up", or indicates the work is done, fol
 
 - Create a Pull Request targeting `main` with:
   - Title: concise description (referencing the issue number if one exists)
-  - Body: summary of changes (+ `Closes #N` only if an issue exists)
+  - Body follows the PR template: evidence, **benchmark/eval impact** (results
+    or `N/A` with a reason), boundary analysis, rollback, and `Closes #N`
+    (only if an issue exists)
 - Verify the PR was created successfully before continuing
 
-## 10. Verify PR CI passes and merge
+## 10. Verify CI, then merge only with developer approval
+
+The merge gate is defined in `AGENTS.md`: merging requires **CI green AND
+developer approval**.
 
 - Check the PR's required status checks after the PR is open
 - Prefer the repo's summary gate when configured: the `build` check must pass before merge
 - **Poll until CI is conclusive:** if checks are pending, wait 30 seconds and re-check (repeat up to 10 times)
 - If no CI checks are configured on the PR, **stop and ask the user** before proceeding
 - If any required check fails, fix the issues locally, commit, push, and re-poll from the beginning
-- **ONLY merge when the PR's required checks are green** (prefer squash merge for clean history)
-- If CI fails on the PR, fix on the branch, push, and re-poll
-- **NEVER merge a PR with pending or failing CI** — this is a hard stop
+- **A PR with pending or failing CI must not be merged** — this is a hard stop
+- **Merge ONLY once CI is green AND the developer has approved.** A developer's
+  *standing approval* (pre-authorizing merges for this task or session) counts —
+  note that standing approval in the PR before merging.
+- **Absent standing approval, request review and stop.** Do not merge
+  autonomously. Prefer squash merge for clean history.
 
-## 11. Verify main branch CI
+## 11. Verify main branch CI (only if the merge happened)
 
 - After merge, check that CI passes on the updated `main` branch
 - If CI fails on main:
@@ -104,14 +114,15 @@ When the user says "finish issue", "wrap up", or indicates the work is done, fol
   - Fix the issue, push, create PR, merge
   - Repeat until main CI is green
 
-## 12. Clean up branches
+## 12. Clean up branches (only if the merge happened)
 
+- Skip this step entirely while the PR is still open awaiting review/approval
 - Delete the feature branch remotely: `git push origin --delete <branch-name>`
 - Delete the feature branch locally: `git branch -d <branch-name>`
 - Delete any fix branches (remote + local) the same way
 - **NEVER delete `main`**
 
-## 13. Align local main
+## 13. Align local main (only if the merge happened)
 
 // turbo
 
@@ -124,8 +135,9 @@ When the user says "finish issue", "wrap up", or indicates the work is done, fol
 ## Important rules
 
 - **NEVER push a file that contains clear private data** — no hardcoded credentials, API keys, passwords, private keys, or tokens in ANY file, regardless of file type. Scan every file before staging.
-- **NEVER commit or push before user approval** — always ask first
-- **NEVER force-push to `main`**
+- **Commits and pushes on the feature branch are autonomous** — no per-commit approval is needed
+- **The merge gate requires CI green AND developer approval** — see `AGENTS.md`. Standing approval counts; absent it, request review and stop
+- **NEVER push to `main`** and **NEVER force-push to `main`**
 - **NEVER delete `main`** — only delete feature and fix branches
 - **ALWAYS verify PR CI** before merging, and main CI after merging
 - If in doubt about sensitive files, ask the user before committing

--- a/.agents/workflows/start-issue.md
+++ b/.agents/workflows/start-issue.md
@@ -28,8 +28,8 @@ When the user says "start issue #N", "work on #N", or references working on a sp
 
 ## 4. Plan the work
 
-- Create an implementation plan artifact
-- Request user review before coding
+- Create an implementation plan artifact in `.agents/plans/` for non-trivial issues
+- Proceed once the plan is written; request review only when requirements are ambiguous
 
 ## 5. Commit conventions
 
@@ -47,7 +47,8 @@ When the user says "start issue #N", "work on #N", or references working on a sp
 
 ## Important rules
 
-- **NEVER commit or push before user approval** — always ask first
+- **Commits and pushes on the feature branch are autonomous** — no per-commit approval is needed
+- **NEVER push to `main`** — always use a feature branch; the merge gate is defined in `AGENTS.md`
 - **NEVER commit directly to `main`** — always use a feature branch
 - **ALWAYS check current branch** before starting work with `git branch --show-current`
 - If already on a feature branch for the issue, continue working there — don't create a new one

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(**/clients.toml)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push origin main:*)"
+    ]
+  }
+}

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+# Project-scoped Codex CLI configuration (applies when this repo is trusted).
+# Keep model tracking OpenAI's current flagship coding model.
+model = "gpt-5.6"  # alias routes to gpt-5.6-sol (flagship, verified 2026-07-11)
+model_reasoning_effort = "high"

--- a/.github/ISSUE_TEMPLATE/harness_task.md
+++ b/.github/ISSUE_TEMPLATE/harness_task.md
@@ -1,0 +1,38 @@
+---
+name: Harness task
+about: Work item aligned with the harness-first roadmap
+title: "[HARNESS] "
+labels: direction/harness-first
+assignees: ''
+---
+
+## Outcome
+
+The concrete capability or behaviour that exists once this is done. Describe it
+from the harness's point of view, not the implementation's.
+
+## Exit criteria
+
+Measurable, checkable conditions for "done". Prefer commands and observable
+results over prose. Example:
+
+- [ ] `python scripts/check_boundaries.py` stays green
+- [ ] New behaviour covered by `tests/unit/test_*.py`
+- [ ] ...
+
+## Benchmark impact
+
+How will the M0 coding eval detect that this succeeded (success rate, cost,
+latency, tool-error rate)? If it cannot be measured yet, say so and explain the
+interim signal.
+
+## Boundary
+
+Where does this live — core (`agent_forge/`), extension (`plugins/`), or cloud
+(future `agent-forge-cloud`)? If it touches core, confirm it introduces no
+audit-domain vocabulary (see AGENTS.md and `scripts/boundary_baseline.txt`).
+
+## References
+
+- Roadmap milestone: docs/roadmap.md (Mx — ...)
+- Related issues: #...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,60 @@
-## Summary
+<!--
+Agent Forge is a harness-first project. Every PR must show evidence, not
+intent. Fill in each section below — do not delete headings. Use "N/A" with a
+one-line reason where a section genuinely does not apply.
+See docs/roadmap.md and AGENTS.md for the quality gates enforced here.
+-->
 
-Brief description of what this PR does.
+## What & why
 
-## Changes
+What does this change do, and why now? Link the issue it closes.
 
-- Change 1
-- Change 2
+Closes #<issue>
 
-## Related Issues
+## Evidence
 
-Closes #(issue number)
+Paste the **actual commands you ran and their real output** — not a checklist.
+At minimum:
 
-## Type of Change
+```
+# tests
+$ make test-unit
+...
 
-- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-- [ ] ✨ New feature (non-breaking change that adds functionality)
-- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] 📝 Documentation update
-- [ ] ♻️ Refactoring (no functional changes)
-- [ ] 🧪 Tests (adding or updating tests)
+# lint + types
+$ make lint
+...
 
-## Checklist
+# boundary ratchet
+$ python scripts/check_boundaries.py
+...
+```
 
-- [ ] My code follows the project's style guidelines (`make lint` passes)
-- [ ] I have added tests that prove my fix/feature works
-- [ ] All existing tests pass (`make test`)
-- [ ] I have updated documentation if needed
-- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+## Benchmark impact
+
+How does this change move the M0 coding eval (success / cost / latency /
+tool-error rate)? Paste the results delta, or write **N/A** with a reason
+(benchmark harness tracked in #135).
+
+## Boundary analysis
+
+Does this touch `agent_forge/*` with domain concepts (audit / Proof-of-Audit
+vocabulary)? The boundary check must be green and the baseline in
+`scripts/boundary_baseline.txt` may only **shrink**, never grow. If you removed
+a baseline entry, say which. If you added domain code, it belongs in
+`plugins/`, not core.
+
+## Docs
+
+Which docs did you update in this branch (behaviour changes require doc updates
+in the same PR)? Or state why none are needed.
+
+## Rollback
+
+How does a maintainer revert this safely if it misbehaves in production? Note
+any migrations, state, or config that a plain `git revert` would not undo.
+
+## ADR
+
+Does this change architecture? If so, link the ADR under `docs/adr/`. Otherwise
+state "no architectural change".

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Run linters
         run: make lint
 
+      - name: Check core boundaries
+        run: python scripts/check_boundaries.py
+
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 > This file is read by every AI coding assistant working in this repo
 > (Claude Code, Codex CLI, Gemini Code Assist, GitHub Copilot, etc.).
-> Keep it concise and current. Tool-specific notes live in `CLAUDE.md`,
-> `.codex/config.toml`, and `.claude/settings.json`.
+> `CLAUDE.md` is a symlink to this file — there is one source of truth.
+> Keep it concise and current. Tool-specific configuration lives in
+> `.codex/config.toml` and `.claude/settings.json`.
 
 ## 1. Mission & direction
 
@@ -45,6 +46,7 @@ one merge policy, stated once below.
   session) satisfies the approval half — record that standing approval in the
   PR. Absent standing approval, request review and stop; do not merge.
 - **Never force-push `main`.** Force-push feature branches only when necessary.
+- **Use git worktrees for parallel tasks** so concurrent branches stay isolated.
 - **Clean up after merge** — delete the merged feature branch (local + remote)
   and realign local `main`.
 
@@ -166,7 +168,7 @@ Runners: `make test-unit`, `make test-integration`, `make test` (all + coverage)
 
 ## 7. Code quality
 
-- Run `make lint` (ruff check + mypy) before committing.
+- Run `make lint` (ruff check + mypy) and `make test-unit` before committing.
 - Run `make format` (ruff format) to auto-format.
 - All public functions and methods have **type hints**.
 - Use **Google-style docstrings** for public APIs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,43 +1,71 @@
 # Agent Forge — AI Agent Coding Standards
 
-> This file is read by AI coding assistants (GitHub Copilot, Gemini Code Assist, Claude, etc.)
-> to enforce project-wide conventions. Keep it up to date.
+> This file is read by every AI coding assistant working in this repo
+> (Claude Code, Codex CLI, Gemini Code Assist, GitHub Copilot, etc.).
+> Keep it concise and current. Tool-specific notes live in `CLAUDE.md`,
+> `.codex/config.toml`, and `.claude/settings.json`.
 
-## 🚨 No Hardcoded Configuration Values
+## 1. Mission & direction
 
-**NEVER hardcode** URLs, ports, secrets, API keys, or any
-environment-dependent values directly in source code.
+Agent Forge is a **small, measurable, high-correctness coding harness** — not a
+broad agent platform. Every change should make the harness more correct or
+better measured, not merely broader.
 
-### Rules
+- **Canonical roadmap:** `docs/roadmap.md`
+- **Pivot decision:** `docs/adr/002-harness-first-reset.md`
 
-1. **Always use environment variables** with a sensible local-dev fallback:
+**Quality gates for every substantive change** (state each in the PR body):
 
-   ```python
-   # ✅ CORRECT
-   api_key = os.environ.get("GEMINI_API_KEY")
+1. **Evidence** — benchmark/eval results, or an explicit `N/A` with a reason.
+2. **Boundary check green** — `python scripts/check_boundaries.py` passes.
+3. **ADR** — architecture-affecting decisions get an ADR in `docs/adr/`.
+4. **Docs in the same branch** — behavior changes ship with their doc updates.
 
-   # ❌ WRONG — hardcoded key
-   api_key = "AIzaSy..."
+---
 
-   # ❌ WRONG — hardcoded URL
-   redis_url = "redis://production-host:6379/0"
-   ```
+## 2. Authority boundaries — git workflow
 
-2. **Use the configuration system** — don't redeclare config in every file:
+This section is the single source of truth for git authority. There is exactly
+one merge policy, stated once below.
 
-   ```python
-   # ✅ Import from the canonical source
-   from agent_forge.config import load_config
-   config = load_config()
+- **Never push to `main`.** All work happens on a feature branch. Naming:
+  - `feat/<issue-number>-<short-description>` — features
+  - `fix/<issue-number>-<short-description>` — bug fixes
+  - `docs/<issue-number>-<short-description>` — documentation
+  - `refactor/<short-description>` — refactoring
+  - `test/<short-description>` — test additions
+- **Commit and push autonomously on a feature branch.** No per-commit approval
+  is needed. Use [Conventional Commits](https://www.conventionalcommits.org/)
+  (`feat(#N): ...`, `fix(#N): ...`) and keep commits atomic.
+- **Open PRs autonomously**, targeting `main`, referencing the issue
+  (`Closes #N`). The PR body follows the template: evidence, benchmark impact,
+  boundary analysis, rollback.
+- **MERGE GATE:** merging requires **CI green AND developer approval**. A
+  developer's *standing approval* (pre-authorizing merges for a task or
+  session) satisfies the approval half — record that standing approval in the
+  PR. Absent standing approval, request review and stop; do not merge.
+- **Never force-push `main`.** Force-push feature branches only when necessary.
+- **Clean up after merge** — delete the merged feature branch (local + remote)
+  and realign local `main`.
 
-   # ❌ Don't redeclare per-file
-   REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
-   ```
+Use the workflows in `.agents/workflows/start-issue.md` and
+`.agents/workflows/finish-issue.md`.
 
-3. **Never commit secrets** — API keys, tokens, and credentials must come from
-   environment variables, never from source. The `.env` file is in `.gitignore`.
+---
 
-### Environment Variable Naming
+## 3. No hardcoded configuration
+
+**Never hardcode** URLs, ports, secrets, API keys, or environment-dependent
+values in source.
+
+- **Use environment variables** with a sensible local-dev fallback
+  (`os.environ.get("GEMINI_API_KEY")`), never a literal key or URL.
+- **Load config through `agent_forge.config`** (`load_config()`) — do not
+  redeclare config per file.
+- **Never commit secrets.** Keys, tokens, and credentials come from the
+  environment. `.env` is gitignored.
+- **Document new env vars** in `docs/spec.md § Configuration` and the
+  `agent-forge.toml` defaults.
 
 | Prefix              | Purpose                              | Example                            |
 | ------------------- | ------------------------------------ | ---------------------------------- |
@@ -46,61 +74,55 @@ environment-dependent values directly in source code.
 | `OPENAI_API_KEY`    | LLM provider key (direct, no prefix) | `OPENAI_API_KEY`                   |
 | `ANTHROPIC_API_KEY` | LLM provider key (direct, no prefix) | `ANTHROPIC_API_KEY`                |
 
-### Required Environment Variables
+---
 
-Document any new env var in `docs/spec.md § Configuration` and the project's `agent-forge.toml` defaults.
+## 4. Domain-agnostic core — extension-first
+
+Agent Forge's core is a **generic coding harness**. Anything tied to a specific
+use case (smart-contract auditing, web-security scanning, migration, etc.)
+lives in the extension layer, never in `agent_forge/*`.
+
+```
+CORE  (agent_forge/*)        Generic: LLM adapters, ReAct loop, sandbox,
+                             tools, profiles, orchestration, observability,
+                             CLI, hosted-service shell.
+EXTENSION LAYER              Domain features loaded at runtime:
+(plugins/, skills/,          plugins/proof-of-audit/ (audit profiles,
+ workflows/)                 detectors, report schemas), other domains,
+                             --profiles-dir, entry_points, prompt_scope.
+```
+
+**Rules**
+
+1. **No domain vocabulary in `agent_forge/*`.** Terms like `audit`, `solidity`,
+   `severity`, `finding`, `detector`, `reentrancy`, `vulnerability` are
+   audit-domain vocabulary and must not appear in core packages.
+2. **Use generic abstractions in core.** A profile carries `prompt_scope`
+   (generic), not `detectors`. A report is a JSON artifact, not a
+   "proof-of-audit report".
+3. **Deliver domain features via extensions** — profiles as YAML under a
+   plugin's `profiles/` (`--profiles-dir`), tools via `agent_forge.tools` entry
+   points, prompts through the generic `prompt_scope` field, workflows as
+   markdown under `.agents/workflows/`.
+4. **Test accordingly.** Core tests must not depend on any domain profile or
+   plugin existing; domain tests live with the plugin.
+
+**Enforcement is mechanical.** `scripts/check_boundaries.py` runs in CI.
+`scripts/boundary_baseline.txt` lists the historical violations being extracted
+(issue #140) — it may only **shrink**, never grow. To mark a deliberate false
+positive, add `# boundary-ok` on that line.
 
 ---
 
-## 🚨 Git Workflow — Branch & PR Only
+## 5. Architecture conventions
 
-**NEVER push directly to `main`.** All changes must go through a feature branch and Pull Request.
+**Python**
 
-### Rules
-
-1. **Always work on a branch** — use the naming conventions:
-   - `feat/<issue-number>-<short-description>` for features
-   - `fix/<issue-number>-<short-description>` for bug fixes
-   - `docs/<issue-number>-<short-description>` for documentation
-   - `refactor/<short-description>` for refactoring
-   - `test/<short-description>` for test additions
-
-2. **Submit a Pull Request** targeting `main` — include a clear description and reference the issue (`Closes #N`).
-
-3. **Merge only on explicit developer request** — never merge a PR autonomously. Wait for the developer to say "merge", "you can merge", or equivalent.
-
-4. **Never force-push to `main`** — only force-push on feature branches if absolutely necessary.
-
-5. **Clean up after merge** — delete the feature branch (local + remote) and align local `main`.
-
-6. **Use the `/start-issue` workflow** when beginning work on any issue or task. Run the steps in `.agent/workflows/start-issue.md`.
-
-7. **Automatically run `/finish-issue` when completing work.** When work on any issue or task is done, **always execute every step** in `.agents/workflows/finish-issue.md` — verify coverage, run tests, lint, commit, push, open PR, wait for CI green, and merge. This workflow is mandatory, not optional. Do not skip steps or ask whether to run it.
-
-8. **Update documentation with every user-facing change.** Any change that
-   modifies CLI flags, API endpoints, configuration options, deployment
-   topology, or observable behavior **must** include corresponding documentation
-   updates in the same branch. Review and update as needed:
-   - `README.md` — features, project structure, usage examples
-   - `docs/` — architecture, configuration, hosted-service, extending, testing
-   - `docs/spec.md` — technical specification, interface contracts
-   - Inline docstrings in changed modules
-   
-   Skip only for purely internal refactors with zero user-facing impact.
-
----
-
-## Architecture Conventions
-
-### Python
-
-- **Python 3.11+** — use modern syntax: `X | Y` unions, `match` statements, `tomllib`
-- **Async-first** — use `async/await` for I/O-bound operations (LLM calls, Docker, file I/O)
-- **ABCs for interfaces** — all providers and tools implement abstract base classes
-- **Pydantic for validation** — use Pydantic models for external data (config, API responses)
-- **Dataclasses for internals** — use `@dataclass` for internal data structures
-
-### Module Layout
+- **Python 3.11+** — modern syntax: `X | Y` unions, `match`, `tomllib`.
+- **Async-first** — `async/await` for I/O (LLM calls, Docker, file I/O).
+- **ABCs for interfaces** — providers and tools implement abstract base classes.
+- **Pydantic for external data** (config, API responses); `@dataclass` for
+  internal structures.
 
 | Package                     | Purpose                                      |
 | --------------------------- | -------------------------------------------- |
@@ -111,89 +133,13 @@ Document any new env var in `docs/spec.md § Configuration` and the project's `a
 | `agent_forge.orchestration` | Task queue, event bus, workers               |
 | `agent_forge.observability` | Structured logging, tracing, cost tracking   |
 
-### Docker / Sandbox
-
-- Sandbox containers use `--network none` by default
-- Never pass API keys into the sandbox
-- Resource limits are mandatory: `--cpus`, `--memory`, `--pids-limit`
-- All file operations are validated to stay within `/workspace`
+**Docker / sandbox** — containers run `--network none` by default; never pass
+API keys into the sandbox; resource limits (`--cpus`, `--memory`,
+`--pids-limit`) are mandatory; all file ops stay within `/workspace`.
 
 ---
 
-## 🚨 Domain-Agnostic Core — Extension-First Architecture
-
-Agent Forge is a **generic coding agent framework** — comparable to Claude Code, Codex, or Antigravity.
-It must remain **domain-agnostic**. Any feature tied to a specific use case (smart contract auditing,
-web security scanning, code migration, etc.) belongs in the **extension layer**, never in the core packages.
-
-### The Boundary
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│  CORE  (agent_forge/*)                                       │
-│  Generic, domain-agnostic capabilities:                      │
-│  LLM adapters, ReAct loop, sandbox, tools, profiles,         │
-│  orchestration, observability, CLI, hosted service shell      │
-├──────────────────────────────────────────────────────────────┤
-│  EXTENSION LAYER  (plugins/, skills/, workflows/)            │
-│  Domain-specific capabilities loaded at runtime:             │
-│  - plugins/proof-of-audit/  → audit profiles, detectors,    │
-│    report schemas, challenge evidence, multi-agent personas  │
-│  - plugins/<other-domain>/  → any future specialization      │
-│  - --profiles-dir, entry_points, skill files, workflows      │
-└──────────────────────────────────────────────────────────────┘
-```
-
-### Rules
-
-1. **Core packages must not import or reference domain-specific concepts.**
-   Terms like "reentrancy", "access control", "vulnerability", "finding", "severity",
-   "detector" are audit-domain vocabulary — they do not belong in `agent_forge.*`.
-
-2. **Use generic abstractions in core.** A profile has `prompt_scope` (generic),
-   not `detectors` (audit-specific). A report is a JSON artifact, not a
-   "proof-of-audit report".
-
-3. **Domain features are delivered via extensions:**
-   - **Profiles** → YAML files in a plugin's `profiles/` directory, loaded with `--profiles-dir`
-   - **Tools** → Python entry points registered under `agent_forge.tools`
-   - **Prompts** → Injected through the generic `prompt_scope` field on `AgentProfile`
-   - **Workflows** → Markdown files in `.agent/workflows/`
-
-4. **Test accordingly.** Core tests must not depend on any domain-specific profile
-   or plugin existing. Domain tests live alongside the plugin.
-
-### Example: Adding a New Domain
-
-To add a "web-security-scanner" domain, create `plugins/web-security-scanner/` with its own
-profiles, tools, and workflows. **Do not modify any file under `agent_forge/`** to add
-web-security concepts.
-
-### Distribution Model
-
-Extensions can be **separate installable packages** — they do not need to live in
-this monorepo. A user installs the core agent and then adds domain capabilities:
-
-```bash
-pip install agent-forge                        # core framework
-pip install agent-forge-proof-of-audit         # audit profiles, tools, report schemas
-pip install agent-forge-web-security           # hypothetical web-security extension
-```
-
-The `plugins/` directory in this repo is a **development convenience** for first-party
-extensions. At runtime, extensions are discovered through:
-
-- **`entry_points`** — Python's standard plugin mechanism (already used for tools
-  via the `agent_forge.tools` group in `tools/plugins.py`).
-  Future groups: `agent_forge.profiles`, `agent_forge.prompts`.
-- **`--profiles-dir`** — CLI flag pointing to a directory of profile YAMLs.
-- **Config** — `agent-forge.toml` can declare extension paths.
-
----
-
-## 🧪 Testing Standards
-
-### File Naming
+## 6. Testing standards
 
 | Pattern                       | Purpose                                      | Runner                  |
 | ----------------------------- | -------------------------------------------- | ----------------------- |
@@ -201,52 +147,28 @@ extensions. At runtime, extensions are discovered through:
 | `tests/integration/test_*.py` | Tests with real Docker containers            | `make test-integration` |
 | `tests/e2e/test_*.py`         | Full agent run on sample repos               | `make test` (all)       |
 
-### Rules
+**Rules**
 
-1. **Mock LLM responses, not tools.** Tools should be tested against a real sandbox when possible. Use recorded/cached LLM responses (VCR pattern) for deterministic tests.
+1. **Mock LLM responses, not tools.** Test tools against a real sandbox where
+   possible; use recorded/cached LLM responses (VCR pattern) for determinism.
+2. **Use `pytest` fixtures** for sandbox setup/teardown — no manual setup in
+   the test body.
+3. **Never mock the sandbox in integration tests** — they exist to verify real
+   Docker interactions.
+4. **Use `respx`** for HTTP mocking in LLM adapter unit tests.
+5. **e2e and eval tests must assert outcomes.** A "fix" test asserts the patch
+   exists/applies and verification passes. Asserting only exit codes or "the
+   agent ran" is not acceptable.
 
-2. **Use `pytest` fixtures** for sandbox setup/teardown:
-
-   ```python
-   # ✅ CORRECT — use fixture
-   @pytest.fixture
-   async def sandbox():
-       sb = DockerSandbox()
-       await sb.start("./tests/fixtures/sample_repo", SandboxConfig())
-       yield sb
-       await sb.stop()
-
-   # ❌ WRONG — manual setup in test body
-   ```
-
-3. **Never mock the sandbox in integration tests.** Integration tests exist to verify real Docker interactions.
-
-4. **Use `respx` for HTTP mocking** in LLM adapter unit tests:
-
-   ```python
-   # ✅ CORRECT — mock HTTP, not the adapter
-   respx.post("https://generativelanguage.googleapis.com/...").respond(json={...})
-   ```
-
-### Running Tests
-
-```bash
-# Unit tests only (fast, no Docker needed)
-make test-unit
-
-# Integration tests (requires Docker)
-make test-integration
-
-# All tests with coverage
-make test
-```
+Runners: `make test-unit`, `make test-integration`, `make test` (all + coverage).
 
 ---
 
-## Code Quality
+## 7. Code quality
 
-- Run `make lint` before committing (ruff check + mypy)
-- Run `make format` to auto-format (ruff format)
-- All public functions and methods must have **type hints**
-- Use **Google-style docstrings** for public APIs
-- Follow [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages
+- Run `make lint` (ruff check + mypy) before committing.
+- Run `make format` (ruff format) to auto-format.
+- All public functions and methods have **type hints**.
+- Use **Google-style docstrings** for public APIs.
+- Follow [Conventional Commits](https://www.conventionalcommits.org/) for
+  all commit messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Agent Forge — Claude Code notes
+
+Project conventions (mission, git authority boundaries, architecture, testing)
+live in `AGENTS.md`. It is imported below and applies in full.
+
+@AGENTS.md
+
+## Claude-specific notes
+
+- Run `make lint` and `make test-unit` before committing.
+- Use git worktrees for parallel tasks so branches stay isolated.
+- Follow `.agents/workflows/start-issue.md` and `.agents/workflows/finish-issue.md`.
+- Never grow `scripts/boundary_baseline.txt` — it may only shrink.
+- When a change affects architecture, write an ADR in `docs/adr/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,1 @@
-# Agent Forge — Claude Code notes
-
-Project conventions (mission, git authority boundaries, architecture, testing)
-live in `AGENTS.md`. It is imported below and applies in full.
-
-@AGENTS.md
-
-## Claude-specific notes
-
-- Run `make lint` and `make test-unit` before committing.
-- Use git worktrees for parallel tasks so branches stay isolated.
-- Follow `.agents/workflows/start-issue.md` and `.agents/workflows/finish-issue.md`.
-- Never grow `scripts/boundary_baseline.txt` — it may only shrink.
-- When a change affects architecture, write an ADR in `docs/adr/`.
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -235,20 +235,21 @@ plugins/
 
 ---
 
-## Roadmap
+## Direction
 
-| Phase | Focus                                                             | Status         |
-| ----- | ----------------------------------------------------------------- | -------------- |
-| **1** | Core Agent MVP — ReAct loop + Docker sandbox + CLI                | ✅ Complete    |
-| **2** | Production Hardening — Observability, multi-provider, Redis queue | ✅ Complete    |
-| **3** | Git-Aware Agent & Plugin System                                   | ✅ Complete    |
-| **4** | Web Dashboard & REST API                                          | ⬜ Planned     |
-| **5** | Multi-Agent Collaboration                                         | ⬜ Planned     |
-| **6** | Advanced Isolation & Scaling (microVMs, K8s)                      | 🚧 In Progress |
-| **7** | Platform & Ecosystem (MCP, marketplace, IDE plugins)              | 🚧 In Progress |
+Agent Forge is being reset to a **harness-first** strategy: a small, measurable,
+high-correctness coding harness that competes on correctness and verified task
+completion rather than feature breadth. The rationale is recorded in
+[ADR-002: Harness-First Strategic Reset](docs/adr/002-harness-first-reset.md).
 
-See [spec.md § Roadmap](docs/spec.md#12-roadmap) for detailed milestones.
-Hosted service support for external clients is the first completed Phase 7 milestone.
+The work is now organized into milestones **M0–M6** — starting with an evaluation
+harness and quality gate (M0), then the agent-computer interface, context engine,
+provider API, policy engine, durable execution, and standards interop. Hosted,
+multi-tenant, and scaling concerns (web dashboard, RBAC, Kubernetes, fleet
+scaling) move to a separate `agent-forge-cloud` project.
+
+See the **[Roadmap](docs/roadmap.md)** for milestones, exit criteria, and tracking
+issues. The former Phase 1–7 plan is superseded.
 
 ---
 

--- a/agent_forge/extensions/templates/pyproject.toml.template
+++ b/agent_forge/extensions/templates/pyproject.toml.template
@@ -37,8 +37,3 @@ $extension_name = "$package_name:WORKFLOWS_DIR"
 
 [tool.hatch.build.targets.wheel]
 packages = ["$package_name"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"$package_name/profiles" = "$package_name/profiles"
-"$package_name/prompts" = "$package_name/prompts"
-"$package_name/workflows" = "$package_name/workflows"

--- a/docs/adr/002-harness-first-reset.md
+++ b/docs/adr/002-harness-first-reset.md
@@ -1,0 +1,97 @@
+# ADR-002: Harness-First Strategic Reset
+
+**Status:** Accepted  
+**Date:** 2026-07-11  
+**Context:** [Strategic Reset plan](../../.agents/plans/strategic-reset-2026-07.md), [roadmap.md](../roadmap.md), [spec.md § 12](../spec.md#12-roadmap)
+
+---
+
+## Context
+
+Agent Forge began as a broad "agent platform": a coding agent plus a widening
+surface of hosted-service, multi-tenant, and scaling ambitions. A July 2026 audit
+of the codebase and roadmap found that this breadth had outrun the core's measured
+quality. The verified findings:
+
+- **Completion means "stopped", not "correct".** A run is treated as complete when
+  the model stops calling tools (`agent_forge/agent/core.py`), not when the
+  requested change is present, applies, and is verified.
+- **Tests do not assert the work happened.** The end-to-end "fix" tests do not
+  assert that a patch was produced (`tests/e2e/test_pipeline_e2e.py`), and the
+  real-LLM tests accept failure as a passing outcome.
+- **Domain vocabulary has leaked into the core.** Proof-of-Audit (PoA) vocabulary
+  and schemas appear in six core modules — `agent/prompts.py`, `service/app.py`,
+  `service/models.py`, `service/client.py`, `service/__init__.py`, and
+  `profiles/profile.py` — violating the repo's own domain-agnostic-core rule.
+- **The roadmap is stale.** The spec §12 phase list leaves finished phases
+  unchecked and prioritizes breadth (web dashboard, Kubernetes, multi-agent,
+  marketplace) over measured harness quality.
+- **Governance is contradictory.** AGENTS.md simultaneously demands explicit merge
+  approval and mandates autonomous merge; the start-issue workflow forbids
+  committing before approval while the finish-issue workflow auto-merges.
+- **Trust boundary and dependency weight.** `docker-compose.yml` mounts the Docker
+  socket (a dev-only trust boundary presented without that caveat), and the base
+  dependencies include `fastapi`, `uvicorn`, and `google-cloud-storage` — hosted
+  concerns carried by every install.
+
+Taken together, the project claimed capabilities it did not measure and carried
+scope it could not yet justify.
+
+## Decision
+
+**Agent Forge pivots to a harness-first strategy: a small, measurable,
+high-correctness coding harness**, targeting the capability bar of the first
+public releases of Claude Code, Codex CLI, OpenHands, and aider. The
+[roadmap](../roadmap.md) is canonical and reorganizes the work into milestones
+M0–M6.
+
+Concretely:
+
+1. **Evaluation gate before features.** M0 builds a reproducible eval harness
+   (`make eval`) with real patch assertions and success/cost/latency/tool-error
+   metrics. No feature is "complete" without eval evidence, or an explicit,
+   justified N/A.
+2. **Proof-of-Audit extracted from core.** PoA moves entirely to
+   `plugins/proof-of-audit/` as an installable extension. The core becomes
+   domain-agnostic in fact, not just in aspiration.
+3. **SaaS in a separate project.** Hosted, multi-tenant, and scaling concerns move
+   to a future `agent-forge-cloud` project that consumes the core's runner
+   contract. The core ships as a local, embeddable library and CLI.
+4. **Standards-first interop.** MCP for tools and ACP for IDE integration, rather
+   than bespoke agent-to-agent protocols or editor plugins.
+5. **Verification-aware completion.** A run succeeds only when its completion
+   contract is satisfied — the change exists, the patch applies, checks ran, and
+   no failure is left unacknowledged.
+6. **Governance made non-contradictory, with mechanical gates.** The agent
+   configuration is rewritten so authority boundaries are consistent (autonomous
+   through PR; merge requires green CI plus developer approval). Quality is
+   enforced mechanically rather than by convention: a boundary check
+   (`scripts/check_boundaries.py`) runs in CI with a baseline that may only
+   shrink, PRs must carry eval/benchmark evidence, and architecture-affecting
+   changes require an ADR.
+
+## Consequences
+
+### Positive
+
+- **Measurable quality.** Every capability is judged against an eval, so claims in
+  the README and docs are backed by evidence.
+- **Smaller, legible core.** Removing PoA and hosted dependencies shrinks the core
+  and makes it easier to reason about and to embed.
+- **Credible open-source positioning.** A focused harness that competes on
+  correctness is a clearer, more defensible story than a broad platform.
+- **Non-contradictory governance.** Consistent authority boundaries and mechanical
+  gates remove the ambiguity that previously stalled or corrupted the workflow.
+
+### Negative / accepted costs
+
+- **Issue backlog churn.** The reset rewrites, defers, and closes a large number of
+  existing issues; contributors tracking the old roadmap must re-orient.
+- **Hosted-service scope freeze.** Web dashboard, RBAC, billing, Kubernetes, and
+  fleet scaling are frozen out of core and deferred to `agent-forge-cloud`
+  (umbrella issue #142); users wanting those capabilities wait for that project.
+- **Benchmark maintenance burden.** An eval gate is only useful if it is
+  maintained; the project takes on the ongoing cost of keeping benchmarks
+  reproducible and meaningful.
+- **PoA users must install the extension.** Proof-of-Audit stops shipping in the
+  core, so existing PoA users must install `plugins/proof-of-audit/` explicitly.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,217 @@
+# Agent Forge Roadmap
+
+**Status:** Canonical roadmap. Supersedes the phase roadmap formerly in
+[`docs/spec.md` §12](spec.md#12-roadmap). Decision record:
+[`docs/adr/002-harness-first-reset.md`](adr/002-harness-first-reset.md).
+**Date:** 2026-07-11.
+
+---
+
+## Mission
+
+Agent Forge is a small, measurable, high-correctness coding harness. It exists to
+turn a coding task into a verified change, and to prove — with benchmarks — that it
+does so reliably at a known cost and latency. We optimize for correctness and
+verified task completion over feature breadth. The target bar is the capability of
+the first public releases of Claude Code, Codex CLI, OpenHands, and aider: a core
+that is small enough to reason about and good enough to measure.
+
+## Principles
+
+1. **Evaluation before features.** No feature is "complete" without benchmark
+   evidence (or an explicit, justified N/A). We measure task success, cost,
+   latency, and tool-error rate before we claim a capability works.
+2. **Domain-agnostic core.** The core knows nothing about any specific domain.
+   Domain work — for example Proof-of-Audit — lives in extensions, not in
+   `agent_forge/`. The boundary is enforced mechanically by
+   `scripts/check_boundaries.py` in CI, with a baseline that may only shrink.
+3. **Simplicity is a feature.**
+   [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent) shows that a
+   small, legible agent loop stays competitive. More framework does not make a
+   better agent; every added abstraction must earn its place against a measured
+   result.
+4. **Standards before proprietary integrations.** We adopt open standards rather
+   than build bespoke ones: [MCP](https://modelcontextprotocol.io) for tools,
+   [ACP](https://agentclientprotocol.com/get-started/introduction) for IDE
+   integration. We do not ship a custom agent-to-agent protocol or bespoke editor
+   plugins when a standard covers the need.
+5. **Verification-aware completion.** A run succeeds only when its completion
+   contract is satisfied — the requested change exists, the patch applies, checks
+   ran, and no failure is left unacknowledged. A run does not succeed merely
+   because the model stopped calling tools.
+
+---
+
+## Milestones
+
+Milestones are ordered by priority. The M0 evaluation gate comes first and gates
+everything after it: subsequent milestones are only "done" once they show up as an
+improvement (or a justified non-regression) in the eval harness.
+
+### M0 — Evaluation harness & quality gate
+
+**Outcome:** A reproducible coding benchmark that scores task success, cost,
+latency, and tool-error rate from a clean checkout, with trajectory capture, so
+every later milestone can be judged by evidence rather than assertion.
+
+**Exit criteria:** `make eval` runs from a clean checkout and reports per-task
+success/cost/latency/tool-error metrics with real patch assertions; a smoke subset
+runs in CI on every PR.
+
+**Tracking:** [#135](https://github.com/akoita/agent-forge/issues/135).
+
+### M1 — Agent-computer interface
+
+**Outcome:** A robust interface between the agent and the machine: atomic,
+multi-file patches that either apply cleanly or roll back, and shell sessions the
+agent can drive over long-running work without losing state or silently
+truncating output.
+
+**Exit criteria:**
+- Atomic `apply_patch` with preconditions, rollback on failure, and diff
+  manifests ([#136](https://github.com/akoita/agent-forge/issues/136)).
+- Resumable PTY sessions with polling, cancellation, and explicit truncation
+  metadata ([#137](https://github.com/akoita/agent-forge/issues/137)).
+
+The SWE-agent agent-computer interface (ACI) result shows that interface design
+materially affects agent performance, independent of the underlying model
+([SWE-agent, arXiv:2405.15793](https://arxiv.org/abs/2405.15793)); this milestone
+treats the interface as a first-class, measured surface.
+
+### M2 — Context engine
+
+**Outcome:** The agent assembles the right context for a task and keeps it within
+budget across a long run, instead of dumping files into the prompt.
+
+**Exit criteria:** Layered `AGENTS.md`/`CLAUDE.md` discovery; a repository map with
+symbol ranking (precedent: [aider repository map](https://aider.chat/docs/repomap.html));
+working-set management; compaction and stale tool-result pruning; prompt caching;
+and durable summaries — landed and shown to help (or not hurt) on the M0 eval
+([#24](https://github.com/akoita/agent-forge/issues/24)).
+
+### M3 — Provider API v2
+
+**Outcome:** A provider abstraction built around a capability model, so the harness
+can exploit modern provider features rather than target a lowest common
+denominator.
+
+**Exit criteria:**
+- Capability model covering reasoning continuity, parallel tool calls, prompt
+  caching, structured output, and stateful response IDs; the OpenAI adapter
+  migrates to the
+  [Responses API](https://developers.openai.com/api/docs/guides/migrate-to-responses)
+  ([#42](https://github.com/akoita/agent-forge/issues/42)).
+- Configurable OpenAI-compatible endpoints (Ollama, vLLM, gateways)
+  ([#46](https://github.com/akoita/agent-forge/issues/46)).
+
+### M4 — Policy & approval engine
+
+**Outcome:** Operator-controlled policies over what the agent may do, with a clear
+record of every approval decision. Sandboxing (isolation) and approvals
+(authorization) are treated as separate concerns.
+
+**Exit criteria:**
+- P0 policies: read-only, workspace-write, and elevated modes; command
+  classification; and recorded approval decisions
+  ([#43](https://github.com/akoita/agent-forge/issues/43)).
+- Budget, pause, and cancellation policy
+  ([#29](https://github.com/akoita/agent-forge/issues/29)).
+
+### M5 — Durable execution & verification-aware completion
+
+**Outcome:** Runs that survive interruption and that only report success when a
+completion contract is satisfied.
+
+**Exit criteria:**
+- Step-level checkpoints with resume, replay, and idempotency
+  ([#138](https://github.com/akoita/agent-forge/issues/138)).
+- A completion contract: the change exists, the patch applies, checks ran, and no
+  failure is left unacknowledged
+  ([#139](https://github.com/akoita/agent-forge/issues/139)).
+- Typed run-event streaming over a durable transport
+  ([#27](https://github.com/akoita/agent-forge/issues/27)).
+
+### M6 — Standards interop & parallelism
+
+**Outcome:** Interoperation with the wider ecosystem through open standards, and
+safe parallel execution.
+
+**Exit criteria:**
+- MCP client first ([#40](https://github.com/akoita/agent-forge/issues/40)).
+- ACP server for IDE integration
+  ([#47](https://github.com/akoita/agent-forge/issues/47)).
+- Worktree-isolated parallel execution
+  ([#33](https://github.com/akoita/agent-forge/issues/33)).
+
+Hierarchical delegation ([#32](https://github.com/akoita/agent-forge/issues/32))
+stays deferred until the M0 gate is credible: multi-agent orchestration is only
+worth building once we can measure whether it helps.
+
+### Cross-cutting — extraction
+
+**Outcome:** The core becomes genuinely domain-agnostic and dependency-light.
+
+**Exit criteria:**
+- Proof-of-Audit moved out of core into an installable extension
+  ([#140](https://github.com/akoita/agent-forge/issues/140)).
+- A generic runner; `fastapi`/`uvicorn`/`google-cloud-storage` moved from base
+  dependencies to extras ([#141](https://github.com/akoita/agent-forge/issues/141)).
+
+---
+
+## Out of core
+
+The following are explicitly out of scope for the core harness. Hosted-service
+concerns move to the future `agent-forge-cloud` project, parked under the umbrella
+issue [#142](https://github.com/akoita/agent-forge/issues/142):
+
+- Web dashboard and run-history UI.
+- Multi-tenant auth, RBAC, billing, and quotas.
+- Kubernetes scheduling, Firecracker fleets, warm pools, and capacity dashboards.
+- A community tool marketplace.
+
+Also not planned, in core or cloud:
+
+- A custom agent-to-agent protocol (use standards).
+- An orchestration DSL.
+- Opaque vector memory as a default context mechanism.
+- Bespoke VS Code / JetBrains plugins — superseded by the ACP server (M6).
+
+---
+
+## SaaS split
+
+The line between the open-source core and the future hosted product:
+
+| Agent Forge core (local & embeddable)          | agent-forge-cloud (separate deployable) | Extensions (installable packages)      |
+| ---------------------------------------------- | --------------------------------------- | -------------------------------------- |
+| Agent loop                                     | Tenancy                                 | Domain prompts                         |
+| Tools                                          | Auth / RBAC                             | Report schemas                         |
+| Policies                                       | Billing                                 | Profiles                               |
+| Context engine                                 | Quotas                                  | Domain tools                           |
+| Events                                         | Scheduler                               |                                        |
+| Sandbox interface                              | Sandbox fleet                           |                                        |
+| Runner protocol                                | Artifact storage                        |                                        |
+|                                                | UI                                      |                                        |
+
+The core is a library and CLI that runs locally and embeds into other programs.
+`agent-forge-cloud` is a separate deployable that consumes the core's runner
+contract and adds the multi-tenant, hosted concerns. Extensions are installable
+packages that add domain behavior on top of the core.
+
+---
+
+## References
+
+- [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent) — a small,
+  competitive agent loop.
+- [SWE-agent (arXiv:2405.15793)](https://arxiv.org/abs/2405.15793) — the
+  agent-computer interface result.
+- [aider repository map](https://aider.chat/docs/repomap.html) — repository map
+  with symbol ranking.
+- [OpenAI: migrate to the Responses API](https://developers.openai.com/api/docs/guides/migrate-to-responses).
+- [Model Context Protocol (MCP)](https://modelcontextprotocol.io).
+- [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/introduction).
+- [OpenHands SDK capability index](https://github.com/OpenHands/docs/blob/main/llms.txt).
+- [Claude Code security](https://code.claude.com/docs/en/security).
+- [Running Codex safely](https://openai.com/index/running-codex-safely/).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1452,86 +1452,17 @@ clean:                     ## Clean up containers and build artifacts
 
 ## 12. Roadmap
 
-### Phase 1 — Core Agent MVP
+The roadmap has moved. The canonical roadmap now lives in
+[`docs/roadmap.md`](roadmap.md), and its direction is set by
+[ADR-002: Harness-First Strategic Reset](adr/002-harness-first-reset.md).
 
-> **Goal:** A working end-to-end agent that can modify code inside a Docker sandbox.
+The former Phase 1–7 checklist that occupied this section is **superseded**.
+Phases 1 and 2 were in fact delivered (the unchecked boxes were stale). The
+remaining phases were re-scoped into the harness-first milestones (M0–M6) in
+[`docs/roadmap.md`](roadmap.md) or moved to the `agent-forge-cloud` backlog
+(umbrella issue [#142](https://github.com/akoita/agent-forge/issues/142)) — web
+dashboard, multi-tenant RBAC/billing/quotas, Kubernetes scheduling, warm-pool
+scaling, and the tool marketplace among them.
 
-- [ ] Project scaffolding (`pyproject.toml`, directory structure, Makefile)
-- [ ] Configuration system (TOML loading, env var override, CLI flags)
-- [ ] LLM client base classes + Gemini adapter (with streaming)
-- [ ] Tool system base classes + `read_file`, `write_file`, `list_directory`
-- [ ] Sandbox Docker image + `DockerSandbox` implementation
-- [ ] `run_shell`, `search_codebase`, `edit_file` tools
-- [ ] ReAct loop implementation with termination conditions
-- [ ] State machine for run lifecycle
-- [ ] Click CLI with `run`, `status`, `list`, `config` commands
-- [ ] Unit + integration tests
-- [ ] README with architecture diagram and quick start
-
-### Phase 2 — Production Hardening
-
-> **Goal:** Reliability, observability, and multi-provider support ready for real-world use.
-
-- [ ] Structured logging with `structlog` (JSON + colored console)
-- [ ] Token/cost tracking and run summary reports
-- [ ] OpenAI + Anthropic LLM adapters
-- [ ] In-memory task queue + worker
-- [ ] Event bus for run lifecycle events
-- [ ] Exponential backoff, timeout handling, graceful degradation
-- [ ] Redis task queue backend for concurrent agent runs
-- [ ] End-to-end tests with sample repos + recorded LLM responses
-- [ ] asciinema demo recording
-
-### Phase 3 — Git-Aware Agent & Plugin System
-
-> **Goal:** The agent understands git workflows and users can extend it with custom tools.
-
-- [x] Git-aware tools: `git_diff`, `git_commit`, `git_create_branch`, `create_pr`
-- [x] Plugin system: load custom tools from external Python packages
-- [ ] Tool dependency resolution (e.g., a tool that requires another tool's output)
-- [ ] Custom system prompt templates (per-project `.agent-forge/prompts/`)
-- [ ] Agent memory: persist learnings across runs (file-based initially)
-
-### Phase 4 — Web Dashboard & REST API
-
-> **Goal:** A real-time web interface for monitoring and controlling agent runs.
-
-- [ ] REST API layer (FastAPI) for agent run management
-- [ ] WebSocket streaming for live run observation
-- [ ] Web dashboard (Next.js): run list, live logs, tool invocation timeline
-- [ ] Cost guardrails UI: budget alerts, auto-pause when cost exceeds threshold
-- [ ] Run history browser with diff viewer for file changes
-
-### Phase 5 — Multi-Agent Collaboration
-
-> **Goal:** Agents can delegate sub-tasks to other agents and coordinate complex workflows.
-
-- [ ] Agent-to-agent communication protocol
-- [ ] Hierarchical task delegation: parent agent breaks task into sub-tasks
-- [ ] Parallel agent execution with shared workspace coordination
-- [ ] Conflict resolution when multiple agents modify the same files
-- [ ] Orchestration DSL or YAML-based workflow definitions
-
-### Phase 6 — Advanced Isolation & Scaling
-
-> **Goal:** Enterprise-grade isolation and horizontal scaling.
-
-- [ ] Firecracker microVM sandbox backend (replacing Docker for stronger isolation)
-- [ ] Kubernetes-native sandbox provisioning (pod-per-task)
-- [ ] Distributed task queue with worker auto-scaling
-- [ ] Sandbox image caching and warm pool for sub-second startup
-- [ ] Resource usage analytics and capacity planning dashboard
-
-### Phase 7 — Platform & Ecosystem
-
-> **Goal:** Agent Forge becomes a platform others can build on.
-
-- [x] Hosted service mode for external clients (versioned run API, headless report contract, deployment model, auth and policy controls, compatibility client, operations guide)
-- [ ] MCP (Model Context Protocol) tool server: expose tools for interop with external agents
-- [ ] Multi-tenant auth + RBAC (team workspaces, API keys, usage quotas)
-- [ ] Custom LLM routing: cost/latency-based model selection per tool call
-- [ ] Human-in-the-loop approval gates for destructive operations
-- [ ] Persistent vector-backed memory for cross-run RAG context
-- [ ] Community tool marketplace
-- [ ] Self-hosted model support (Ollama, vLLM) as LLM backend
-- [ ] IDE plugins (VS Code, JetBrains) for in-editor agent invocation
+See [`docs/roadmap.md`](roadmap.md) for current milestones, exit criteria, and
+tracking issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,6 @@ Issues = "https://github.com/akoita/agent-forge/issues"
 [tool.hatch.build.targets.wheel]
 packages = ["agent_forge"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"agent_forge/profiles/builtins" = "agent_forge/profiles/builtins"
-
 [tool.ruff]
 target-version = "py311"
 line-length = 100

--- a/scripts/boundary_baseline.txt
+++ b/scripts/boundary_baseline.txt
@@ -1,0 +1,19 @@
+# Boundary ratchet baseline for scripts/check_boundaries.py
+#
+# The domain-agnostic-core rule (AGENTS.md) forbids audit-domain vocabulary in
+# packages under agent_forge/. The files below are KNOWN, pre-existing
+# violations that are being extracted into plugins/proof-of-audit/ under
+# issue #140. They are exempt from the checker until that work lands.
+#
+# This baseline is a ratchet: it may ONLY shrink. Adding a new file here is not
+# allowed for new work — new violations must be fixed, not baselined. When a
+# file below is cleaned up, delete its line; the checker fails on a stale entry
+# so the baseline cannot drift out of date.
+#
+# Verified against the tree on 2026-07-11 (six violating core modules).
+agent_forge/agent/prompts.py
+agent_forge/profiles/profile.py
+agent_forge/service/__init__.py
+agent_forge/service/app.py
+agent_forge/service/client.py
+agent_forge/service/models.py

--- a/scripts/check_boundaries.py
+++ b/scripts/check_boundaries.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Domain-boundary checker for the agent-forge core.
+
+Enforces the domain-agnostic-core rule declared in ``AGENTS.md``: packages
+under ``agent_forge/`` must stay free of audit-domain vocabulary. Domain work
+belongs in ``plugins/`` (see the Proof-of-Audit extraction tracked in issue
+#140).
+
+The checker is a *ratchet*:
+
+* Any forbidden term in a file that is **not** listed in the baseline is a new
+  violation and fails the run.
+* Every baseline entry must still contain at least one violation. A baseline
+  file that is now clean (or that no longer exists) is a *stale* entry and also
+  fails the run, so the baseline can only ever shrink.
+
+A line containing the ``# boundary-ok`` pragma is exempt, for the rare
+legitimate English use of a flagged word (e.g. "finding") in a comment or
+docstring.
+
+Usage::
+
+    python scripts/check_boundaries.py
+    python scripts/check_boundaries.py --baseline path/to/baseline.txt
+
+Exit code ``0`` means the boundary is intact; ``1`` means a new violation or a
+stale baseline entry was found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_CORE_DIR = _REPO_ROOT / "agent_forge"
+_DEFAULT_BASELINE = _REPO_ROOT / "scripts" / "boundary_baseline.txt"
+
+_PRAGMA = "# boundary-ok"
+
+# Audit-domain vocabulary that must not appear in core packages. Multiword and
+# hyphenated terms (e.g. "proof-of-audit") match across ``-``, ``_`` or space
+# separators. Matching is case-insensitive and anchored on ASCII-alphanumeric
+# boundaries (rather than Python's ``\b``, which treats ``_`` as a word char).
+# This means snake_case leakage such as ``build_proof_of_audit_request`` is
+# caught, while an alphabetic extension like "auditor" does not trip "audit"
+# and "poang" does not trip "poa".
+_FORBIDDEN_TERMS: tuple[str, ...] = (
+    "audit",
+    "solidity",
+    "vulnerability",
+    "vulnerabilities",
+    "severity",
+    "finding",
+    "findings",
+    "detector",
+    "detectors",
+    "reentrancy",
+    "proof-of-audit",
+    "poa",
+    "exploit",
+)
+
+
+def _compile_terms(terms: tuple[str, ...]) -> list[tuple[str, re.Pattern[str]]]:
+    """Compile each forbidden term into a case-insensitive, boundary-anchored regex.
+
+    Args:
+        terms: The forbidden vocabulary. Multiword or hyphenated terms may use
+            any of ``-``, ``_`` or space as separators.
+
+    Returns:
+        A list of ``(term, pattern)`` pairs preserving input order.
+    """
+    compiled: list[tuple[str, re.Pattern[str]]] = []
+    for term in terms:
+        parts = re.split(r"[-_ ]+", term)
+        body = r"[-_ ]+".join(re.escape(part) for part in parts)
+        pattern = rf"(?<![A-Za-z0-9]){body}(?![A-Za-z0-9])"
+        compiled.append((term, re.compile(pattern, re.IGNORECASE)))
+    return compiled
+
+
+def _iter_py_files(root: Path) -> list[Path]:
+    """Return every ``*.py`` file under ``root``, sorted for determinism."""
+    return sorted(root.rglob("*.py"))
+
+
+def _scan_file(
+    path: Path, patterns: list[tuple[str, re.Pattern[str]]]
+) -> list[tuple[int, str, str]]:
+    """Scan a single file for forbidden terms.
+
+    Args:
+        path: The file to scan.
+        patterns: Compiled ``(term, pattern)`` pairs from :func:`_compile_terms`.
+
+    Returns:
+        A list of ``(line_number, term, line_text)`` tuples, one per matched
+        term on each line. Lines carrying the ``# boundary-ok`` pragma are
+        skipped.
+    """
+    violations: list[tuple[int, str, str]] = []
+    text = path.read_text(encoding="utf-8")
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if _PRAGMA in line:
+            continue
+        for term, pattern in patterns:
+            if pattern.search(line):
+                violations.append((lineno, term, line.strip()))
+    return violations
+
+
+def _load_baseline(baseline_path: Path) -> list[str]:
+    """Load repo-relative paths from the baseline file.
+
+    Blank lines and ``#`` comments are ignored. A missing baseline file yields
+    an empty list (equivalent to "no exemptions").
+
+    Args:
+        baseline_path: Path to the baseline file.
+
+    Returns:
+        The list of repo-relative path strings, in file order.
+    """
+    if not baseline_path.exists():
+        return []
+    entries: list[str] = []
+    for raw in baseline_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        entries.append(line)
+    return entries
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the boundary check.
+
+    Args:
+        argv: Optional argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        ``0`` if the boundary is intact, ``1`` otherwise.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--core-dir",
+        type=Path,
+        default=_DEFAULT_CORE_DIR,
+        help="Directory to scan for forbidden terms (default: agent_forge/).",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=_DEFAULT_BASELINE,
+        help="Baseline file of ratcheted exemptions (default: scripts/boundary_baseline.txt).",
+    )
+    args = parser.parse_args(argv)
+
+    core_dir: Path = args.core_dir.resolve()
+    baseline_path: Path = args.baseline
+    base_dir = core_dir.parent
+
+    baseline_entries = _load_baseline(baseline_path)
+    baseline_set = set(baseline_entries)
+    patterns = _compile_terms(_FORBIDDEN_TERMS)
+
+    files = _iter_py_files(core_dir)
+    new_violations: list[tuple[str, int, str, str]] = []
+    baseline_hits: set[str] = set()
+
+    for path in files:
+        rel = path.relative_to(base_dir).as_posix()
+        file_violations = _scan_file(path, patterns)
+        if not file_violations:
+            continue
+        if rel in baseline_set:
+            baseline_hits.add(rel)
+        else:
+            for lineno, term, text in file_violations:
+                new_violations.append((rel, lineno, term, text))
+
+    stale_entries = [entry for entry in baseline_entries if entry not in baseline_hits]
+
+    exit_code = 0
+    if new_violations:
+        exit_code = 1
+        print("New boundary violations (not in baseline):", file=sys.stderr)
+        for rel, lineno, term, text in new_violations:
+            print(f"  {rel}:{lineno}: forbidden term '{term}' -> {text}", file=sys.stderr)
+    if stale_entries:
+        exit_code = 1
+        print(
+            "Stale baseline entries (now clean or missing) — remove them, "
+            "the baseline may only shrink:",
+            file=sys.stderr,
+        )
+        for entry in stale_entries:
+            print(f"  {entry}", file=sys.stderr)
+
+    if exit_code == 0:
+        print(
+            f"boundary check OK: scanned {len(files)} files, "
+            f"baseline size {len(baseline_entries)}"
+        )
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_check_boundaries.py
+++ b/tests/unit/test_check_boundaries.py
@@ -1,0 +1,159 @@
+"""Unit tests for ``scripts/check_boundaries.py`` (the domain-boundary ratchet).
+
+The script lives under ``scripts/`` rather than the ``agent_forge`` package, so
+it is loaded here by file path via :mod:`importlib`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_boundaries.py"
+
+
+def _load_module() -> ModuleType:
+    """Import ``check_boundaries.py`` as a module from its file path."""
+    spec = importlib.util.spec_from_file_location("check_boundaries", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cb: ModuleType = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pkg(root: Path) -> Path:
+    """Create and return a fake ``agent_forge`` package under ``root``."""
+    pkg = root / "agent_forge"
+    pkg.mkdir()
+    return pkg
+
+
+def _write(pkg: Path, name: str, content: str) -> None:
+    """Write ``content`` to ``pkg/name``."""
+    (pkg / name).write_text(content, encoding="utf-8")
+
+
+def _baseline(root: Path, *entries: str) -> Path:
+    """Write a baseline file listing ``entries`` and return its path."""
+    path = root / "baseline.txt"
+    path.write_text("\n".join(entries) + "\n", encoding="utf-8")
+    return path
+
+
+def _run(pkg: Path, baseline: Path) -> int:
+    """Invoke the checker against ``pkg`` with ``baseline``."""
+    return int(cb.main(["--core-dir", str(pkg), "--baseline", str(baseline)]))
+
+
+# ---------------------------------------------------------------------------
+# Ratchet behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_clean_tree_passes(tmp_path: Path) -> None:
+    pkg = _make_pkg(tmp_path)
+    _write(pkg, "mod.py", "def hello() -> str:\n    return 'ok'\n")
+    assert _run(pkg, _baseline(tmp_path)) == 0
+
+
+def test_new_violation_outside_baseline_fails(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pkg = _make_pkg(tmp_path)
+    _write(pkg, "leak.py", "# harmless\nSEVERITY = 'high'\n")
+    code = _run(pkg, _baseline(tmp_path))
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "leak.py" in err
+    assert ":2:" in err
+    assert "severity" in err
+
+
+def test_violation_in_baselined_file_passes(tmp_path: Path) -> None:
+    pkg = _make_pkg(tmp_path)
+    _write(pkg, "leak.py", "severity = 1\n")
+    baseline = _baseline(tmp_path, "agent_forge/leak.py")
+    assert _run(pkg, baseline) == 0
+
+
+def test_clean_baselined_file_is_stale(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pkg = _make_pkg(tmp_path)
+    _write(pkg, "clean.py", "x = 1\n")
+    baseline = _baseline(tmp_path, "agent_forge/clean.py")
+    code = _run(pkg, baseline)
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "agent_forge/clean.py" in err
+    assert "stale" in err.lower()
+
+
+def test_missing_baselined_file_is_stale(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pkg = _make_pkg(tmp_path)
+    _write(pkg, "present.py", "x = 1\n")
+    baseline = _baseline(tmp_path, "agent_forge/gone.py")
+    code = _run(pkg, baseline)
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "agent_forge/gone.py" in err
+
+
+def test_boundary_ok_pragma_exempts_line(tmp_path: Path) -> None:
+    pkg = _make_pkg(tmp_path)
+    _write(pkg, "mod.py", "note = 'a real finding worth reporting'  # boundary-ok\n")
+    assert _run(pkg, _baseline(tmp_path)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Word-boundary semantics
+# ---------------------------------------------------------------------------
+
+
+def test_alphabetic_extension_does_not_match(tmp_path: Path) -> None:
+    """Documented choice: ASCII-alnum boundaries treat "auditor" as a distinct
+    word, so it does NOT trip "audit"; likewise "poang" does not trip "poa"."""
+    pkg = _make_pkg(tmp_path)
+    _write(pkg, "mod.py", "auditor = 1\nauditing = 2\npoang = 3\n")
+    assert _run(pkg, _baseline(tmp_path)) == 0
+
+
+def test_snake_case_identifier_matches(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Underscores act as separators, so audit-domain identifiers are caught."""
+    pkg = _make_pkg(tmp_path)
+    _write(pkg, "mod.py", "def build_proof_of_audit_request() -> None:\n    return None\n")
+    code = _run(pkg, _baseline(tmp_path))
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "proof-of-audit" in err
+
+
+def test_term_matcher_boundaries() -> None:
+    patterns = dict(cb._compile_terms(cb._FORBIDDEN_TERMS))
+    audit = patterns["audit"]
+    assert audit.search("an audit report") is not None
+    assert audit.search("do_audit_now") is not None
+    assert audit.search("AUDIT") is not None
+    assert audit.search("auditor") is None
+    assert audit.search("auditing") is None
+    poa = patterns["poa"]
+    assert poa.search("emit POA now") is not None
+    assert poa.search("poang") is None

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ dependencies = [
     { name = "google-cloud-storage" },
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "rich" },
     { name = "structlog" },
     { name = "uvicorn" },
@@ -33,6 +34,7 @@ dev = [
     { name = "respx" },
     { name = "ruff" },
     { name = "types-docker" },
+    { name = "types-pyyaml" },
     { name = "vulture" },
 ]
 redis = [
@@ -54,6 +56,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "python-semantic-release", marker = "extra == 'dev'", specifier = ">=9.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "radon", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
@@ -61,6 +64,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "structlog", specifier = ">=24.0" },
     { name = "types-docker", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", specifier = ">=0.34" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.11" },
 ]
@@ -1351,6 +1355,61 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "radon"
 version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1588,6 +1647,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/91/63f4fa68a7d563ca54f62c013aeefb480a2e18a0ee0623a56119f1662bf2/types_paramiko-4.0.0.20260402.tar.gz", hash = "sha256:a9287bdb78cb67c8e79897dc98b761900968cd2de288f72cc298c1a25cde6a38", size = 29105, upload-time = "2026-04-02T04:20:26.809Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/5e/d650556433e9b745fb85676f4382b7ec0f35156696d946b9bf5ac470358b/types_paramiko-4.0.0.20260402-py3-none-any.whl", hash = "sha256:38ef646f54d5410012d8607b9f023a355ecaec12b749d0325bce5f16706f6183", size = 38816, upload-time = "2026-04-02T04:20:25.788Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

Executes the July 2026 project audit: Agent Forge pivots from "broad agent platform" to a **small, measurable, high-correctness coding harness**. This PR lands the canonical roadmap (M0–M6), the pivot ADR, contradiction-free governance, per-tool agent configuration, and mechanical enforcement of the domain-agnostic-core rule. The issue backlog was migrated in parallel (#135–#142 created; #24, #27, #29, #33, #40, #42, #46, #47 rewritten; #43 elevated to P0; #32 deferred; 16 issues labeled `proposed-close` awaiting maintainer confirmation).

Direction docs: `docs/roadmap.md`, `docs/adr/002-harness-first-reset.md`, plan of record `.agents/plans/strategic-reset-2026-07.md`.

## Evidence

```
$ python scripts/check_boundaries.py
boundary check OK: scanned 54 files, baseline size 6   (exit 0)

$ python -m pytest tests/unit/test_check_boundaries.py -q
9 passed in 0.06s

$ uv run make lint
ruff check agent_forge tests  → All checks passed!
mypy agent_forge              → Success: no issues found in 54 source files

Ratchet demo (during development): injecting a forbidden term into
agent_forge/agent/core.py → exit 1 naming file:line:term; reverted → exit 0.

$ grep -c "Phase 4\|Phase 5\|Phase 6\|Phase 7" docs/spec.md
0   (stale phase roadmap fully removed)

$ grep -in "never merge\|mandatory, not optional\|NEVER commit or push before" AGENTS.md CLAUDE.md .agents/workflows/*.md
(no matches — governance contradictions gone)

$ python3 -m json.tool .claude/settings.json → valid
$ python3 -c "import tomllib; tomllib.load(open('.codex/config.toml','rb'))" → valid
```

No code under `agent_forge/` is modified by this PR; the full test suite runs in CI.

## Benchmark impact

**N/A** — this PR is docs, governance, and CI tooling only. The benchmark harness itself is the top P0 (#135); after it lands, every subsequent feature PR must fill this section with real numbers.

## Boundary analysis

Adds the boundary checker and a baseline of exactly the six historical violators (`agent_forge/agent/prompts.py`, `service/app.py`, `service/models.py`, `service/client.py`, `service/__init__.py`, `profiles/profile.py`), tracked for extraction in #140. No domain code added to core; the baseline may only shrink from here (enforced: a clean baseline entry fails CI as stale).

## Docs

This PR *is* the docs change: new `docs/roadmap.md` + ADR-002; `docs/spec.md` §12 and `README.md` reconciled; AGENTS.md/CLAUDE.md/workflows rewritten.

## Rollback

`git revert` of this single commit restores the previous docs and governance; no migrations, state, or runtime behavior involved. The GitHub issue migration is independent and reversible via label removal/reopening.

## ADR

Yes — `docs/adr/002-harness-first-reset.md` (included in this PR).

---

**Merge gate note:** developer standing approval is on record (global pre-authorization by @akoita); merging on CI green per AGENTS.md §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)